### PR TITLE
Changes to support the entire broker flow

### DIFF
--- a/daml/Main.daml
+++ b/daml/Main.daml
@@ -95,7 +95,7 @@ test = scenario do
   relationshipReqCid <- exchange `submit` exercise exchangeCid Exchange_RequestCustodianRelationship with ..
   custodian `submit` exercise relationshipReqCid CustodianRelationshipRequest_Approve
 
-  depositTransferRequest <- bob `submit` exerciseByKey @Investor (operator, bob) Investor_AllocateToExchange with ..
+  depositTransferRequest <- bob `submit` exerciseByKey @Investor (operator, bob) Investor_AllocateToProvider with provider = exchange, ..
   depositCid <- custodian `submit` exercise depositTransferRequest DepositTransferRequest_Approve
 
     -- Alice deposits some USDT under her account
@@ -123,7 +123,7 @@ test = scenario do
   alice `submit` exercise aliceInvCid ExchangeParticipantInvitation_Accept
 
   -- Alice places a bid for the BTC/USDT pair
-  depositTransferRequest <- alice `submit` exerciseByKey @Investor (operator, alice) Investor_AllocateToExchange with depositCid = depositCid3, ..
+  depositTransferRequest <- alice `submit` exerciseByKey @Investor (operator, alice) Investor_AllocateToProvider with provider = exchange, depositCid = depositCid3, ..
   depositCid3 <- custodian `submit` exercise depositTransferRequest DepositTransferRequest_Approve
 
   bidOrderRequestCid <- alice `submit` exerciseByKey @ExchangeParticipant (exchange, operator, alice) ExchangeParticipant_PlaceBid with depositCid = depositCid3, pair = (btcTokenId, usdtTokenId), price = 10000.00

--- a/daml/Marketplace/Broker.daml
+++ b/daml/Marketplace/Broker.daml
@@ -3,6 +3,11 @@ module Marketplace.Broker where
 
 import Marketplace.BrokerCustomer
 import Marketplace.Registry
+import Marketplace.Transfer
+import Marketplace.Utils
+
+import DA.Finance.Asset
+import DA.Finance.Types
 
 
 template BrokerInvitation
@@ -39,3 +44,25 @@ template Broker
         with
           brokerCustomer : Party
         do create BrokerCustomerInvitation with ..
+
+      nonconsuming Broker_RequestDepositTransfer : ContractId DepositTransferRequest
+        with
+          depositCid : ContractId AssetDeposit
+          receiverAccountId : Id
+        do
+           deposit <- fetch depositCid
+           assert $ deposit.account.owner == broker
+           create DepositTransferRequest with sender = broker, senderAccountId = deposit.account.id, ..
+
+      nonconsuming BrokerAllocateToProvider : ContractId DepositTransferRequest
+        with
+          depositCid : ContractId AssetDeposit
+          provider : Party
+        do
+          deposit <- fetch depositCid
+          let receiverAccountId = Id
+                with
+                  signatories = deposit.account.id.signatories,
+                    label = getAccountLabel broker provider,
+                    version = 0
+          exercise self Broker_RequestDepositTransfer with ..

--- a/daml/Marketplace/Investor.daml
+++ b/daml/Marketplace/Investor.daml
@@ -55,17 +55,17 @@ template Investor
         do
            deposit <- fetch depositCid
            assert $ deposit.account.owner == investor
-           create DepositTransferRequest with senderAccountId = deposit.account.id, ..
+           create DepositTransferRequest with sender = investor, senderAccountId = deposit.account.id, ..
 
-      nonconsuming Investor_AllocateToExchange : ContractId DepositTransferRequest
+      nonconsuming Investor_AllocateToProvider : ContractId DepositTransferRequest
         with
           depositCid : ContractId AssetDeposit
-          exchange : Party
+          provider : Party
         do
           deposit <- fetch depositCid
           let receiverAccountId = Id
                 with
                   signatories = deposit.account.id.signatories,
-                    label = getAccountLabel investor exchange,
+                    label = getAccountLabel investor provider,
                     version = 0
           exercise self Investor_RequestDepositTransfer with ..

--- a/daml/Marketplace/Onboarding.daml
+++ b/daml/Marketplace/Onboarding.daml
@@ -1,6 +1,7 @@
 daml 1.2
 module Marketplace.Onboarding where
 
