### PR TITLE
better role onboarding. reduce operator visibility

### DIFF
--- a/daml/Main.daml
+++ b/daml/Main.daml
@@ -30,79 +30,96 @@ test = scenario do
 
   -- onboard issuers
   btcIssuerInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardIssuer with issuer = btcIssuer, ..
-  btcIssuer `submit` exercise btcIssuerInvCid IssuerInvitation_Accept
+  btcIssuerCid <- btcIssuer `submit` exercise btcIssuerInvCid IssuerInvitation_Accept
 
   usdtIssuerInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardIssuer with issuer = usdtIssuer, ..
-  usdtIssuer `submit` exercise usdtIssuerInvCid IssuerInvitation_Accept
+  usdtIssuerCid <- usdtIssuer `submit` exercise usdtIssuerInvCid IssuerInvitation_Accept
 
   -- onboard investors
   aliceInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardInvestor with investor = alice, ..
-  alice `submit` exercise aliceInvCid InvestorInvitation_Accept
+  aliceInvestorCid <- alice `submit` exercise aliceInvCid InvestorInvitation_Accept
 
   custodian `submit` exerciseByKey @Custodian (operator, custodian) UpdateAssetSettlementRules
 
   bobInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardInvestor with investor = bob, ..
-  bob `submit` exercise bobInvCid InvestorInvitation_Accept
+  bobInvestorCid <- bob `submit` exercise bobInvCid InvestorInvitation_Accept
+
+  -- issuers establish a relationship with the custodian
+  relationshipReqCid <- btcIssuer `submit` exercise btcIssuerCid Issuer_RequestCustodianRelationship with ..
+  custodian `submit` exercise relationshipReqCid CustodianRelationshipRequest_Approve
+
+  relationshipReqCid <- usdtIssuer `submit` exercise usdtIssuerCid Issuer_RequestCustodianRelationship with ..
+  custodian `submit` exercise relationshipReqCid CustodianRelationshipRequest_Approve
+
+  -- investors establish a relationship with the custodian
+  relationshipReqCid <- alice `submit` exercise aliceInvestorCid Investor_RequestCustodianRelationship with ..
+  custodian `submit` exercise relationshipReqCid CustodianRelationshipRequest_Approve
+
+  relationshipReqCid <- bob `submit` exercise bobInvestorCid Investor_RequestCustodianRelationship with ..
+  custodian `submit` exercise relationshipReqCid CustodianRelationshipRequest_Approve
 
   custodian `submit` exerciseByKey @Custodian (operator, custodian) UpdateAssetSettlementRules
 
-  -- issuer issues a token
+  -- issuers issue tokens
   btcIssuer `submit` exerciseByKey @Issuer (operator, btcIssuer) Issuer_IssueToken with name = "BTC", quantityPrecision = 6
   usdtIssuer `submit` exerciseByKey @Issuer (operator, usdtIssuer) Issuer_IssueToken with name = "USDT", quantityPrecision = 2
 
   let btcTokenId = Id with signatories = fromList [ btcIssuer ], label = "BTC", version = 0
   let usdtTokenId = Id with signatories = fromList [ usdtIssuer ], label = "USDT", version = 0
 
-  -- alice deposits some BTC under her account and gets them in a form of a deposit
+  -- the issuers disclose the tokens to everyone
+  btcIssuer `submit` exerciseByKey @Token btcTokenId Token_AddObservers with party = btcIssuer, newObservers = fromList [custodian, exchange, alice, bob]
+  usdtIssuer `submit` exerciseByKey @Token usdtTokenId Token_AddObservers with party = usdtIssuer, newObservers = fromList [custodian, exchange, alice, bob]
+
+  -- Alice deposits some BTC under her account and gets them in a form of a deposit
   depositCid <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenId = btcTokenId, depositQuantity = 0.01, beneficiary = alice
 
