### PR TITLE
Order amount splits

### DIFF
--- a/daml/Marketplace/ExchangeParticipant.daml
+++ b/daml/Marketplace/ExchangeParticipant.daml
@@ -80,31 +80,47 @@ template ExchangeParticipant
         with
           depositCid : ContractId AssetDeposit
           pair : IdPair
+          amount : Decimal
           price : Decimal
         do
           deposit <- fetch depositCid
           assertMsg ("deposit should be for " <> pair._2.label <> " but it is for " <> deposit.asset.id.label)
             $ pair._2 == deposit.asset.id
+          assertMsg ("amount should be less than or equal to deposit amount") $ amount <= deposit.asset.quantity
+
+          newDepositCid <- if amount < deposit.asset.quantity
+                  then head <$> exercise depositCid AssetDeposit_Split with quantities = [ amount ]
+                  else return depositCid
+
+          newDeposit <- fetch newDepositCid
 
           (_, baseToken) <- fetchByKey @Token pair._1
-          let qty = roundBankers baseToken.quantityPrecision $ deposit.asset.quantity / price
+          let qty = roundBankers baseToken.quantityPrecision $ newDeposit.asset.quantity / price
 
-          exercise self ExchangeParticipant_MakeOrder with depositCid, pair, price, qty, isBid = True
+          exercise self ExchangeParticipant_MakeOrder with depositCid = newDepositCid, pair, price, qty, isBid = True
 
       nonconsuming ExchangeParticipant_PlaceOffer : (ContractId OrderRequest, ContractId DepositDebitRequest)
         with
           depositCid : ContractId AssetDeposit
           pair : IdPair
+          amount : Decimal
           price : Decimal
         do
           deposit <- fetch depositCid
           assertMsg ("deposit should be for " <> pair._1.label <> " but it is for " <> deposit.asset.id.label)
             $ pair._1 == deposit.asset.id
+          assertMsg ("amount should be less than or equal to deposit amount") $ amount <= deposit.asset.quantity
+
+          newDepositCid <- if amount < deposit.asset.quantity
+                           then head <$> exercise depositCid AssetDeposit_Split with quantities = [ amount ]
+                           else return depositCid
+
+          newDeposit <- fetch newDepositCid
 
           (_, baseToken) <- fetchByKey @Token pair._1
-          let qty = roundBankers baseToken.quantityPrecision deposit.asset.quantity
+          let qty = roundBankers baseToken.quantityPrecision newDeposit.asset.quantity
 
-          exercise self ExchangeParticipant_MakeOrder with depositCid, pair, price, qty, isBid = False
+          exercise self ExchangeParticipant_MakeOrder with depositCid = newDepositCid, pair, price, qty, isBid = False
 
       nonconsuming ExchangeParticipant_MakeOrder : (ContractId OrderRequest, ContractId DepositDebitRequest)
         with

