### PR TITLE
better handling of order qty calculation given qty precisions

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 1.3.0
+sdk-version: 1.4.0
 name: da-marketplace
 source: daml
 parties:

--- a/daml/Main.daml
+++ b/daml/Main.daml
@@ -47,7 +47,7 @@ test = scenario do
   custodian `submit` exerciseByKey @Custodian (operator, custodian) UpdateAssetSettlementRules
 
   -- issuer issues a token
-  btcIssuer `submit` exerciseByKey @Issuer (operator, btcIssuer) Issuer_IssueToken with name = "BTC", quantityPrecision = 8
+  btcIssuer `submit` exerciseByKey @Issuer (operator, btcIssuer) Issuer_IssueToken with name = "BTC", quantityPrecision = 6
   usdtIssuer `submit` exerciseByKey @Issuer (operator, usdtIssuer) Issuer_IssueToken with name = "USDT", quantityPrecision = 2
 
   let btcTokenId = Id with signatories = fromList [ btcIssuer ], label = "BTC", version = 0
@@ -92,7 +92,7 @@ test = scenario do
 
   -- bob places a bid for the BTC/USDT pair but he is using a deposit of bitcoin so he can only place an offer
   bob `submitMustFail` exerciseByKey @ExchangeParticipant (exchange, bob) ExchangeParticipant_PlaceBid with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.0
-  offerOrderRequestCid <- bob `submit` exerciseByKey @ExchangeParticipant (exchange, bob) ExchangeParticipant_PlaceOffer with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.0
+  offerOrderRequestCid <- bob `submit` exerciseByKey @ExchangeParticipant (exchange, bob) ExchangeParticipant_PlaceOffer with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.00
   -- exchange assigns it an orderId
   offerOrderCid <- exchange `submit` exercise offerOrderRequestCid OrderRequestAck with orderId = 1
 
@@ -102,12 +102,12 @@ test = scenario do
 
   -- alice places a bid for the BTC/USDT pair but he is using a deposit of bitcoin so he can only place an offer
   depositCid3 <- alice `submit` exerciseByKey @Investor (operator, alice) Investor_AllocateToExchange with depositCid = depositCid3, ..
-  bidOrderRequestCid <- alice `submit` exerciseByKey @ExchangeParticipant (exchange, alice) ExchangeParticipant_PlaceBid with depositCid = depositCid3, pair = (btcTokenId, usdtTokenId), price = 10_000.0
+  bidOrderRequestCid <- alice `submit` exerciseByKey @ExchangeParticipant (exchange, alice) ExchangeParticipant_PlaceBid with depositCid = depositCid3, pair = (btcTokenId, usdtTokenId), price = 10000.00
   -- exchange assigns it a clorderid
   bidOrderCid <- exchange `submit` exercise bidOrderRequestCid OrderRequestAck with orderId = 2
 
   -- exchange matches the two orders
   exchange `submit` exercise bidOrderCid OrderFill with fillQty = 0.01, fillPrice = 10000.0, counterParty = bob
-  exchange `submit` exercise offerOrderCid OrderFill with fillQty = 0.01, fillPrice = 10000.0, counterParty = alice
+  exchange `submit` exercise offerOrderCid OrderFill with fillQty = 0.01, fillPrice = 10000.00, counterParty = alice
 
   return ()

--- a/daml/Marketplace/Role.daml
+++ b/daml/Marketplace/Role.daml
@@ -186,6 +186,9 @@ template ExchangeParticipant
             $ pair `elem` exchangeCdata.tokenPairs
           assertMsg ("deposit should be for " <> pair._2.label <> " but it is for " <> deposit.asset.id.label)
             $ pair._2 == deposit.asset.id
+          (_, quoteToken) <- fetchByKey @Token pair._2
+          assertMsg ("price should be rounded to at most " <> show quoteToken.quantityPrecision <> " decimal places")
+            $ roundBankers quoteToken.quantityPrecision price == price
           (_, baseToken) <- fetchByKey @Token pair._1
           let qty = roundBankers baseToken.quantityPrecision $ deposit.asset.quantity / price
               order = Order with isBid = True, status = "New", orderId = -1, ..
@@ -205,6 +208,9 @@ template ExchangeParticipant
             $ pair `elem` exchangeCdata.tokenPairs
           assertMsg ("deposit should be for " <> pair._1.label <> " but it is for " <> deposit.asset.id.label)
             $ pair._1 == deposit.asset.id
+          (_, quoteToken) <- fetchByKey @Token pair._2
+          assertMsg ("price should be rounded to at most " <> show quoteToken.quantityPrecision <> " decimal places")
+            $ roundBankers quoteToken.quantityPrecision price == price
           (_, baseToken) <- fetchByKey @Token pair._1
           let qty = roundBankers baseToken.quantityPrecision deposit.asset.quantity
               order = Order with isBid = False, status = "New", orderId = -1, ..

--- a/daml/Marketplace/Trading.daml
+++ b/daml/Marketplace/Trading.daml
@@ -1,11 +1,15 @@
 daml 1.2
 module Marketplace.Trading where
 
+import Marketplace.Token
 import Marketplace.Utils
 
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
+
+import DA.Math
+
 
 type TokenPair = (Id, Id)
 
@@ -70,18 +74,31 @@ template Order
           fillPrice : Decimal
           counterParty : Party
         do
+          assert $ fillQty > 0.0
           assert $ fillQty <= qty
           assert $ if isBid then fillPrice <= price
                             else fillPrice >= price
           deposit <- fetch depositCid
           let receiverAccountId = getAccountId counterParty exchange [deposit.account.provider]
           (senderRuleCid, _) <- fetchByKey @AssetSettlementRule deposit.account.id
+          (_, baseToken) <- fetchByKey @Token pair._1
+          (_, quoteToken) <- fetchByKey @Token pair._2
           if fillQty < qty then do
-            [filledCid, restCid] <- exercise depositCid AssetDeposit_Split
-              with quantities = [if isBid then fillQty * fillPrice else fillQty]
-            exercise senderRuleCid AssetSettlement_Transfer with depositCid = filledCid, ..
-            remainingCid <- create this with depositCid = restCid, qty = qty - fillQty, status = "PartiallyFilled"
-            return $ Some remainingCid
+            let minFillQty = 10.0 ** (- intToDecimal if isBid then quoteToken.quantityPrecision else baseToken.quantityPrecision)
+            let depositFillQty = min (if isBid
+                                      then roundBankers quoteToken.quantityPrecision $ fillQty * fillPrice
+                                      else fillQty)
+                                     (deposit.asset.quantity - minFillQty)
+            if (depositFillQty > 0.0 && depositFillQty < deposit.asset.quantity)
+            then do
+              [filledCid, restCid] <- exercise depositCid AssetDeposit_Split with quantities = [depositFillQty]
+              exercise senderRuleCid AssetSettlement_Transfer with depositCid = filledCid, ..
+              remainingCid <- create this with depositCid = restCid, qty = qty - fillQty, status = "PartiallyFilled"
+              return $ Some remainingCid
+            else do
+              -- the fillQty is not enough to warrant a deposit transfer
+              remainingCid <- create this with qty = qty - fillQty, status = "PartiallyFilled"
+              return $ Some remainingCid
           else do
             exercise senderRuleCid AssetSettlement_Transfer with ..
             return None


### PR DESCRIPTION
- In this PR we attempt better handling of order qty calculation given an asset deposit qty.
- We also use the quote token's qty precision as the tick size for creating bids and offers
- bump to sdk 1.4.0