### PR TITLE
Factor out all fns dealing with claims into a module

### DIFF
--- a/daml/Marketplace/Claims.daml
+++ b/daml/Marketplace/Claims.daml
@@ -1,0 +1,48 @@
+module Marketplace.Claims (
+    assetDescVers
+  , binaryCallOption
+) where
+
+import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..), serialize, cond, one)
+import ContingentClaims.FinancialClaim (european)
+import ContingentClaims.Observable qualified as O
+import ContingentClaims.Observation (Observation)
+import ContingentClaims.Observation qualified as O
+import DA.Finance.Types (Id)
+import Marketplace.AssetDescription (AssetDescription(..))
+import Daml.Control.Recursion
+
+type C = Claim Observation Date Id
+type F = ClaimF Observation Date Id
+
+assetDescVers: Id 
+             -> Text  
+             -> Party 
+             -> Id 
+             -> C -> [Update (ContractId AssetDescription)]
+assetDescVers assetId description issuer safekeepingAccountId = 
+  ana write . ana zipWithIndex . (assetId.version + 1, ) . para depthFst --TODO: use ghylo
+    where
+      depthFst : F (C, [C]) -> [C] --only @And@ and @Or@ are included
+      depthFst ZeroF = []
+      depthFst (OneF _) = []
+      depthFst (ScaleF _ (_, cs)) = cs
+      depthFst (WhenF _ (_, cs)) = cs
+      depthFst (GiveF (_, cs)) = cs
+      depthFst (AndF (c, cs) (c', cs')) = c :: cs ++ c' :: cs'
+      depthFst (OrF (c, cs) (c', cs')) = c :: cs ++ c' :: cs'
+      depthFst (CondF _ (_, cs) (_, cs')) = cs ++ cs'
+      zipWithIndex (_, []) = Nil
+      zipWithIndex (i, x :: xs) = Cons (i, x) (succ i, xs)
+      write : [(Int, C)] -> ListF (Update (ContractId AssetDescription)) [(Int, C)]
+      write ((version', claims') :: vcs) =
+        let assetId' = assetId with version = version'
+            claims = serialize claims'
+        in Cons (create AssetDescription with assetId = assetId', ..) vcs
+      write [] = Nil
+
+binaryCallOption : Date -> Decimal -> Id -> Id -> C
+binaryCallOption expiry strike underlyingId currencyId =
+  european expiry (binary strike underlyingId.label currencyId)
+    where binary : Decimal -> Text -> Id -> Claim O.Observation Date Id
+          binary strike spot ccy = cond (O.pure strike O.<= O.observe spot) (one currencyId) Zero

--- a/daml/Marketplace/Custody.daml
+++ b/daml/Marketplace/Custody.daml
@@ -145,7 +145,7 @@ template Service
           fixings: Map Text (Map Date Decimal) --TODO these should be looked up from a contract on-ledger, not provided by the custodian!
         do
           exercise lifecycleRequestCid (Lifecycle' with investor = customer, ..)
-       
+
 
 -- TODO: remove when @fixings@ param above is removed; or replace with GenMap
 instance MapKey Date where
@@ -275,7 +275,7 @@ template LifecycleRequest
           investor: Party
           safekeepingDepositCid: ContractId AssetDeposit
           fixings: Map Text (Map Date Decimal) --TODO these should be looked up from a contract on-ledger, not provided by the custodian!
-      controller investor  
+      controller investor
         do
           t <- toDateUTC <$> getTime
           assetDeposit <- fetch assetDepositCid

--- a/daml/Marketplace/Issuance.daml
+++ b/daml/Marketplace/Issuance.daml
@@ -1,22 +1,14 @@
 module Marketplace.Issuance where
 
-import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..), deserialize, serialize, cond, one)
-import ContingentClaims.FinancialClaim (european)
-import ContingentClaims.Observable qualified as O
-import ContingentClaims.Observation (Observation)
-import ContingentClaims.Observation qualified as O
+import ContingentClaims.Claim (serialize, deserialize)
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
-import Daml.Control.Recursion
 import DA.Text (unwords)
 import Marketplace.AssetDescription (AssetDescription(..), Claims)
+import Marketplace.Claims (assetDescVers, binaryCallOption)
 
 type T = Issuance
-
--- TODO: don't export; used below in Origination
-type C = Claim Observation Date Id
-type F = ClaimF Observation Date Id
 
 template Issuance
   with
@@ -66,13 +58,11 @@ template Service
           currencyId: Id
         do
           -- TODO: refactor into a more composable form and add to contingent-claims lib
-          let binary : Decimal -> Text -> Id -> Claim O.Observation Date Id
-              binary strike spot ccy = cond (O.pure strike O.<= O.observe spot) (one currencyId) Zero
           create OriginationRequest with
-            claims = serialize $ european expiry (binary strike underlyingId.label currencyId)
+            claims = serialize $ binaryCallOption expiry strike underlyingId currencyId
             description = unwords [ underlyingId.label, show expiry, "Binary Call @", show strike ]
             ..
-          
+
       nonconsuming RequestCreateIssuance : ContractId CreateIssuanceRequest
         with
           issuanceId : Text
@@ -96,31 +86,11 @@ template Service
           createOriginationCid: ContractId OriginationRequest
         do
           OriginationRequest{..} <- fetch createOriginationCid
-          let assetDescVers: C -> [Update (ContractId AssetDescription)]
-              assetDescVers = ana write . ana zipWithIndex . (assetId.version + 1, ) . para depthFst --TODO: use ghylo
-                where
-                  depthFst : F (C, [C]) -> [C] --only @And@ and @Or@ are included
-                  depthFst ZeroF = []
-                  depthFst (OneF _) = []
-                  depthFst (ScaleF _ (_, cs)) = cs
-                  depthFst (WhenF _ (_, cs)) = cs
-                  depthFst (GiveF (_, cs)) = cs
-                  depthFst (AndF (c, cs) (c', cs')) = c :: cs ++ c' :: cs'
-                  depthFst (OrF (c, cs) (c', cs')) = c :: cs ++ c' :: cs'
-                  depthFst (CondF _ (_, cs) (_, cs')) = cs ++ cs'
-                  zipWithIndex (_, []) = Nil
-                  zipWithIndex (i, x :: xs) = Cons (i, x) (succ i, xs)
-                  write : [(Int, C)] -> ListF (Update (ContractId AssetDescription)) [(Int, C)]
-                  write ((version', claims') :: vcs) = 
-                    let assetId' = assetId with version = version'
-                        claims = serialize claims'
-                    in Cons (create AssetDescription with assetId = assetId', ..) vcs
-                  write [] = Nil
           -- assertMsg "issued must be 0" $ description.issued == 0.0
           -- assertMsg "authorized must be > 0" $ description.authorized > 0.0
           archive createOriginationCid
           create AssetDescription with ..
-          sequence $ assetDescVers $ deserialize claims
+          sequence $ assetDescVers assetId description issuer safekeepingAccountId $ deserialize claims
 
       nonconsuming CreateIssuance : (ContractId Issuance, ContractId AssetDeposit)
         with


### PR DESCRIPTION
Move out all the `Claim` related code into a separate module. This is mainly so as not to pollute the `Issuance`  imports.