--- a/daml/Tests/ExchangeTrade.daml
+++ b/daml/Tests/ExchangeTrade.daml
@@ -53,7 +53,7 @@ doSetupTransfer lp@(LedgerParties operator public custodian exchange issuer _ al
 
   -- > alice places a bid for BTC
   (bidOrderRequestCid, debitRequestCid) <- alice `submit` exerciseByKeyCmd @ExchangeParticipant (exchange, operator, alice) ExchangeParticipant_PlaceBid
-      with depositCid = aliceUsdId, pair = (btcTokenId, usdTokenId), price = 10000.00
+      with depositCid = aliceUsdId, amount = 10000.0, pair = (btcTokenId, usdTokenId), price = 10000.00
   custodian `submit` exerciseCmd debitRequestCid DepositDebitRequest_Approve
 
   -- > exchange rejects bid
@@ -62,14 +62,14 @@ doSetupTransfer lp@(LedgerParties operator public custodian exchange issuer _ al
 
   -- > alice places a new bid for BTC
   (bidOrderRequestCid, debitRequestCid) <- alice `submit` exerciseByKeyCmd @ExchangeParticipant (exchange, operator, alice) ExchangeParticipant_PlaceBid
-      with depositCid = aliceUsdId, pair = (btcTokenId, usdTokenId), price = 10000.00
+      with depositCid = aliceUsdId, amount = 10000.0, pair = (btcTokenId, usdTokenId), price = 10000.00
   custodian `submit` exerciseCmd debitRequestCid DepositDebitRequest_Approve
   bidOrderCid <- exchange `submit` exerciseByKeyCmd @Exchange (operator, exchange) Exchange_ApproveOrderRequest
       with orderRequestCid = bidOrderRequestCid, orderId = 1
 
   -- > bob places a new offer for BTC
   (offerOrderRequestCid, debitRequestCid) <- bob `submit` exerciseByKeyCmd @ExchangeParticipant (exchange, operator, bob) ExchangeParticipant_PlaceOffer
-      with depositCid = bobBtcId, pair = (btcTokenId, usdTokenId), price = 10000.00
+      with depositCid = bobBtcId, amount = 10.0, pair = (btcTokenId, usdTokenId), price = 10000.00
   custodian `submit` exerciseCmd debitRequestCid DepositDebitRequest_Approve
   offerOrderCid <- exchange `submit` exerciseByKeyCmd @Exchange (operator, exchange) Exchange_ApproveOrderRequest
       with orderRequestCid = offerOrderRequestCid, orderId = 2

--- a/ui/src/components/Custodian/CreateDeposit.tsx
+++ b/ui/src/components/Custodian/CreateDeposit.tsx
@@ -8,10 +8,10 @@ import { RegisteredBroker, RegisteredInvestor } from '@daml.js/da-marketplace/li
 import { Token } from '@daml.js/da-marketplace/lib/Marketplace/Token'
 
 import { TokenInfo, wrapDamlTuple, damlTupleToString, makeContractInfo } from '../common/damlTypes'
+import { countDecimals, preciseInputSteps } from '../common/utils';
 import { useOperator } from '../common/common'
 import FormErrorHandled from '../common/FormErrorHandled'
 import ContractSelect from '../common/ContractSelect'
-import { countDecimals } from '../common/utils';
 
 import './CreateDeposit.css'
 
@@ -90,7 +90,7 @@ const CreateDeposit: React.FC = () => {
         const number = Number(result.value)
 
         if (number < 0) {
-            return setDepositQuantityError(`The quantity must a positive number.`)
+            return setDepositQuantityError(`The quantity must be a positive number.`)
         }
 
         if (countDecimals(number) > quantityPrecision) {
@@ -100,6 +100,8 @@ const CreateDeposit: React.FC = () => {
         setDepositQuantityError(undefined)
         setDepositQuantity(number.toString())
     }
+
+    const { step, placeholder } = preciseInputSteps(quantityPrecision);
 
     return (
         <FormErrorHandled onSubmit={handleCreateDeposit}>
@@ -124,8 +126,8 @@ const CreateDeposit: React.FC = () => {
                     className='create-deposit-quantity'
                     label='Quantity'
                     type='number'
-                    step={`0.${"0".repeat(quantityPrecision === 0? quantityPrecision : quantityPrecision-1)}1`}
-                    placeholder={`0.${"0".repeat(quantityPrecision)}`}
+                    step={step}
+                    placeholder={placeholder}
                     error={depositQuantityError}
                     disabled={!token}
                     onChange={validateTokenQuantity}/>

--- a/ui/src/components/Exchange/CreateMarket.tsx
+++ b/ui/src/components/Exchange/CreateMarket.tsx
@@ -12,7 +12,7 @@ import FormErrorHandled from '../common/FormErrorHandled'
 import PageSection from '../common/PageSection'
 import ContractSelect from '../common/ContractSelect'
 import Page from '../common/Page'
-import { countDecimals } from '../common/utils';
+import { countDecimals, preciseInputSteps } from '../common/utils';
 
 import "./CreateMarket.css"
 
@@ -93,6 +93,8 @@ const CreateMarket: React.FC<Props> = ({ sideNav, onLogout }) => {
         setMaxQuantity(newMaxQuantity.toString())
     }
 
+    const { step, placeholder } = preciseInputSteps(quantityPrecision);
+
     return (
         <Page
             sideNav={sideNav}
@@ -131,8 +133,8 @@ const CreateMarket: React.FC<Props> = ({ sideNav, onLogout }) => {
                             <Form.Input
                                 label='Minimum Quantity'
                                 type='number'
-                                step={`0.${"0".repeat(quantityPrecision === 0? quantityPrecision : quantityPrecision-1)}1`}
-                                placeholder={`0.${"0".repeat(quantityPrecision)}`}
+                                step={step}
+                                placeholder={placeholder}
                                 error={minQuantityError}
                                 disabled={!quoteToken || !baseToken}
                                 onChange={validateMinQuantity}/>
@@ -140,8 +142,8 @@ const CreateMarket: React.FC<Props> = ({ sideNav, onLogout }) => {
                             <Form.Input
                                 label='Maximum Quantity'
                                 type='number'
-                                step={`0.${"0".repeat(quantityPrecision === 0? quantityPrecision : quantityPrecision-1)}1`}
-                                placeholder={`0.${"0".repeat(quantityPrecision)}`}
+                                step={step}
+                                placeholder={placeholder}
                                 error={maxQuantityError}
                                 disabled={!quoteToken || !baseToken}
                                 onChange={validateMaxQuantity}/>

--- a/ui/src/components/Investor/OrderForm.css
+++ b/ui/src/components/Investor/OrderForm.css
@@ -4,7 +4,15 @@
 
 .order-form > .field {
     width: 450px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+}
+
+.order-form > .field > .asset-label {
+    position: relative;
+    right: 0px;
+    top: 5px;
+}
+
+.order-form > .field > input.uncontrolled:disabled {
+    opacity: 1.0;
+    color: grey;
 }

--- a/ui/src/components/common/FormErrorHandled.tsx
+++ b/ui/src/components/common/FormErrorHandled.tsx
@@ -46,6 +46,9 @@ const FormErrorHandled: (props: Props) => React.ReactElement = ({
         setLoading(false);
     }
 
+    const errorMsgList = error?.message instanceof Array ? error.message : undefined;
+    const errorMsgContent = error?.message instanceof Array ? undefined : error?.message;
+
     return (
         <Form
             className={className}
@@ -55,7 +58,7 @@ const FormErrorHandled: (props: Props) => React.ReactElement = ({
             onSubmit={() => loadAndCatch(onSubmit)}
         >
             { isCallable(children) ? children(callback => loadAndCatch(callback)) : children }
-            <Message error header={error?.header} content={error?.message}/>
+            <Message error header={error?.header} content={errorMsgContent} list={errorMsgList}/>
         </Form>
     )
 }

--- a/ui/src/components/common/Holdings.tsx
+++ b/ui/src/components/common/Holdings.tsx
@@ -11,7 +11,7 @@ import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 
 import { WalletIcon, IconClose } from '../../icons/Icons'
 import { DepositInfo, wrapDamlTuple, getAccountProvider } from './damlTypes'
-import { groupDeposits, countDecimals } from './utils'
+import { groupDeposits, countDecimals, preciseInputSteps } from './utils'
 import { useOperator } from './common'
 import FormErrorHandled from './FormErrorHandled'
 import PageSection from './PageSection'
@@ -314,6 +314,8 @@ const SplitForm: React.FC<SplitFormProps> = ({ deposit, onRequestClose }) => {
         setSplitAssetDecimal(number)
     }
 
+    const { step, placeholder } = preciseInputSteps(tokenQuantityPrecision);
+
     return (
         <>
             <div className='selected-form-heading'>
@@ -328,8 +330,8 @@ const SplitForm: React.FC<SplitFormProps> = ({ deposit, onRequestClose }) => {
                 <Form.Group className='inline-form-group'>
                     <Form.Input
                         type='number'
-                        step={`0.${"0".repeat(tokenQuantityPrecision === 0? tokenQuantityPrecision : tokenQuantityPrecision-1)}1`}
-                        placeholder={`0.${"0".repeat(tokenQuantityPrecision)}`}
+                        step={step}
+                        placeholder={placeholder}
                         error={splitNumberError}
                         onChange={validateSplitNumber}/>
                     <Button

--- a/ui/src/components/common/errorTypes.ts
+++ b/ui/src/components/common/errorTypes.ts
@@ -15,14 +15,29 @@ function isRuntimeError(err: any): err is RuntimeError {
     return err.stack !== undefined && err.message !== undefined;
 }
 
+export class AppError extends Error {
+    header: string;
+    messages: string | string[];
+
+    constructor(header: string, messages: string | string[]) {
+        super(header);
+        this.header = header;
+        this.messages = messages;
+    }
+}
+
 export type ErrorMessage = {
     header: string;
-    message: string;
+    message: string | string[];
 }
 
 export function parseError(err: any): ErrorMessage | undefined {
+    if (err instanceof AppError) {
+        return { ...err, message: err.messages };
+    }
+
     if (isDamlError(err)) {
-        return { header: "DAML API Error", message: err.errors.join('\n') };
+        return { header: "DAML API Error", message: err.errors };
     }
 
     if (isRuntimeError(err)) {

--- a/ui/src/components/common/utils.ts
+++ b/ui/src/components/common/utils.ts
@@ -53,3 +53,19 @@ export function countDecimals(value: number) {
     return 0;
 }
 
+type PreciseInputSteps = {
+    step: string;
+    placeholder: string;
+}
+
+export function preciseInputSteps(precision: number): PreciseInputSteps {
+    const step = precision > 0
+      ? `0.${"0".repeat(precision-1)}1`
+      : '1';
+
+    const placeholder = precision > 0
+      ? `0.${"0".repeat(precision)}`
+      : '0';
+
+    return { step, placeholder };
+}


### PR DESCRIPTION
This starts adding some improvements to the Order Form for investors. 

The main thing is instead of selecting a deposit from a dropdown, you are free to enter any amount you wish. The UI looks up available deposits and picks the first deposit CID that contains at least that amount, and exercises the same choice as it used to. 

The choice now performs the split automatically if the amount is less than the total amount of the deposit.

I also added a read-only text input that previews the total amount of asset you'll get if the order gets accepted and filled, and some nicer error handling if the amount is invalid for some reason.

![Screen Shot 2021-01-06 at 11 05 06 AM](https://user-images.githubusercontent.com/64022527/103790721-99343880-500f-11eb-8bee-8aee5d2f5eaa.png)
![Screen Shot 2021-01-06 at 11 06 05 AM](https://user-images.githubusercontent.com/64022527/103790725-99cccf00-500f-11eb-9c02-be730f341405.png)
