### PR TITLE
add multi issuer support

### DIFF
--- a/daml/Main.daml
+++ b/daml/Main.daml
@@ -13,7 +13,8 @@ import DA.Next.Set
 
 test = scenario do
   operator <- getParty "Operator"
-  issuer <- getParty "Issuer"
+  btcIssuer <- getParty "BtcIssuer"
+  usdtIssuer <- getParty "UsdtIssuer"
   custodian <- getParty "Custodian"
   exchange <- getParty "Exchange"
 
@@ -23,13 +24,16 @@ test = scenario do
   -- create operator
   opCid <- operator `submit` create Operator with ..
 
-  -- onboard issuer
-  issuerInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardIssuer with ..
-  issuer `submit` exercise issuerInvCid IssuerInvitation_Accept
-
   -- onboard custodian
   custodianInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardCustodian with ..
   custodian `submit` exercise custodianInvCid CustodianInvitation_Accept
+
+  -- onboard issuers
+  btcIssuerInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardIssuer with issuer = btcIssuer, ..
+  btcIssuer `submit` exercise btcIssuerInvCid IssuerInvitation_Accept
+
+  usdtIssuerInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardIssuer with issuer = usdtIssuer, ..
+  usdtIssuer `submit` exercise usdtIssuerInvCid IssuerInvitation_Accept
 
   -- onboard investors
   aliceInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardInvestor with investor = alice, ..
@@ -43,11 +47,14 @@ test = scenario do
   custodian `submit` exerciseByKey @Custodian (operator, custodian) UpdateAssetSettlementRules
 
   -- issuer issues a token
-  issuer `submit` exerciseByKey @Issuer (operator, issuer) Issuer_IssueToken with name = "BTC", quantityPrecision = 8
-  issuer `submit` exerciseByKey @Issuer (operator, issuer) Issuer_IssueToken with name = "USDT", quantityPrecision = 2
+  btcIssuer `submit` exerciseByKey @Issuer (operator, btcIssuer) Issuer_IssueToken with name = "BTC", quantityPrecision = 8
+  usdtIssuer `submit` exerciseByKey @Issuer (operator, usdtIssuer) Issuer_IssueToken with name = "USDT", quantityPrecision = 2
+
+  let btcTokenId = Id with signatories = fromList [ btcIssuer ], label = "BTC", version = 0
+  let usdtTokenId = Id with signatories = fromList [ usdtIssuer ], label = "USDT", version = 0
 
   -- alice deposits some BTC under her account and gets them in a form of a deposit
-  depositCid <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenName = "BTC", depositQuantity = 0.01, beneficiary = alice
+  depositCid <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenId = btcTokenId, depositQuantity = 0.01, beneficiary = alice
 
   -- alice transfers the deposit to bob
   depositCid <- alice `submit` exerciseByKey @Investor (operator, alice) Investor_TransferTo with receiver = bob, depositCid
@@ -65,8 +72,8 @@ test = scenario do
   bob `submitMustFail` exerciseByKey @Investor (operator, bob) Investor_TransferTo with receiver = bob, depositCid
 
   -- alice deposits some USDT under her account
-  depositCid1 <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenName = "USDT", depositQuantity = 1000.0, beneficiary = alice
-  depositCid2 <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenName = "USDT", depositQuantity = 500.0, beneficiary = alice
+  depositCid1 <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenId = usdtTokenId, depositQuantity = 1000.0, beneficiary = alice
+  depositCid2 <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenId = usdtTokenId, depositQuantity = 500.0, beneficiary = alice
 
   -- alice merges the two assets
   depositCid3 <- alice `submit` exercise depositCid1 AssetDeposit_Merge with depositCids = [depositCid2]
@@ -77,10 +84,9 @@ test = scenario do
 
   -- the exchange adds support for BTC/USDT pair
   -- first the issuer discloses the tokens to everyone
