### PR TITLE
Investor deposit/withdraw and issuer observe

### DIFF
--- a/daml/Marketplace/Investor.daml
+++ b/daml/Marketplace/Investor.daml
@@ -3,6 +3,7 @@ module Marketplace.Investor where
 import Marketplace.Custodian
 import Marketplace.Registry
 import Marketplace.Transfer
+import Marketplace.Token
 import Marketplace.Utils
 
 import DA.Finance.Asset
@@ -57,6 +58,28 @@ template Investor
            deposit <- fetch depositCid
            assert $ deposit.account.owner == investor
            create DepositTransferRequest with sender = investor, senderAccountId = deposit.account.id, ..
+
+      nonconsuming Investor_RequestDeposit : ContractId DepositCreditRequest
+        with
+          tokenId : Id
+          depositQuantity : Decimal
+          custodian : Party
+        do
+          (tokenCid, token) <- fetchByKey @Token tokenId
+          let accountId = getAccountId investor custodian [custodian]
+              quantity = roundBankers token.quantityPrecision depositQuantity
+              account = Account with id = accountId, provider = custodian, owner = investor
+              asset = Asset with id = tokenId, ..
+
+          create DepositCreditRequest with owner = investor, ..
+
+      nonconsuming Investor_RequestWithdrawl : ContractId DepositDebitRequest
+        with
+          depositCid : ContractId AssetDeposit
+        do
+          deposit <- fetch depositCid
+          create DepositDebitRequest with
+              owner = investor, ownerAccount = deposit.account, ..
 
       nonconsuming Investor_AllocateToProvider : ContractId DepositTransferRequest
         with

--- a/daml/Marketplace/Investor.daml
+++ b/daml/Marketplace/Investor.daml
@@ -2,8 +2,8 @@ module Marketplace.Investor where
 
 import Marketplace.Custodian
 import Marketplace.Registry
-import Marketplace.Transfer
 import Marketplace.Token
+import Marketplace.Transfer
 import Marketplace.Utils
 
 import DA.Finance.Asset

--- a/daml/Marketplace/Trading.daml
+++ b/daml/Marketplace/Trading.daml
@@ -62,7 +62,11 @@ template Order
     status : Text
     orderId : Int
   where
+    let tokenObservers = if isBid
+                         then pair._2.signatories
+                         else pair._1.signatories
     signatory exchange, exchParticipant
+    observer tokenObservers
     ensure qty > 0.0
 
     key (exchange, orderId) : (Party, Int)

--- a/daml/Marketplace/Transfer.daml
+++ b/daml/Marketplace/Transfer.daml
@@ -97,10 +97,11 @@ template DepositCreditRequest
       DepositCreditRequest_Approve : ContractId AssetDeposit
         do
           let (owner, provider) = getAccountOwnerProvider account.id.label
+          let tokenSignatories = asset.id.signatories
 
           depositRuleCid <- create AssetSettlementRule
             with account = account
-                 observers = fromList [provider]
+                 observers = tokenSignatories <> fromList [provider]
                  ctrls = fromList [custodian]
 
           newDepositCid <- exercise depositRuleCid AssetSettlement_Credit with asset, ctrl = custodian

--- a/daml/Marketplace/Transfer.daml
+++ b/daml/Marketplace/Transfer.daml
@@ -6,7 +6,7 @@ import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 
-import DA.List
+import DA.List hiding (delete)
 import DA.Next.Set
 
 
@@ -26,6 +26,7 @@ template DepositTransferRequest
     controller custodian can
       DepositTransferRequest_Approve : ContractId AssetDeposit
         do
+          deposit <- fetch depositCid
           let (sender, senderProvider) = getAccountOwnerProvider senderAccountId.label
               (receiver, receiverProvider) = getAccountOwnerProvider receiverAccountId.label
 
@@ -33,6 +34,7 @@ template DepositTransferRequest
                 with id = senderAccountId, provider = senderProvider, owner = sender
               receiverAccount = Account
                 with id = receiverAccountId, provider = receiverProvider, owner = receiver
+              depositObservers = deposit.observers
 
           senderRuleCid <- create AssetSettlementRule
             with account = senderAccount,
@@ -46,10 +48,18 @@ template DepositTransferRequest
           newDepositCid <- exercise senderRuleCid AssetSettlement_Transfer
             with receiverAccountId = receiverAccountId, ..
 
+          newDeposit <- fetch newDepositCid
+          let newObservers = depositObservers <> newDeposit.observers
+              newObservers' = if sender /= newDeposit.account.owner
+                              then delete sender newObservers
+                              else newObservers
+          newDepositCid' <- create newDeposit with observers = newObservers'
+          archive newDepositCid
+
           archive senderRuleCid
           archive receiverRuleCid
 
-          return newDepositCid
+          return newDepositCid'
 
       DepositTransferRequest_Reject : ()
         do return ()


### PR DESCRIPTION
Adds a withdraw/deposit choice to the investor role contract. This uses `Transfer.DepositDebitRequest` and `Transfer.DepositCreditRequest` which are automatically resolved by the custodian trigger. If we want to change it so the custodian has to manually approve each request, we may have to create separate requests in the Custodian module, as the `Trading` requests are also used by the exchange (which will most likely need to remain auto-approved).

Also fixed a few places where the issuer was being removed from the observers on asset deposits in a few places.