+import Marketplace.Broker
 import Marketplace.Custodian
 import Marketplace.Exchange
 import Marketplace.Investor
@@ -50,5 +51,12 @@ template UserSession
               case (optInvestorInvitation, optInvestor) of
                 (None, None) -> void $ exerciseByKey @Operator operator Operator_OnboardInvestor with investor = user
                 (Some investorInvitationCid, Some investorCid) -> archive investorInvitationCid
+                _ -> return ()
+            "Broker" -> do
+              optBrokerInvitation <- lookupByKey @BrokerInvitation userKey
+              optBroker <- lookupByKey @Broker userKey
+              case (optBrokerInvitation, optBroker) of
+                (None, None) -> void $ exerciseByKey @Operator operator Operator_OnboardBroker with broker = user
+                (Some brokerInvitationCid, Some brokerCid) -> archive brokerInvitationCid
                 _ -> return ()
             _ -> return ()

--- a/daml/Marketplace/Trading.daml
+++ b/daml/Marketplace/Trading.daml
@@ -92,7 +92,7 @@ template Order
               [filledCid, restCid] <- exercise depositCid AssetDeposit_Split
                 with quantities = [depositFillQty]
               txReqCid <- create DepositTransferRequest
-                with investor = exchParticipant,
+                with sender = exchParticipant,
                       senderAccountId = deposit.account.id,
                       receiverAccountId = receiverAccountId,
                       depositCid = filledCid
@@ -105,7 +105,7 @@ template Order
               return $ (None, Some remainingCid)
           else do
             txReqCid <- create DepositTransferRequest
-              with investor = exchParticipant,
+              with sender = exchParticipant,
                     senderAccountId = deposit.account.id,
                     receiverAccountId = receiverAccountId,
                     ..
@@ -140,7 +140,7 @@ template BrokerOrderRequest
           assert $ deposit.account.owner == brokerCustomer
           brokerOrderCid <- create BrokerOrder with ..
           let receiverAccountId = Id with signatories = deposit.account.id.signatories, label = getAccountLabel broker broker, version = 0
-          depositTransferReqCid <- create DepositTransferRequest with investor = brokerCustomer, senderAccountId = deposit.account.id, ..
+          depositTransferReqCid <- create DepositTransferRequest with sender = brokerCustomer, senderAccountId = deposit.account.id, ..
           return (brokerOrderCid, depositTransferReqCid)
 
 
@@ -179,4 +179,4 @@ template BrokerOrder
             <> " does not match the requested of " <> show qty) $ depositQty == qty
           let senderAccountId = deposit.account.id
               receiverAccountId = Id with signatories = deposit.account.id.signatories, label = getAccountLabel brokerCustomer broker, version = 0
-          create DepositTransferRequest with investor = broker, ..
+          create DepositTransferRequest with sender = broker, ..

--- a/daml/Marketplace/Transfer.daml
+++ b/daml/Marketplace/Transfer.daml
@@ -13,7 +13,7 @@ import DA.Next.Set
 
 template DepositTransferRequest
   with
-    investor : Party
+    sender : Party
     senderAccountId : Id
     receiverAccountId : Id
     depositCid : ContractId AssetDeposit
@@ -22,7 +22,7 @@ template DepositTransferRequest
         receiverSig = head $ toList receiverAccountId.signatories
         custodian = senderSig
     ensure senderSig == receiverSig
-    signatory investor
+    signatory sender
 
     controller custodian can
       DepositTransferRequest_Approve : ContractId AssetDeposit

--- a/ui/src/components/Investor/InvestorWallet.tsx
+++ b/ui/src/components/Investor/InvestorWallet.tsx
@@ -75,8 +75,8 @@ const AllocationForm: React.FC<FormProps> = ({ depositCid, options }) => {
         setLoading(true);
         try {
             const key = wrapDamlTuple([operator, investor]);
-            const args = { depositCid, exchange };
-            await ledger.exerciseByKey(Investor.Investor_AllocateToExchange, key, args);
+            const args = { depositCid, provider: exchange };
+            await ledger.exerciseByKey(Investor.Investor_AllocateToProvider, key, args);
             setError(undefined);
         } catch (err) {
             setError(parseError(err));


### PR DESCRIPTION
Some model changes to support the broker flow.

- Given that we now have multiple account providers (ie @Exchange @Custodian @Broker) it makes sense to change the `AllocateToExchange` choice to a more generic `AllocateToProvider`.