-  let btcTokenId = Id with signatories = fromList [issuer], label = "BTC", version = 0
-      usdtTokenId = Id with signatories = fromList [issuer], label = "USDT", version = 0
-  issuer `submit` exerciseByKey @Token btcTokenId Token_AddObservers with party = issuer, newObservers = fromList [exchange, alice, bob]
-  issuer `submit` exerciseByKey @Token usdtTokenId Token_AddObservers with party = issuer, newObservers = fromList [exchange, alice, bob]
+  btcIssuer `submit` exerciseByKey @Token btcTokenId Token_AddObservers with party = btcIssuer, newObservers = fromList [exchange, alice, bob]
+  usdtIssuer `submit` exerciseByKey @Token usdtTokenId Token_AddObservers with party = usdtIssuer, newObservers = fromList [exchange, alice, bob]
+
   -- then the exchange adds the BTC/USDT pair to their list
   exchange `submit` exerciseByKey @Exchange (operator, exchange) Exchange_AddPair with baseTokenId = btcTokenId, quoteTokenId = usdtTokenId
 

--- a/daml/Marketplace/Role.daml
+++ b/daml/Marketplace/Role.daml
@@ -22,20 +22,19 @@ template Operator
     maintainer key
 
     controller operator can
-      nonconsuming Operator_OnboardIssuer : ContractId IssuerInvitation
-        with
-          issuer : Party
-        do create IssuerInvitation with ..
-
       nonconsuming Operator_OnboardCustodian : ContractId CustodianInvitation
         with
           custodian : Party
-          issuer : Party
         do
-          (issuerCid, issuerCdata) <- fetchByKey @Issuer (operator, issuer)
-          exercise issuerCid Issuer_SetObservers
-            with ctrl = operator, newObservers = insert custodian issuerCdata.observers
           create CustodianInvitation with ..
+
+      nonconsuming Operator_OnboardIssuer : ContractId IssuerInvitation
+        with
+          issuer : Party
+          custodian : Party
+        do
+          exerciseByKey @Custodian (operator, custodian) Custodian_AddIssuer with ..
+          create IssuerInvitation with ..
 
       nonconsuming Operator_OnboardInvestor : ContractId InvestorInvitation
         with
@@ -216,11 +215,12 @@ template IssuerInvitation
   with
     operator : Party
     issuer : Party
+    custodian : Party
   where
     signatory operator
     controller issuer can
       IssuerInvitation_Accept : ContractId Issuer
-        do create Issuer with observers = empty, ..
+        do create Issuer with observers = fromList [custodian], ..
 
 
 template Issuer
@@ -259,20 +259,19 @@ template CustodianInvitation
   with
     operator : Party
     custodian : Party
-    issuer : Party
   where
     signatory operator
 
     controller custodian can
       CustodianInvitation_Accept : ContractId Custodian
-        do create Custodian with investors = [], exchanges = [], ..
+        do create Custodian with investors = [], exchanges = [], issuers = [], ..
 
 
 template Custodian
   with
     operator : Party
     custodian : Party
-    issuer : Party
+    issuers  : [Party]
     investors : [Party]
     exchanges : [Party]
   where
@@ -282,6 +281,13 @@ template Custodian
     maintainer key._1
 
     controller operator can
+      Custodian_AddIssuer : ContractId Custodian
+        with
+          issuer : Party
+        do
+          assertMsg ("Issuer " <> show issuer <> " already exists") $ issuer `notElem` issuers
+          create this with issuers = issuer :: issuers
+
       Custodian_AddExchange : ContractId Custodian
         with
           exchange : Party
@@ -306,11 +312,10 @@ template Custodian
 
       nonconsuming CreateDeposit : ContractId AssetDeposit
         with
-          tokenName : Text
+          tokenId : Id
           depositQuantity : Decimal
           beneficiary : Party
         do
-          let tokenId = Id with signatories = fromList [ issuer ], label = tokenName, version = 0
           (tokenCid, token) <- fetchByKey @Token tokenId
           let quantity = roundBankers token.quantityPrecision depositQuantity
               asset = Asset with id = tokenId, ..


### PR DESCRIPTION
An attempt at adding support for multiple issuers. This changes the onboarding flow slightly - custodians must be onboarded before issuers.