### PR TITLE
Exberry pid contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,8 @@ publish: package
 # some_files = $(shell cd $(target_dir) && echo da-marketplace-*)
 # helloooo = $(filter-out da-marketplace-exberry%.gz, $(some_files))
 package: $(operator_bot) $(issuer_bot) $(custodian_bot) $(broker_bot) $(exchange_bot) $(exberry_adapter) $(matching_engine) $(dar) $(ui) $(dabl_meta) verify-artifacts
-	cd $(target_dir) && zip ${NAME}.dit $(filter-out da-marketplace-exberry%.tar.gz, $(shell cd $(target_dir) && echo da-marketplace-*)) dabl-meta.yaml
+	cd $(target_dir) && zip ${NAME}.dit $(shell cd $(target_dir) && echo da-marketplace-*) dabl-meta.yaml
+	# cd $(target_dir) && zip ${NAME}.dit $(filter-out da-marketplace-exberry%.tar.gz, $(shell cd $(target_dir) && echo da-marketplace-*)) dabl-meta.yaml
 
 $(dabl_meta): $(target_dir) dabl-meta.yaml
 	cp dabl-meta.yaml $@

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ $(ui):
 
 .PHONY: clean
 clean: clean-ui
-	rm -rf $(state_dir) $(exberry_adapter_dir) $(exberry_adapter) $(matching_engine_dir) $(matching_engine) $(operator_bot_dir) $(operator_bot) $(issuer_bot_dir) $(issuer_bot) $(custodian_bot_dir) $(custodian_bot) $(broker_bot_dir) $(broker_bot) $(exchange_bot) $(dar) $(ui) $(dabl_meta) $(target_dir)/${NAME}.dit
+	rm -rf $(state_dir) $(exberry_adapter_dir) $(exberry_adapter) $(matching_engine_dir) $(matching_engine) $(operator_bot_dir) $(operator_bot) $(issuer_bot_dir) $(issuer_bot) $(custodian_bot_dir) $(custodian_bot) $(broker_bot_dir) $(broker_bot) $(exchange_bot_dir) $(exchange_bot) $(dar) $(ui) $(dabl_meta) $(target_dir)/${NAME}.dit
 
 clean-ui:
 	rm -rf $(ui) daml.js ui/node_modules ui/build ui/yarn.lock

--- a/automation/broker/pyproject.toml
+++ b/automation/broker/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "The DA Marketplace Broker Bot"
 authors = ["Digital Asset"]
 

--- a/automation/custodian/pyproject.toml
+++ b/automation/custodian/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "The DA Marketplace Custodian Bot"
 authors = ["Digital Asset"]
 

--- a/automation/exchange/pyproject.toml
+++ b/automation/exchange/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "The DA Marketplace Exchange Bot"
 authors = ["Digital Asset"]
 

--- a/automation/issuer/pyproject.toml
+++ b/automation/issuer/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "The DA Marketplace Issuer Bot"
 authors = ["Digital Asset"]
 

--- a/automation/operator/pyproject.toml
+++ b/automation/operator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "The DA Marketplace Operator Bot"
 authors = ["Digital Asset"]
 

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -1,6 +1,6 @@
 catalog:
     name: da-marketplace
-    version: 0.0.2
+    version: 0.0.2.1
     short_description: DA Marketplace
     description: A marketplace for issuing and trading digital tokens.
     release_date: 2020-10-14

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -16,4 +16,5 @@ subdeployments:
     - da-marketplace-exchange-bot-0.0.2.tar.gz
     - da-marketplace-matching-engine-0.0.2.tar.gz
     - da-marketplace-operator-bot-0.0.2.tar.gz
+    - da-marketplace-exberry-adapter-0.0.2.1.tar.gz
     - da-marketplace-ui-0.0.2.zip

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -1,6 +1,6 @@
 catalog:
     name: da-marketplace
-    version: 0.0.2.1
+    version: 0.0.2
     short_description: DA Marketplace
     description: A marketplace for issuing and trading digital tokens.
     release_date: 2020-10-14
@@ -16,5 +16,5 @@ subdeployments:
     - da-marketplace-exchange-bot-0.0.2.tar.gz
     - da-marketplace-matching-engine-0.0.2.tar.gz
     - da-marketplace-operator-bot-0.0.2.tar.gz
-    - da-marketplace-exberry-adapter-0.0.2.1.tar.gz
+    - da-marketplace-exberry-adapter-0.0.2.tar.gz
     - da-marketplace-ui-0.0.2.zip

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -1,6 +1,6 @@
 catalog:
     name: da-marketplace
-    version: 0.0.2
+    version: 0.0.3
     short_description: DA Marketplace
     description: A marketplace for issuing and trading digital tokens.
     release_date: 2020-10-14
@@ -9,12 +9,12 @@ catalog:
     license: 0BSD
     tags: [ dabl-sample-app, application ]
 subdeployments:
