### PR TITLE
Use HashRouter and persist credentials to localStorage

### DIFF
--- a/ui/src/Credentials.ts
+++ b/ui/src/Credentials.ts
@@ -1,8 +1,10 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { encode } from 'jwt-simple';
-import { ledgerId } from './config';
+import { encode } from 'jwt-simple'
+import { expiredToken } from '@daml/dabl-react'
+
+import { ledgerId } from './config'
 
 export const APPLICATION_ID: string = 'da-marketplace';
 
@@ -15,6 +17,33 @@ export type Credentials = {
   party: string;
   token: string;
   ledgerId: string;
+}
+
+function isCredentials(credentials: any): credentials is Credentials {
+  return typeof credentials.party === 'string' &&
+         typeof credentials.token === 'string' &&
+         typeof credentials.ledgerId === 'string'
+}
+
+const CREDENTIALS_STORAGE_KEY = 'credentials';
+
+export function storeCredentials(credentials?: Credentials): void {
+  localStorage.setItem(CREDENTIALS_STORAGE_KEY, JSON.stringify(credentials));
+}
+
+export function retrieveCredentials(): Credentials | undefined {
+  const credentialsJson = localStorage.getItem(CREDENTIALS_STORAGE_KEY);
+
+  try {
+    const credentials = JSON.parse(credentialsJson || '');
+    if (isCredentials(credentials) && !expiredToken(credentials.token)) {
+      return credentials;
+    }
+  } catch {
+    console.warn("Could not parse credentials: ", credentialsJson);
+  }
+
+  return undefined;
 }
 
 function computeToken(party: string): string {

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react'
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Route,
   Redirect,
   Switch
@@ -12,27 +12,33 @@ import {
 import DamlLedger from '@daml/react'
 import { PublicLedger, WellKnownPartiesProvider } from '@daml/dabl-react'
 
-import Credentials, { computeCredentials } from '../Credentials'
+import Credentials, { computeCredentials, storeCredentials, retrieveCredentials } from '../Credentials'
 import { httpBaseUrl } from '../config'
 
+import { RegistryLookupProvider } from './common/RegistryLookup'
 import { useDablParties } from './common/common'
+import OnboardingTile from './common/OnboardingTile'
+
 import LoginScreen from './LoginScreen'
 import MainScreen from './MainScreen'
-import OnboardingTile from './common/OnboardingTile'
-import { RegistryLookupProvider } from './common/RegistryLookup'
 
 /**
  * React component for the entry point into the application.
  */
 // APP_BEGIN
 const App: React.FC = () => {
-  const [credentials, setCredentials] = React.useState<Credentials>();
+  const [credentials, setCredentials] = React.useState<Credentials | undefined>(retrieveCredentials());
+
+  const handleCredentials = (credentials?: Credentials) => {
+    setCredentials(credentials);
+    storeCredentials(credentials);
+  }
 
   return (
     <Router>
       <Switch>
         <Route exact path='/'>
-          <LoginScreen onLogin={setCredentials}/>
+          <LoginScreen onLogin={handleCredentials}/>
         </Route>
 
         <Route path='/role' render={() => {
@@ -45,7 +51,7 @@ const App: React.FC = () => {
                 <WellKnownPartiesProvider>
                   <PublicProvider>
                     <RegistryLookupProvider>
-                      <MainScreen onLogout={() => setCredentials(undefined)}/>
+                      <MainScreen onLogout={() => handleCredentials(undefined)}/>
                     </RegistryLookupProvider>
                   </PublicProvider>
                 </WellKnownPartiesProvider>


### PR DESCRIPTION
This PR fixes two issues: 

1) when refreshing the page on DABL, you used to get that 404 nginx error. Fixed by using HashRouter.
2) when refreshing the page (in general), you'd fall back to the login screen because credentials are not persisted. 

This also makes sure there's some type safety around the JSON-ified credentials that are read out of localStorage. 

In theory, once the token expires after 24h, then the app should redirect the user back to the login page as if it was never in the store at all, though this code path remains to be tested