-  -- alice transfers the deposit to bob
+  -- Alice transfers the deposit to bob
   depositCid <- alice `submit` exerciseByKey @Investor (operator, alice) Investor_TransferTo with receiver = bob, depositCid
 
   -- oboard exchange
   exchangeInvCid <- operator `submit` exerciseByKey @Operator operator Operator_OnboardExchange with ..
-  exchange `submit` exercise exchangeInvCid ExchangeInvitation_Accept
+  exchangeCid <- exchange `submit` exercise exchangeInvCid ExchangeInvitation_Accept
+
+  -- exchange establishes a relationship with the custodian
+  relationshipReqCid <- exchange `submit` exercise exchangeCid Exchange_RequestCustodianRelationship with ..
+  custodian `submit` exercise relationshipReqCid CustodianRelationshipRequest_Approve
 
   custodian `submit` exerciseByKey @Custodian (operator, custodian) UpdateAssetSettlementRules
 
-  -- bob alocates this to the exchange
+  -- Bob alocates this to the exchange
   depositCid <- bob `submit` exerciseByKey @Investor (operator, bob) Investor_AllocateToExchange with ..
 
   -- Bob cannot claim back the asset using a transfer
   bob `submitMustFail` exerciseByKey @Investor (operator, bob) Investor_TransferTo with receiver = bob, depositCid
 
-  -- alice deposits some USDT under her account
+  -- Alice deposits some USDT under her account
   depositCid1 <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenId = usdtTokenId, depositQuantity = 1000.0, beneficiary = alice
   depositCid2 <- custodian `submit` exerciseByKey @Custodian (operator, custodian) CreateDeposit with tokenId = usdtTokenId, depositQuantity = 500.0, beneficiary = alice
 
-  -- alice merges the two assets
+  -- Alice merges the two assets
   depositCid3 <- alice `submit` exercise depositCid1 AssetDeposit_Merge with depositCids = [depositCid2]
 
-  -- bob is onboarded as an exchange participant
+  -- Bob is onboarded as an exchange participant
   (_, bobInvCid) <- exchange `submit` exerciseByKey @Exchange (operator, exchange) Exchange_InviteParticipant with exchParticipant = bob
   bob `submit` exercise bobInvCid ExchangeParticipantInvitation_Accept
 
   -- the exchange adds support for BTC/USDT pair
-  -- first the issuer discloses the tokens to everyone
-  btcIssuer `submit` exerciseByKey @Token btcTokenId Token_AddObservers with party = btcIssuer, newObservers = fromList [exchange, alice, bob]
-  usdtIssuer `submit` exerciseByKey @Token usdtTokenId Token_AddObservers with party = usdtIssuer, newObservers = fromList [exchange, alice, bob]
-
-  -- then the exchange adds the BTC/USDT pair to their list
   exchange `submit` exerciseByKey @Exchange (operator, exchange) Exchange_AddPair with baseTokenId = btcTokenId, quoteTokenId = usdtTokenId
 
-  -- bob places a bid for the BTC/USDT pair but he is using a deposit of bitcoin so he can only place an offer
-  bob `submitMustFail` exerciseByKey @ExchangeParticipant (exchange, bob) ExchangeParticipant_PlaceBid with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.0
-  offerOrderRequestCid <- bob `submit` exerciseByKey @ExchangeParticipant (exchange, bob) ExchangeParticipant_PlaceOffer with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.00
+  -- Bob places a bid for the BTC/USDT pair but he is using a deposit of bitcoin so he can only place an offer
+  bob `submitMustFail` exerciseByKey @ExchangeParticipant (exchange, operator, bob) ExchangeParticipant_PlaceBid with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.0
+  offerOrderRequestCid <- bob `submit` exerciseByKey @ExchangeParticipant (exchange, operator, bob) ExchangeParticipant_PlaceOffer with depositCid, pair = (btcTokenId, usdtTokenId), price = 10_000.00
   -- exchange assigns it an orderId
   offerOrderCid <- exchange `submit` exercise offerOrderRequestCid OrderRequestAck with orderId = 1
 
