### PR TITLE
Evidence Trades

### DIFF
--- a/daml/Main.daml
+++ b/daml/Main.daml
@@ -135,8 +135,8 @@ test = scenario do
   bidOrderCid <- exchange `submit` exerciseByKey @Exchange (operator, exchange) Exchange_ApproveOrderRequest with orderRequestCid = bidOrderRequestCid, orderId = 2
 
   -- exchange matches the two orders
-  (Some txReqCid1, _) <- exchange `submit` exercise bidOrderCid Order_Fill with fillQty = 0.01, fillPrice = 10000.0, counterParty = bob
-  (Some txReqCid2, _) <- exchange `submit` exercise offerOrderCid Order_Fill with fillQty = 0.01, fillPrice = 10000.00, counterParty = alice
+  (Some txReqCid1, _) <- exchange `submit` exercise bidOrderCid Order_Fill with fillQty = 0.01, fillPrice = 10000.0, counterParty = bob, counterOrderId = 1, timestamp = "1601394768171637000"
+  (Some txReqCid2, _) <- exchange `submit` exercise offerOrderCid Order_Fill with fillQty = 0.01, fillPrice = 10000.00, counterParty = alice, counterOrderId = 2, timestamp = "1601394768171637000"
 
   bobDepositCid <- custodian `submit` exercise txReqCid1 DepositTransferRequest_Approve
   aliceDepositCid <- custodian `submit` exercise txReqCid2 DepositTransferRequest_Approve

--- a/daml/Marketplace/Trading.daml
+++ b/daml/Marketplace/Trading.daml
@@ -69,6 +69,8 @@ template Order
           fillQty : Decimal
           fillPrice : Decimal
           counterParty : Party
+          counterOrderId : Int
+          timestamp : Text
         do
           assert $ fillQty > 0.0
           assert $ fillQty <= qty
@@ -98,10 +100,12 @@ template Order
                       depositCid = filledCid
               remainingCid <- create this
                 with depositCid = restCid, qty = qty - fillQty, status = "PartiallyFilled"
+              create TradeSide with isBuy = isBid, ..
               return $ (Some txReqCid, Some remainingCid)
             else do
               -- the fillQty is not enough to warrant a deposit transfer
               remainingCid <- create this with qty = qty - fillQty, status = "PartiallyFilled"
+              create TradeSide with isBuy = isBid, ..
               return $ (None, Some remainingCid)
           else do
             txReqCid <- create DepositTransferRequest
@@ -109,6 +113,7 @@ template Order
                     senderAccountId = deposit.account.id,
                     receiverAccountId = receiverAccountId,
                     ..
+            create TradeSide with isBuy = isBid, ..
             return $ (Some txReqCid, None)
 
       Order_Cancel : ()
@@ -179,4 +184,33 @@ template BrokerOrder
             <> " does not match the requested of " <> show qty) $ depositQty == qty
           let senderAccountId = deposit.account.id
               receiverAccountId = Id with signatories = deposit.account.id.signatories, label = getAccountLabel brokerCustomer broker, version = 0
+          create BrokerTrade with isBuy = isBid, ..
           create DepositTransferRequest with sender = broker, ..
+
+
+template TradeSide
+  with
+    exchParticipant : Party
+    exchange : Party
+    pair : TokenPair
+    price : Decimal
+    qty : Decimal
+    isBuy : Bool
+    orderId : Int
+    counterOrderId : Int
+    timestamp : Text
+  where
+    signatory exchange, exchParticipant
+
+
+template BrokerTrade
+  with
+    brokerCustomer : Party
+    broker : Party
+    pair : TokenPair
+    price : Decimal
+    qty : Decimal
+    isBuy : Bool
+    brokerOrderId : Int
+  where
+    signatory broker, brokerCustomer

--- a/exberry_adapter/bot/exberry_adapter_bot.py
+++ b/exberry_adapter/bot/exberry_adapter_bot.py
@@ -142,12 +142,16 @@ def main():
         commands.append(exercise(taker_cid, 'Order_Fill', {
             'fillQty': execution['executedQuantity'],
             'fillPrice': execution['executedPrice'],
-            'counterParty': maker['exchParticipant']
+            'counterOrderId': maker['orderId'],
+            'counterParty': maker['exchParticipant'],
+            'timestamp': execution['eventTimestamp']
         }))
         commands.append(exercise(maker_cid, 'Order_Fill', {
             'fillQty': execution['executedQuantity'],
             'fillPrice': execution['executedPrice'],
-            'counterParty': taker['exchParticipant']
+            'counterParty': taker['exchParticipant'],
+            'counterOrderId': taker['orderId'],
+            'timestamp': execution['eventTimestamp']
         }))
 
         return commands

--- a/matching_engine/bot/matching_engine_bot.py
+++ b/matching_engine/bot/matching_engine_bot.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 
 import dazl
 from dazl import exercise
