### PR TITLE
add marketplace.svg to make package dit zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ publish: package
 # some_files = $(shell cd $(target_dir) && echo da-marketplace-*)
 # helloooo = $(filter-out da-marketplace-exberry%.gz, $(some_files))
 package: $(operator_bot) $(issuer_bot) $(custodian_bot) $(broker_bot) $(exchange_bot) $(exberry_adapter) $(matching_engine) $(dar) $(ui) $(dabl_meta) verify-artifacts
-	cd $(target_dir) && zip ${NAME}.dit $(shell cd $(target_dir) && echo da-marketplace-*) dabl-meta.yaml
+	cd $(target_dir) && zip -j ${NAME}.dit $(shell cd $(target_dir) && echo da-marketplace-*) ../pkg/marketplace.svg dabl-meta.yaml
 
 $(dabl_meta): $(target_dir) dabl-meta.yaml
 	cp dabl-meta.yaml $@


### PR DESCRIPTION
`marketplace.svg` needs to be added to the `.dit` zip in the root, this adds it to the `zip` stage in the `Makefile`.