-    - da-marketplace-model-0.0.2.dar
-    - da-marketplace-broker-bot-0.0.2.tar.gz
-    - da-marketplace-custodian-bot-0.0.2.tar.gz
-    - da-marketplace-issuer-bot-0.0.2.tar.gz
-    - da-marketplace-exchange-bot-0.0.2.tar.gz
-    - da-marketplace-matching-engine-0.0.2.tar.gz
-    - da-marketplace-operator-bot-0.0.2.tar.gz
-    - da-marketplace-exberry-adapter-0.0.2.tar.gz
-    - da-marketplace-ui-0.0.2.zip
+    - da-marketplace-model-0.0.3.dar
+    - da-marketplace-broker-bot-0.0.3.tar.gz
+    - da-marketplace-custodian-bot-0.0.3.tar.gz
+    - da-marketplace-issuer-bot-0.0.3.tar.gz
+    - da-marketplace-exchange-bot-0.0.3.tar.gz
+    - da-marketplace-matching-engine-0.0.3.tar.gz
+    - da-marketplace-operator-bot-0.0.3.tar.gz
+    - da-marketplace-exberry-adapter-0.0.3.tar.gz
+    - da-marketplace-ui-0.0.3.zip

--- a/daml.yaml
+++ b/daml.yaml
@@ -12,7 +12,7 @@ parties:
   - Public
   - Exchange
   - Broker
-version: 0.0.2
+version: 0.0.3
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/daml/Marketplace/Utils.daml
+++ b/daml/Marketplace/Utils.daml
@@ -21,6 +21,10 @@ template ExberrySID
   where
     signatory exchange
 
+    controller exchange can
+      ExberrySID_Ack : ()
+        do return ()
+
 
 getAccountId : Party -> Party -> [Party] -> Id
 getAccountId owner provider signatories = Id with

--- a/daml/Marketplace/Utils.daml
+++ b/daml/Marketplace/Utils.daml
@@ -14,6 +14,13 @@ data MarketRole = CustodianRole | IssuerRole | ExchangeRole | InvestorRole | Bro
     deriving (Show, Eq)
 
 
+template ExberrySID
+  with
+    exchange : Party
+    sid      : Int
+  where
+    signatory exchange
+
 getAccountId : Party -> Party -> [Party] -> Id
 getAccountId owner provider signatories = Id with
     signatories = fromList signatories

--- a/exberry_adapter/bot/exberry_adapter_bot.py
+++ b/exberry_adapter/bot/exberry_adapter_bot.py
@@ -7,7 +7,7 @@ from dazl import create, exercise, exercise_by_key
 
 dazl.setup_default_logger(logging.INFO)
 
-SID = 100  # TODO: pass this as a configuration
+SID = 1 # default SID, use ExberrySID contract to change while running
 def get_sid() -> int:
     global SID
     SID = SID + 1
@@ -54,9 +54,11 @@ def main():
         logging.info("DA Marketplace <> Exberry adapter is ready!")
 
     @client.ledger_created(MARKETPLACE.ExberrySID)
-    def handleExberrySID(event):
+    def handle_exberry_SID(event):
         global SID
         SID = event.cdata['sid']
+        logging.info(f'Changed current SID to {SID}')
+        return exercise(event.cid, 'ExberrySID_Ack', {})
 
     # Marketplace --> Exberry
     @client.ledger_created(MARKETPLACE.OrderRequest)

--- a/exberry_adapter/bot/exberry_adapter_bot.py
+++ b/exberry_adapter/bot/exberry_adapter_bot.py
@@ -33,6 +33,7 @@ class MARKETPLACE:
     OrderRequest = 'Marketplace.Trading:OrderRequest'
     OrderCancelRequest = 'Marketplace.Trading:OrderCancelRequest'
     Order = 'Marketplace.Trading:Order'
+    ExberrySID = 'Marketplace.Utils:ExberrySID'
 
 
 def main():
@@ -51,6 +52,11 @@ def main():
     @client.ledger_ready()
     def say_hello(event):
         logging.info("DA Marketplace <> Exberry adapter is ready!")
+
+    @client.ledger_created(MARKETPLACE.ExberrySID)
+    def handleExberrySID(event):
+        global SID
+        SID = event.cdata['sid']
 
     # Marketplace --> Exberry
     @client.ledger_created(MARKETPLACE.OrderRequest)

--- a/exberry_adapter/pyproject.toml
+++ b/exberry_adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2.1"
+version = "0.0.2"
 description = "The DA Marketplace <> Exberry Adapter Bot"
 authors = ["Digital Asset"]
 

--- a/exberry_adapter/pyproject.toml
+++ b/exberry_adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "The DA Marketplace <> Exberry Adapter Bot"
 authors = ["Digital Asset"]
 

--- a/exberry_adapter/pyproject.toml
+++ b/exberry_adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.2.1"
 description = "The DA Marketplace <> Exberry Adapter Bot"
 authors = ["Digital Asset"]
 

--- a/matching_engine/pyproject.toml
+++ b/matching_engine/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.0.2"
+version = "0.0.3"
 description = "DA Marketplace matching engine bot"
 authors = ["Digital Asset"]
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,9 +1,9 @@
 {
   "name": "da-marketplace",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "dependencies": {
-    "@daml.js/da-marketplace": "file:../daml.js/da-marketplace-0.0.2",
+    "@daml.js/da-marketplace": "file:../daml.js/da-marketplace-0.0.3",
     "@daml/dabl-react": "file:./dabl-react",
     "@daml/ledger": "1.6.0",
     "@daml/react": "1.6.0",


### PR DESCRIPTION
Add a contract called `ExberryPID` that can be created to tell the exberry adapter what PID to use for order IDs. Also includes the exberry adapter in the distributed dit file.