@@ -80,6 +81,7 @@ def main():
         for (cid, passive_order) in sorted(opposite_book.items(), key=sorter, reverse=(not is_bid)):
             if is_crossing(passive_order, order):
                 logging.info(f"Order crosses with \n{order_to_str(passive_order)}")
+                timestamp = f"{str(time.time()).replace('.','')}000"
 
                 fill_qty = min(passive_order['qty'], order['qty'])
                 fill_price = passive_order['price']
@@ -87,12 +89,16 @@ def main():
                 fill_passive = exercise(cid, 'Order_Fill', {
                     'fillQty': fill_qty,
                     'fillPrice': fill_price,
-                    'counterParty': order['exchParticipant']
+                    'counterOrderId': order['orderId'],
+                    'counterParty': order['exchParticipant'],
+                    'timestamp': timestamp
                 })
                 fill_aggressive = exercise(event.cid, 'Order_Fill', {
                     'fillQty': fill_qty,
                     'fillPrice': fill_price,
-                    'counterParty': passive_order['exchParticipant']
+                    'counterOrderId': passive_order['orderId'],
+                    'counterParty': passive_order['exchParticipant'],
+                    'timestamp': timestamp
                 })
 
                 return client.submit([fill_passive, fill_aggressive])

--- a/ui/src/components/Investor/InvestorOrders.tsx
+++ b/ui/src/components/Investor/InvestorOrders.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 
 import { useStreamQuery } from '@daml/react'
-import { Order, OrderRequest } from '@daml.js/da-marketplace/lib/Marketplace/Trading'
+import { BrokerTrade, Order, OrderRequest, TradeSide } from '@daml.js/da-marketplace/lib/Marketplace/Trading'
 
 import { OrdersIcon } from '../../icons/Icons'
-import { OrderCard } from '../common/OrderCard'
+import { BrokerTradeCard } from '../common/BrokerTradeCard'
 import ExchangeOrderCard from '../common/ExchangeOrderCard'
-import PageSection from '../common/PageSection'
+import { OrderCard } from '../common/OrderCard'
 import Page from '../common/Page'
