### PR TITLE
fix sidebar name flashing

### DIFF
--- a/ui/src/components/Broker/Broker.tsx
+++ b/ui/src/components/Broker/Broker.tsx
@@ -73,7 +73,7 @@ const Broker: React.FC<Props> = ({ onLogout }) => {
 
     const loadingScreen = <OnboardingTile>Loading...</OnboardingTile>
 
-    const sideNav = <BrokerSideNav url={url}/>
+    const sideNav = <BrokerSideNav url={url} name={registeredBroker.contracts[0]?.payload.name || broker}/>
 
     const brokerScreen = <Switch>
         <Route exact path={path}>

--- a/ui/src/components/Broker/BrokerSideNav.tsx
+++ b/ui/src/components/Broker/BrokerSideNav.tsx
@@ -2,24 +2,14 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { Header, Menu } from 'semantic-ui-react'
 
-import { useParty, useStreamFetchByKey } from '@daml/react'
-import { RegisteredBroker } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-
-import { wrapDamlTuple } from '../common/damlTypes'
-
 import { WalletIcon, OrdersIcon } from '../../icons/Icons'
-import { useOperator } from '../common/common'
 
 type Props = {
     url: string;
+    name: string;
 }
 
-const ExchangeSideNav: React.FC<Props> = ({ url }) => {
-    const broker = useParty();
-    const operator = useOperator();
-    const key = () => wrapDamlTuple([operator, broker]);
-    const registeredBroker = useStreamFetchByKey(RegisteredBroker, key, [operator, broker]).contract;
-
+const ExchangeSideNav: React.FC<Props> = ({ url, name }) => {
     return (
         <Menu.Menu>
             <Menu.Item
@@ -27,7 +17,7 @@ const ExchangeSideNav: React.FC<Props> = ({ url }) => {
                 to={url}
                 exact
             >
-                <Header as='h3'>@{registeredBroker?.payload.name || broker}</Header>
+                <Header as='h3'>@{name}</Header>
             </Menu.Item>
 
             <Menu.Item

--- a/ui/src/components/Custodian/Custodian.tsx
+++ b/ui/src/components/Custodian/Custodian.tsx
@@ -70,7 +70,9 @@ const Custodian: React.FC<Props> = ({ onLogout }) => {
 
     const loadingScreen = <OnboardingTile>Loading...</OnboardingTile>
 
-    const sideNav = <CustodianSideNav disabled={!custodianContract} url={url}/>
+    const sideNav = <CustodianSideNav disabled={!custodianContract}
+                                      url={url}
+                                      name={registeredCustodian.contracts[0]?.payload.name || custodian}/>
 
     const custodianScreen = <Switch>
         <Route exact path={path}>

--- a/ui/src/components/Custodian/CustodianSideNav.tsx
+++ b/ui/src/components/Custodian/CustodianSideNav.tsx
@@ -2,31 +2,22 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { Header, Menu } from 'semantic-ui-react'
 
-import { useParty, useStreamFetchByKey } from '@daml/react'
-import { RegisteredCustodian } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-
-import { wrapDamlTuple } from '../common/damlTypes'
 import { UserIcon } from '../../icons/Icons'
-import { useOperator } from '../common/common'
 
 type Props = {
     url: string;
     disabled?: boolean;
+    name: string;
 }
 
-const CustodianSideNav: React.FC<Props> = ({ disabled, url }) => {
-    const custodian = useParty();
-    const operator = useOperator();
-    const key = () => wrapDamlTuple([operator, custodian]);
-    const registeredCustodian = useStreamFetchByKey(RegisteredCustodian, key, [operator, custodian]).contract;
-
+const CustodianSideNav: React.FC<Props> = ({ disabled, url, name }) => {
     const HomeMenuItem = (
         <Menu.Item
             as={NavLink}
             to={url}
             exact
         >
-            <Header as='h3'>@{registeredCustodian?.payload.name || custodian}</Header>
+            <Header as='h3'>@{name}</Header>
         </Menu.Item>
     )
 

--- a/ui/src/components/Exchange/Exchange.tsx
+++ b/ui/src/components/Exchange/Exchange.tsx
@@ -58,7 +58,7 @@ const Exchange: React.FC<Props> = ({ onLogout }) => {
                     .catch(err => console.error(err));
     }
 
-    const sideNav = <ExchangeSideNav url={url}/>;
+    const sideNav = <ExchangeSideNav url={url} name={registeredExchange.contracts[0]?.payload.name || exchange}/>;
 
     const inviteScreen = (
         <InviteAcceptTile role={MarketRole.ExchangeRole} onSubmit={acceptInvite} onLogout={onLogout}>

--- a/ui/src/components/Exchange/ExchangeSideNav.tsx
+++ b/ui/src/components/Exchange/ExchangeSideNav.tsx
@@ -2,30 +2,21 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { Header, Menu } from 'semantic-ui-react'
 
-import { useParty, useStreamFetchByKey } from '@daml/react'
-import { RegisteredExchange } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-
 import { PublicIcon, UserIcon } from '../../icons/Icons'
-import {  wrapDamlTuple } from '../common/damlTypes'
-import { useOperator } from '../common/common'
 
 type Props = {
     url: string;
+    name: string;
 }
 
-const ExchangeSideNav: React.FC<Props> = ({ url }) => {
-    const exchange = useParty();
-    const operator = useOperator();
-    const key = () => wrapDamlTuple([operator, exchange]);
-    const registeredExchange = useStreamFetchByKey(RegisteredExchange, key, [operator, exchange]).contract;
-
+const ExchangeSideNav: React.FC<Props> = ({ url, name }) => {
     const HomeMenuItem = (
         <Menu.Item
             as={NavLink}
             to={url}
             exact
         >
-            <Header as='h3'>@{registeredExchange?.payload.name || exchange}</Header>
+            <Header as='h3'>@{name}</Header>
         </Menu.Item>
     )
 

--- a/ui/src/components/Investor/Investor.tsx
+++ b/ui/src/components/Investor/Investor.tsx
@@ -76,7 +76,9 @@ const Investor: React.FC<Props> = ({ onLogout }) => {
                     .catch(err => console.error(err));
     }
 
-    const sideNav = <InvestorSideNav url={url} exchanges={allExchanges}/>;
+    const sideNav = <InvestorSideNav url={url}
+                                     exchanges={allExchanges}
+                                     name={registeredInvestor.contracts[0]?.payload.name || investor}/>
 
     const inviteScreen = (
         <InviteAcceptTile role={MarketRole.InvestorRole} onSubmit={acceptInvite} onLogout={onLogout}>

--- a/ui/src/components/Investor/InvestorSideNav.tsx
+++ b/ui/src/components/Investor/InvestorSideNav.tsx
@@ -2,31 +2,23 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { Header, Menu } from 'semantic-ui-react'
 
-import { useParty, useStreamFetchByKey } from '@daml/react'
-import { RegisteredInvestor } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-
 import { ExchangeIcon, OrdersIcon, WalletIcon } from '../../icons/Icons'
-import { ExchangeInfo, unwrapDamlTuple, wrapDamlTuple } from '../common/damlTypes'
-import { useOperator } from '../common/common'
+import { ExchangeInfo, unwrapDamlTuple } from '../common/damlTypes'
 
 type Props = {
     url: string;
     exchanges: ExchangeInfo[];
+    name: string;
 }
 
-const InvestorSideNav: React.FC<Props> = ({ url, exchanges }) => {
-    const investor = useParty();
-    const operator = useOperator();
-    const key = () => wrapDamlTuple([operator, investor]);
-    const registeredInvestor = useStreamFetchByKey(RegisteredInvestor, key, [operator, investor]).contract;
-
+const InvestorSideNav: React.FC<Props> = ({ url, exchanges, name }) => {
     const HomeMenuItem = (
         <Menu.Item
             as={NavLink}
             to={url}
             exact
         >
-            <Header as='h3'>@{registeredInvestor?.payload.name || investor}</Header>
+            <Header as='h3'>@{name}</Header>
         </Menu.Item>
     )
 

--- a/ui/src/components/Issuer/Issuer.tsx
+++ b/ui/src/components/Issuer/Issuer.tsx
@@ -82,6 +82,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
     );
 
     const loadingScreen = <OnboardingTile>Loading...</OnboardingTile>
+    const sideNav = <IssuerSideNav url={url} name={registeredIssuer.contracts[0]?.payload.name || issuer}/>;
 
     const issuerScreen = (
         <Switch>
@@ -95,14 +96,14 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
                     marketRelationships={
                         <MarketRelationships role={MarketRole.IssuerRole}
                                              custodianRelationships={allCustodianRelationships}/>}
-                    sideNav={<IssuerSideNav url={url}/>}
+                    sideNav={sideNav}
                     onLogout={onLogout}/>
             </Route>
 
             <Route path={`${path}/issue-asset`}>
                 <Page
                     menuTitle={<><PublicIcon/> Issue Asset</>}
-                    sideNav={<IssuerSideNav url={url}/>}
+                    sideNav={sideNav}
                     onLogout={onLogout}
                 >
                     <PageSection border='blue' background='white'>
@@ -112,7 +113,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
             </Route>
 
             <Route path={`${path}/issued-token/:tokenId`}>
-                <IssuedToken sideNav={<IssuerSideNav url={url}/>} onLogout={onLogout}/>
+                <IssuedToken sideNav={sideNav} onLogout={onLogout}/>
             </Route>
         </Switch>
     )

--- a/ui/src/components/Issuer/IssuerSideNav.tsx
+++ b/ui/src/components/Issuer/IssuerSideNav.tsx
@@ -2,26 +2,19 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { Header, Menu } from 'semantic-ui-react'
 
-import { useParty, useStreamQuery, useStreamFetchByKey } from '@daml/react'
+import { useStreamQuery } from '@daml/react'
 
 import { Token } from '@daml.js/da-marketplace/lib/Marketplace/Token'
-import { RegisteredIssuer } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
 
 import { PublicIcon, CircleIcon } from '../../icons/Icons'
-import { wrapDamlTuple } from '../common/damlTypes'
-import { useOperator } from '../common/common'
 
 type IssuerSideNavProps = {
-    url: string
+    url: string;
+    name: string;
 }
 
-const IssuerSideNav: React.FC<IssuerSideNavProps> = ({ url }) => {
-    const issuer = useParty();
+const IssuerSideNav: React.FC<IssuerSideNavProps> = ({ url, name }) => {
     const allTokens = useStreamQuery(Token).contracts
-
-    const operator = useOperator();
-    const key = () => wrapDamlTuple([operator, issuer]);
-    const registeredIssuer = useStreamFetchByKey(RegisteredIssuer, key, [operator, issuer]).contract;
 
     return <>
         <Menu.Menu>
@@ -30,7 +23,7 @@ const IssuerSideNav: React.FC<IssuerSideNavProps> = ({ url }) => {
                 to={url}
                 exact={true}
             >
-                <Header as='h3'>@{registeredIssuer?.payload.name || issuer}</Header>
+                <Header as='h3'>@{name}</Header>
             </Menu.Item>
             <Menu.Item
                 as={NavLink}


### PR DESCRIPTION
Fixes the name in the sidebar flashing by passing down the name from the main page for each role.

Addresses https://github.com/digital-asset/da-marketplace/issues/79.