### PR TITLE
Display all providers, amounts committed

### DIFF
--- a/ui/src/components/Broker/Broker.tsx
+++ b/ui/src/components/Broker/Broker.tsx
@@ -4,6 +4,7 @@ import { Switch, Route, useRouteMatch } from 'react-router-dom'
 import { useLedger, useParty, useStreamQuery } from '@daml/react'
 import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { Exchange } from '@daml.js/da-marketplace/lib/Marketplace/Exchange'
+import { ExchangeParticipant } from '@daml.js/da-marketplace/lib/Marketplace/ExchangeParticipant'
 import { RegisteredBroker } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
 import { BrokerInvitation } from '@daml.js/da-marketplace/lib/Marketplace/Broker'
 import { CustodianRelationship } from '@daml.js/da-marketplace/lib/Marketplace/Custodian'
@@ -40,15 +41,18 @@ const Broker: React.FC<Props> = ({ onLogout }) => {
 
     const { custodianMap, exchangeMap } = useRegistryLookup();
 
-    const allProviders = [
-        ...allExchanges.map(exchange => {
-            const party = exchange.contractData.exchange;
+    const exchangeProviders = useStreamQuery(ExchangeParticipant).contracts
+        .map(exchParticipant => {
+            const party = exchParticipant.payload.exchange;
             const name = exchangeMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Exchange`,
+                label: `${name ? `${name} (${party})` : party} | Exchange`
             }
-        }),
+        });
+
+    const allProviders = [
+        ...exchangeProviders,
         ...allCustodianRelationships.map(relationship => {
             const party = relationship.contractData.custodian;
             const name = custodianMap.get(party)?.name;

--- a/ui/src/components/Custodian/Clients.tsx
+++ b/ui/src/components/Custodian/Clients.tsx
@@ -6,6 +6,7 @@ import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 
 import { UserIcon } from '../../icons/Icons'
 import { DepositInfo, makeContractInfo } from '../common/damlTypes'
+import { depositSummary } from '../common/utils'
 import StripedTable from '../common/StripedTable'
 import PageSection from '../common/PageSection'
 import Page from '../common/Page'
@@ -22,7 +23,10 @@ const Clients: React.FC<Props> = ({ clients, sideNav, onLogout }) => {
     const allDeposits = useStreamQuery(AssetDeposit).contracts.map(makeContractInfo);
 
     const tableRows = clients.map(client => (
-        <InvestorRow key={client} deposits={allDeposits} investor={client}/>
+        <InvestorRow
+            key={client}
+            deposits={allDeposits.filter(deposit => deposit.contractData.account.owner === client)}
+            investor={client}/>
     ));
 
     return (
@@ -48,32 +52,12 @@ type RowProps = {
     deposits: DepositInfo[];
 }
 
-type StringNumberMap = {
-    [label: string]: number;
-}
+const InvestorRow: React.FC<RowProps> = ({ deposits, investor }) => (
+    <Table.Row>
+        <Table.Cell>{investor}</Table.Cell>
+        <Table.Cell>{depositSummary(deposits)}</Table.Cell>
+    </Table.Row>
+)
 
-const InvestorRow: React.FC<RowProps> = ({ deposits, investor }) => {
-    const depositSums = deposits
-        .filter(deposit => deposit.contractData.account.owner === investor)
-        .reduce((sums, deposit) => {
-            const label = deposit.contractData.asset.id.label;
-            const amount = Number(deposit.contractData.asset.quantity);
-            const existingValue = sums[label] || 0;
-
-            return { ...sums, [label]: existingValue + amount };
-        }, {} as StringNumberMap);
-
-    const holdings = Object
-        .entries(depositSums)
-        .map(([key, value]) => `${key}: ${value}`)
-        .join(", ");
-
-    return (
-        <Table.Row>
-            <Table.Cell>{investor}</Table.Cell>
-            <Table.Cell>{holdings}</Table.Cell>
-        </Table.Row>
-    )
-}
 
 export default Clients;

--- a/ui/src/components/Exchange/ExchangeParticipants.tsx
+++ b/ui/src/components/Exchange/ExchangeParticipants.tsx
@@ -3,17 +3,19 @@ import { Table } from 'semantic-ui-react'
 
 import { useStreamQuery } from '@daml/react'
 import { useStreamQueryAsPublic } from '@daml/dabl-react'
+import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { RegisteredInvestor } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
 import { ExchangeParticipant } from '@daml.js/da-marketplace/lib/Marketplace/ExchangeParticipant'
 import { Order } from '@daml.js/da-marketplace/lib/Marketplace/Trading'
 
 import { UserIcon } from '../../icons/Icons'
-import { ExchangeParticipantInfo, makeContractInfo } from '../common/damlTypes'
+import { ExchangeParticipantInfo, DepositInfo, makeContractInfo } from '../common/damlTypes'
 import StripedTable from '../common/StripedTable'
 import PageSection from '../common/PageSection'
 import Page from '../common/Page'
 
 import InviteParticipant from './InviteParticipant'
+import { depositSummary } from '../common/utils'
 
 type Props = {
     sideNav: React.ReactElement;
@@ -21,6 +23,7 @@ type Props = {
 }
 
 const ExchangeParticipants: React.FC<Props> = ({ sideNav, onLogout }) => {
+    const allDeposits = useStreamQuery(AssetDeposit).contracts.map(makeContractInfo);
     const registeredInvestors = useStreamQueryAsPublic(RegisteredInvestor).contracts.map(makeContractInfo);
     const exchangeParticipants = useStreamQuery(ExchangeParticipant).contracts.map(makeContractInfo);
 
@@ -31,7 +34,10 @@ const ExchangeParticipants: React.FC<Props> = ({ sideNav, onLogout }) => {
     });
 
     const rows = exchangeParticipants.map(participant =>
-        <ExchangeParticipantRow key={participant.contractId} participant={participant}/>
+        <ExchangeParticipantRow
+            key={participant.contractId}
+            deposits={allDeposits}
+            participant={participant}/>
     );
 
     return (
@@ -45,7 +51,7 @@ const ExchangeParticipants: React.FC<Props> = ({ sideNav, onLogout }) => {
                     <InviteParticipant registeredInvestors={investorOptions}/>
                     <StripedTable
                         className='active-participants'
-                        header={['Id', 'Active Orders', 'Volume Traded (USD)', 'Amount Commited (USD)']}
+                        header={['Id', 'Active Orders', 'Volume Traded (USD)', 'Amount Committed']}
                         rows={rows}/>
                 </div>
             </PageSection>
@@ -54,22 +60,24 @@ const ExchangeParticipants: React.FC<Props> = ({ sideNav, onLogout }) => {
 }
 
 type RowProps = {
-    participant: ExchangeParticipantInfo
+    deposits: DepositInfo[];
+    participant: ExchangeParticipantInfo;
 }
 
-const ExchangeParticipantRow: React.FC<RowProps> = ({ participant }) => {
+const ExchangeParticipantRow: React.FC<RowProps> = ({ deposits, participant }) => {
     const { exchange, exchParticipant } = participant.contractData;
 
     const query = () => ({ exchange, exchParticipant });
-    const deps = [exchange, exchParticipant];
-    const activeOrders = useStreamQuery(Order, query, deps).contracts.length;
+    const activeOrders = useStreamQuery(Order, query, [exchange, exchParticipant]).contracts.length;
+
+    const investorDeposits = deposits.filter(deposit => deposit.contractData.account.owner === exchParticipant);
 
     return (
         <Table.Row className='active-participants-row'>
             <Table.Cell>{exchParticipant}</Table.Cell>
             <Table.Cell>{activeOrders}</Table.Cell>
             <Table.Cell>-</Table.Cell>
-            <Table.Cell>-</Table.Cell>
+            <Table.Cell>{depositSummary(investorDeposits) || '-'}</Table.Cell>
         </Table.Row>
     )
 }

--- a/ui/src/components/Investor/Investor.tsx
+++ b/ui/src/components/Investor/Investor.tsx
@@ -5,6 +5,7 @@ import { useLedger, useParty, useStreamQuery } from '@daml/react'
 import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { BrokerCustomer } from '@daml.js/da-marketplace/lib/Marketplace/BrokerCustomer'
 import { CustodianRelationship } from '@daml.js/da-marketplace/lib/Marketplace/Custodian'
+import { ExchangeParticipant } from '@daml.js/da-marketplace/lib/Marketplace/ExchangeParticipant'
 import { Exchange } from '@daml.js/da-marketplace/lib/Marketplace/Exchange'
 import {
     Investor as InvestorModel,
@@ -55,27 +56,30 @@ const Investor: React.FC<Props> = ({ onLogout }) => {
             const name = brokerMap.get(damlTupleToString(broker.key))?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Broker`,
+                label: `${name ? `${name} (${party})` : party} | Broker`
             }
         })
 
-    const allProviders = [
-        ...allExchanges.map(exchange => {
-            const party = exchange.contractData.exchange;
+    const exchangeProviders = useStreamQuery(ExchangeParticipant).contracts
+        .map(exchParticipant => {
+            const party = exchParticipant.payload.exchange;
             const name = exchangeMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Exchange`,
+                label: `${name ? `${name} (${party})` : party} | Exchange`
             }
-        }),
+        });
+
+    const allProviders = [
         ...allCustodianRelationships.map(relationship => {
             const party = relationship.contractData.custodian;
             const name = custodianMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Custodian`,
+                label: `${name ? `${name} (${party})` : party} | Custodian`
             }
         }),
+        ...exchangeProviders,
         ...brokerProviders,
     ];
 

--- a/ui/src/components/common/Holdings.css
+++ b/ui/src/components/common/Holdings.css
@@ -17,3 +17,25 @@
     font-size: 16px;
     line-height: 22px;
 }
+
+.asset-section {
+    border-bottom: 2px var(--grey2) solid;
+    margin-bottom: 25px;
+}
+
+.asset-section:last-child {
+    border: none;
+}
+
+.deposit-row {
+    padding: 10px;
+    margin: 10px 0px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.deposit-row > div {
+    flex-grow: 1;
+    flex-basis: 0;
+}

--- a/ui/src/components/common/utils.ts
+++ b/ui/src/components/common/utils.ts
@@ -1,5 +1,47 @@
+import { DepositInfo } from "./damlTypes";
+
 const vowels = ['a', 'e', 'i', 'o', 'u'];
 
 export const indefiniteArticle = (word: string): string => {
     return vowels.includes(word[0].toLowerCase()) ? `an ${word}` : `a ${word}`;
+}
+
+type StringToDepositInfoArray = {
+    [key: string]: DepositInfo[];
+}
+
+export const groupDeposits = (deposits: DepositInfo[]): StringToDepositInfoArray => {
+    return deposits.reduce((group, deposit) => {
+        const label = deposit.contractData.asset.id.label;
+        const existingValue = group[label] || [];
+
+        return { ...group, [label]: [...existingValue, deposit] };
+    }, {} as StringToDepositInfoArray);
+}
+
+const sumDepositArray = (deposits: DepositInfo[]): number =>
+    deposits.reduce((sum, val) => sum + Number(val.contractData.asset.quantity), 0);
+
+type StringToNumber = {
+    [key: string]: number;
+}
+
+export const sumDeposits = (deposits: DepositInfo[]): StringToNumber => {
+    const depositGroup = groupDeposits(deposits);
+
+    return Object
+        .entries(depositGroup)
+        .reduce((acc, [label, deposits]) => ({
+            ...acc,
+            [label]: sumDepositArray(deposits)
+        }), {} as StringToNumber)
+}
+
+export const depositSummary = (deposits: DepositInfo[]): string => {
+    const depositSums = sumDeposits(deposits);
+
+    return Object
+        .entries(depositSums)
+        .map(([label, total]) => `${label}: ${total}`)
+        .join(", ");
 }


### PR DESCRIPTION
Closes #52, #53, #84 

- Displays amount investors have committed in the exchange view
- Pass in an array of `providers` to the Holdings component
- Groups asset deposits of the same asset together into sections, then lists each individual deposit with options beneath it 
- Splits each button into separate forms to avoid duplicate transfer requests
- You can't merge deposits if the account providers are different, so I filter those options accordingly

![Screen Shot 2020-10-06 at 4 16 22 PM](https://user-images.githubusercontent.com/64022527/95255427-53d55480-07ef-11eb-9736-8d87456eb74d.png)