+import PageSection from '../common/PageSection'
+import { TradeCard } from '../common/TradeCard'
 
 
 type Props = {
@@ -18,6 +20,8 @@ type Props = {
 const InvestorOrders: React.FC<Props> = ({ sideNav, onLogout }) => {
     const allOrders = useStreamQuery(Order).contracts;
     const allOrderRequests = useStreamQuery(OrderRequest).contracts;
+    const allExchangeTrades = useStreamQuery(TradeSide).contracts;
+    const allBrokerTradees = useStreamQuery(BrokerTrade).contracts;
 
     return (
         <Page
@@ -32,6 +36,12 @@ const InvestorOrders: React.FC<Props> = ({ sideNav, onLogout }) => {
 
                     <p>Open Orders</p>
                     { allOrders.map(o => <ExchangeOrderCard key={o.contractId} order={o.payload}/>)}
+
+                    <p>Exchange Trades</p>
+                    { allExchangeTrades.map(t => <TradeCard key={t.contractId} trade={t.payload}/>)}
+
+                    <p>Broker Trades</p>
+                    { allBrokerTradees.map(t => <BrokerTradeCard key={t.contractId} brokerTrade={t.payload}/>)}
                 </div>
             </PageSection>
         </Page>

--- a/ui/src/components/Investor/InvestorOrders.tsx
+++ b/ui/src/components/Investor/InvestorOrders.tsx
@@ -21,7 +21,7 @@ const InvestorOrders: React.FC<Props> = ({ sideNav, onLogout }) => {
     const allOrders = useStreamQuery(Order).contracts;
     const allOrderRequests = useStreamQuery(OrderRequest).contracts;
     const allExchangeTrades = useStreamQuery(TradeSide).contracts;
-    const allBrokerTradees = useStreamQuery(BrokerTrade).contracts;
+    const allBrokerTrades = useStreamQuery(BrokerTrade).contracts;
 
     return (
         <Page
@@ -32,16 +32,16 @@ const InvestorOrders: React.FC<Props> = ({ sideNav, onLogout }) => {
             <PageSection border='blue' background='white'>
                 <div className='investor-orders'>
                     <p>Requested Orders</p>
-                    { allOrderRequests.map(or => <OrderCard key={or.contractId} order={or.payload.order}/>)}
+                    {allOrderRequests.map(or => <OrderCard key={or.contractId} order={or.payload.order}/>)}
 
                     <p>Open Orders</p>
-                    { allOrders.map(o => <ExchangeOrderCard key={o.contractId} order={o.payload}/>)}
+                    {allOrders.map(o => <ExchangeOrderCard key={o.contractId} order={o.payload}/>)}
 
                     <p>Exchange Trades</p>
-                    { allExchangeTrades.map(t => <TradeCard key={t.contractId} trade={t.payload}/>)}
+                    {allExchangeTrades.map(t => <TradeCard key={t.contractId} trade={t.payload}/>)}
 
                     <p>Broker Trades</p>
-                    { allBrokerTradees.map(t => <BrokerTradeCard key={t.contractId} brokerTrade={t.payload}/>)}
+                    {allBrokerTrades.map(t => <BrokerTradeCard key={t.contractId} brokerTrade={t.payload}/>)}
                 </div>
             </PageSection>
         </Page>

--- a/ui/src/components/common/BrokerTradeCard.tsx
+++ b/ui/src/components/common/BrokerTradeCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Card } from 'semantic-ui-react'
+import { unwrapDamlTuple } from '../common/damlTypes'
+import { BrokerTrade } from '@daml.js/da-marketplace/lib/Marketplace/Trading'
+import { ExchangeIcon } from '../../icons/Icons'
+
+import './OrderCard.css'
+
+export type BrokerTradeCardProps = {
+    brokerTrade: BrokerTrade;
+}
+
+const BrokerTradeCard: React.FC<BrokerTradeCardProps> = ({ children, brokerTrade }) => {
+    const [base, quote] = unwrapDamlTuple(brokerTrade.pair).map(t => t.label);
+    const label = brokerTrade.isBuy ? `Bought ${base}/${quote}` : `Sold ${base}/${quote}`;
+    const price = `${brokerTrade.price} ${quote}`;
+    const amount = brokerTrade.isBuy ? `+ ${brokerTrade.qty} ${base}` : `- ${brokerTrade.qty} ${base}`;
+
+    return (
+        <div className='order-card-container'>
+            <div className='order-card'>
+                <Card fluid className='order-info'>
+                    <div><ExchangeIcon/> {label}</div>
+                    <div>{ amount }</div>
+                    <div>{`@ ${price}`}</div>
+                    <div>{`Broker Order ID: ${brokerTrade.brokerOrderId}`}</div>
+                </Card>
+
+                { children }
+            </div>
+        </div>
+    )
+}
+
+export { BrokerTradeCard };

--- a/ui/src/components/common/TradeCard.tsx
+++ b/ui/src/components/common/TradeCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Card } from 'semantic-ui-react'
+import { unwrapDamlTuple } from '../common/damlTypes'
+import { TradeSide } from '@daml.js/da-marketplace/lib/Marketplace/Trading'
+import { ExchangeIcon } from '../../icons/Icons'
+
+import './OrderCard.css'
+
+export type TradeCardProps = {
+    trade: TradeSide;
+}
+
+const TradeCard: React.FC<TradeCardProps> = ({ children, trade }) => {
+    const [base, quote] = unwrapDamlTuple(trade.pair).map(t => t.label);
+    const label = trade.isBuy ? `Bought ${base}/${quote}` : `Sold ${base}/${quote}`;
+    const price = `${trade.price} ${quote}`;
+    const amount = trade.isBuy ? `+ ${trade.qty} ${base}` : `- ${trade.qty} ${base}`;
+    const time = new Date(0);
+    // timestamp is in nanos with millisecond precision
+    time.setUTCMilliseconds(parseInt(trade.timestamp.substring(0, trade.timestamp.length-3)))
+    const timeLabel = new Intl.DateTimeFormat('en-US',
+        { hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(time)
+
+    return (
+        <div className='order-card-container'>
+            <div className='order-card'>
+                <Card fluid className='order-info'>
+                    <div><ExchangeIcon/> {label}</div>
+                    <div>{ amount }</div>
+                    <div>{`@ ${price}`}</div>
+                    <div>{`Order ID: ${trade.orderId}`}</div>
+                    <div>{`Counter Order ID: ${trade.counterOrderId}`}</div>
+                    <div>{timeLabel}</div>
+                </Card>
+
+                { children }
+            </div>
+        </div>
+    )
+}
+
+export { TradeCard };

--- a/ui/src/components/common/TradeCard.tsx
+++ b/ui/src/components/common/TradeCard.tsx
@@ -16,8 +16,8 @@ const TradeCard: React.FC<TradeCardProps> = ({ children, trade }) => {
     const price = `${trade.price} ${quote}`;
     const amount = trade.isBuy ? `+ ${trade.qty} ${base}` : `- ${trade.qty} ${base}`;
     const time = new Date(0);
-    // timestamp is in nanos with millisecond precision
-    time.setUTCMilliseconds(parseInt(trade.timestamp.substring(0, trade.timestamp.length-3)))
+    // timestamp is in nanos with microsecond precision
+    time.setUTCMilliseconds(parseInt(trade.timestamp.substring(0, trade.timestamp.length - 6)))
     const timeLabel = new Intl.DateTimeFormat('en-US',
         { hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(time)
 


### PR DESCRIPTION
This addresses issue #51 

- Add the concept of `TradeSide` to the daml model that evidences an exchange trade for a specific party. The trade now contains the time traded as well as the order ids that matched on the engine
- Add a `BrokerTrade` to the daml model to hold all the fill information for a trade between a broker and their customer
- Add exchange trades and broker trades for investors on UI


~Hasn't been fully tested~

### 2020-10-07 update:
Tested end-to-end on a prod ledger with the Exberry integration