-  -- alice gets onboarded as an exchange participant
+  -- Alice gets onboarded as an exchange participant
   (_, aliceInvCid) <- exchange `submit` exerciseByKey @Exchange (operator, exchange) Exchange_InviteParticipant with exchParticipant = alice
   alice `submit` exercise aliceInvCid ExchangeParticipantInvitation_Accept
 
-  -- alice places a bid for the BTC/USDT pair but he is using a deposit of bitcoin so he can only place an offer
+  -- Alice places a bid for the BTC/USDT pair but he is using a deposit of bitcoin so he can only place an offer
   depositCid3 <- alice `submit` exerciseByKey @Investor (operator, alice) Investor_AllocateToExchange with depositCid = depositCid3, ..
-  bidOrderRequestCid <- alice `submit` exerciseByKey @ExchangeParticipant (exchange, alice) ExchangeParticipant_PlaceBid with depositCid = depositCid3, pair = (btcTokenId, usdtTokenId), price = 10000.00
+  bidOrderRequestCid <- alice `submit` exerciseByKey @ExchangeParticipant (exchange, operator, alice) ExchangeParticipant_PlaceBid with depositCid = depositCid3, pair = (btcTokenId, usdtTokenId), price = 10000.00
   -- exchange assigns it a clorderid
   bidOrderCid <- exchange `submit` exercise bidOrderRequestCid OrderRequestAck with orderId = 2
 

--- a/daml/Marketplace/Role.daml
+++ b/daml/Marketplace/Role.daml
@@ -6,10 +6,55 @@ import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 import DA.List as L
 import DA.Next.Set
+import DA.Action
 
 import Marketplace.Token
 import Marketplace.Trading
 import Marketplace.Utils
+
+
+template UserSession
+  with
+    operator : Party
+    user : Party
+    role : Text
+  where
+    signatory user
+
+    controller operator can
+      UserSession_Ack : ()
+        do
+          let userKey = (operator, user)
+          case role of
+            "Custodian" -> do
+              optCustodianInvitation <- lookupByKey @CustodianInvitation userKey
+              optCustodian <- lookupByKey @Custodian userKey
+              case (optCustodianInvitation, optCustodian) of
+                (None, None) -> void $ exerciseByKey @Operator operator Operator_OnboardCustodian with custodian = user
+                (Some custodianInvitationCid, Some custodianCid) -> archive custodianInvitationCid
+                _ -> return ()
+            "Issuer" -> do
+              optIssuerInvitation <- lookupByKey @IssuerInvitation userKey
+              optIssuer <- lookupByKey @Issuer userKey
+              case (optIssuerInvitation, optIssuer) of
+                (None, None) -> void $ exerciseByKey @Operator operator Operator_OnboardIssuer with issuer = user
+                (Some issuerInvitationCid, Some issuerCid) -> archive issuerInvitationCid
+                _ -> return ()
+            "Exchange" -> do
+              optExchangeInvitation <- lookupByKey @ExchangeInvitation userKey
+              optExchange <- lookupByKey @Exchange userKey
+              case (optExchangeInvitation, optExchange) of
+                (None, None) -> void $ exerciseByKey @Operator operator Operator_OnboardExchange with exchange = user
+                (Some exchangeInvitationCid, Some exchangeCid) -> archive exchangeInvitationCid
+                _ -> return ()
+            "Investor" -> do
+              optInvestorInvitation <- lookupByKey @InvestorInvitation userKey
+              optInvestor <- lookupByKey @Investor userKey
+              case (optInvestorInvitation, optInvestor) of
+                (None, None) -> void $ exerciseByKey @Operator operator Operator_OnboardInvestor with investor = user
+                (Some investorInvitationCid, Some investorCid) -> archive investorInvitationCid
+                _ -> return ()
+            _ -> return ()
 
 
 template Operator
