### PR TITLE
add precondition and filter ui to prevent bad transfer requests

### DIFF
--- a/daml/Marketplace/Transfer.daml
+++ b/daml/Marketplace/Transfer.daml
@@ -21,7 +21,7 @@ template DepositTransferRequest
     let senderSig = head $ toList senderAccountId.signatories
         receiverSig = head $ toList receiverAccountId.signatories
         custodian = senderSig
-    ensure senderSig == receiverSig
+    ensure senderSig == receiverSig && senderAccountId /= receiverAccountId
     signatory sender
 
     controller custodian can
@@ -51,3 +51,6 @@ template DepositTransferRequest
           archive receiverRuleCid
 
           return newDepositCid
+
+      DepositTransferRequest_Reject : ()
+        do return ()

--- a/ui/src/components/common/Holdings.tsx
+++ b/ui/src/components/common/Holdings.tsx
@@ -38,14 +38,16 @@ const Holdings: React.FC<Props> = ({ deposits, exchanges, role, sideNav, onLogou
                 <div className='wallet'>
                     { deposits.map(deposit => {
                         const { asset, account } = deposit.contractData;
-                        const exchangeOptions = exchanges.map(exchange => {
-                            const exchangeParty = exchange.contractData.exchange;
-                            return {
-                                key: exchange.contractId,
-                                text: exchange.registryData?.name ? `${exchange.registryData.name} (${exchangeParty})`
-                                                                  : exchangeParty,
-                                value: exchange.contractData.exchange
-                            }
+                        const exchangeOptions = exchanges
+                            .filter(exchange => exchange.contractData.exchange !== getAccountProvider(account.id.label))
+                            .map(exchange => {
+                                const exchangeParty = exchange.contractData.exchange;
+                                return {
+                                    key: exchange.contractId,
+                                    text: exchange.registryData?.name ? `${exchange.registryData.name} (${exchangeParty})`
+                                                                    : exchangeParty,
+                                    value: exchange.contractData.exchange
+                                }
                         })
                         const assetOptions = deposits.map(d => {
                             return {


### PR DESCRIPTION
this PR addresses Issue #56 .

- Filters out the asset deposit's current account provider from the allocate to exchange dropdown
- Adds DAML precondition to not create transfers where source == destination
- Adds Transfer reject custodian choice for future use with bot