@@ -31,25 +76,19 @@ template Operator
       nonconsuming Operator_OnboardIssuer : ContractId IssuerInvitation
         with
           issuer : Party
-          custodian : Party
         do
-          exerciseByKey @Custodian (operator, custodian) Custodian_AddIssuer with ..
           create IssuerInvitation with ..
 
       nonconsuming Operator_OnboardInvestor : ContractId InvestorInvitation
         with
           investor : Party
-          custodian : Party
         do
-          exerciseByKey @Custodian (operator, custodian) Custodian_AddInvestor with ..
           create InvestorInvitation with ..
 
       nonconsuming Operator_OnboardExchange : ContractId ExchangeInvitation
         with
           exchange : Party
-          custodian : Party
         do
-          exerciseByKey @Custodian (operator, custodian) Custodian_AddExchange with ..
           create ExchangeInvitation with ..
 
 
@@ -59,6 +98,9 @@ template InvestorInvitation
     investor : Party
   where
     signatory operator
+
+    key (operator, investor) : (Party, Party)
+    maintainer key._1
 
     controller investor can
       InvestorInvitation_Accept : ContractId Investor
@@ -76,6 +118,11 @@ template Investor
     maintainer key._1
 
     controller investor can
+      nonconsuming Investor_RequestCustodianRelationship : ContractId CustodianRelationshipRequest
+        with
+          custodian : Party
+        do create CustodianRelationshipRequest with requester = investor, role = "Investor", ..
+
       nonconsuming Investor_TransferTo : ContractId AssetDeposit
         with
           receiver : Party
@@ -108,6 +155,9 @@ template ExchangeInvitation
   where
     signatory operator
 
+    key (operator, exchange) : (Party, Party)
+    maintainer key._1
+
     controller exchange can
       ExchangeInvitation_Accept : ContractId Exchange
         do create Exchange with tokenPairs = [], participants = [], ..
@@ -128,6 +178,11 @@ template Exchange
     observer participants
 
     controller exchange can
+      nonconsuming Exchange_RequestCustodianRelationship : ContractId CustodianRelationshipRequest
+        with
+          custodian : Party
+        do create CustodianRelationshipRequest with requester = exchange, role = "Exchange", ..
+
       Exchange_InviteParticipant : (ContractId Exchange, ContractId ExchangeParticipantInvitation)
         with
           exchParticipant : Party
@@ -153,7 +208,7 @@ template ExchangeParticipantInvitation
     exchange : Party
     exchParticipant : Party
   where
-    signatory operator, exchange
+    signatory exchange
 
     controller exchParticipant can
       ExchangeParticipantInvitation_Accept : ContractId ExchangeParticipant
@@ -166,9 +221,9 @@ template ExchangeParticipant
     exchange : Party
     exchParticipant : Party
   where
-    signatory operator, exchange, exchParticipant
+    signatory exchange, exchParticipant
 
-    key (exchange, exchParticipant) : (Party, Party)
+    key (exchange, operator, exchParticipant) : (Party, Party, Party)
     maintainer key._1
 
     controller exchParticipant can
@@ -221,35 +276,26 @@ template IssuerInvitation
   with
     operator : Party
     issuer : Party
-    custodian : Party
   where
     signatory operator
+
+    key (operator, issuer) : (Party, Party)
+    maintainer key._1
+
     controller issuer can
       IssuerInvitation_Accept : ContractId Issuer
-        do create Issuer with observers = fromList [custodian], ..
+        do create Issuer with ..
 
 
 template Issuer
   with
     operator : Party
     issuer : Party
-    observers : Set Party
-    -- ^ the custodian needs to be part of this set. Ideally everyone needs to be an observer of the issuer
   where
     signatory operator, issuer
-    observer observers
 
     key (operator, issuer) : (Party, Party)
     maintainer key._1
-
-    choice Issuer_SetObservers : ContractId Issuer
-      with
-        ctrl : Party
-        newObservers : Set Party
-      controller ctrl
-      do
-        assert $ ctrl `elem` [operator, issuer]
-        create this with observers = newObservers
 
     controller issuer can
       nonconsuming Issuer_IssueToken : ContractId Token
@@ -258,7 +304,34 @@ template Issuer
           quantityPrecision : Int
         do
           let tokenId = Id with signatories = fromList [ issuer ], label = name, version = 0
-          create Token with id = tokenId, ..
+          create Token with id = tokenId, observers = empty, ..
+
+      nonconsuming Issuer_RequestCustodianRelationship : ContractId CustodianRelationshipRequest
+        with
+          custodian : Party
+        do create CustodianRelationshipRequest with requester = issuer, role = "Issuer", ..
+
+
+template CustodianRelationshipRequest
+  with
+    operator : Party
+    requester : Party
+    custodian : Party
+    role : Text
+  where
+    signatory operator, requester
+
+    controller custodian can
+      CustodianRelationshipRequest_Approve : ()
+        do
+          case role of
+            "Issuer" -> void $ exerciseByKey @Custodian (operator, custodian) Custodian_AddIssuer with issuer = requester
+            "Exchange" -> void $ exerciseByKey @Custodian (operator, custodian) Custodian_AddExchange with exchange = requester
+            "Investor" -> void $ exerciseByKey @Custodian (operator, custodian) Custodian_AddInvestor with investor = requester
+            _ -> abort $ "Unknown role type: " <> role
+
+      CustodianRelationshipRequest_Reject : ()
+        do return ()
 
 
 template CustodianInvitation
@@ -267,6 +340,9 @@ template CustodianInvitation
     custodian : Party
   where
     signatory operator
+
+    key (operator, custodian) : (Party, Party)
+    maintainer key._1
 
     controller custodian can
       CustodianInvitation_Accept : ContractId Custodian
@@ -286,7 +362,7 @@ template Custodian
     key (operator, custodian) :  (Party, Party)
     maintainer key._1
 
-    controller operator can
+    controller custodian can
       Custodian_AddIssuer : ContractId Custodian
         with
           issuer : Party
@@ -308,7 +384,6 @@ template Custodian
           assertMsg ("Investor " <> show investor <> " already exists") $ investor `notElem` investors
           create this with investors = investor :: investors
 
-    controller custodian can
       nonconsuming GetAccount : Account
         with
           investor : Party

--- a/daml/Marketplace/Trading.daml
+++ b/daml/Marketplace/Trading.daml
@@ -18,7 +18,7 @@ template OrderRequest
   with
     order : Order
   where
-    signatory order.operator, order.exchange, order.exchParticipant
+    signatory order.exchange, order.exchParticipant
     ensure order.qty > 0.0
 
     controller order.exchange can
@@ -35,7 +35,7 @@ template OrderCancelRequest
   with
     order : Order
   where
-    signatory order.operator, order.exchange, order.exchParticipant
+    signatory order.exchange, order.exchParticipant
 
     key (order.exchange, order.orderId) : (Party, Int)
     maintainer key._1
@@ -50,7 +50,6 @@ template OrderCancelRequest
 
 template Order
   with
-    operator : Party
     exchange : Party
     exchParticipant : Party
     pair : TokenPair
@@ -61,7 +60,7 @@ template Order
     status : Text
     orderId : Int
   where
-    signatory operator, exchange, exchParticipant
+    signatory exchange, exchParticipant
     ensure qty > 0.0
 
     key (exchange, orderId) : (Party, Int)


### PR DESCRIPTION
with this PR we aim to decouple the onboarding of a role (Exchange, Issuer, Custodian, Investor) in the marketplace from the relationships between roles (ie custodian <> investor and custodian <> exchange).

This will make the onboarding flow of the parties independent and will allow for adding onboarding automation. The model has also been updated to include a UserSession contract that will eventually be used by automation

In this PR we also remove some of the visibility of the Operator party (especially when it comes to orders placed on an exchange)