### PR TITLE
Multiselect relationships + issuer nav

### DIFF
--- a/ui/src/components/Broker/Broker.tsx
+++ b/ui/src/components/Broker/Broker.tsx
@@ -5,7 +5,10 @@ import { useLedger, useParty } from '@daml/react'
 
 import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { RegisteredBroker } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-import { BrokerInvitation } from '@daml.js/da-marketplace/lib/Marketplace/Broker'
+import {
+    Broker as BrokerTemplate,
+    BrokerInvitation
+} from '@daml.js/da-marketplace/lib/Marketplace/Broker'
 import { CustodianRelationship } from '@daml.js/da-marketplace/lib/Marketplace/Custodian'
 import { MarketRole } from '@daml.js/da-marketplace/lib/Marketplace/Utils'
 
@@ -118,8 +121,9 @@ const Broker: React.FC<Props> = ({ onLogout }) => {
                             </FormErrorHandled>
                         }
                         marketRelationships={
-                            <MarketRelationships role={MarketRole.BrokerRole}
-                                                custodianRelationships={allCustodianRelationships}/>}
+                            <MarketRelationships
+                                relationshipRequestChoice={BrokerTemplate.Broker_RequestCustodianRelationship}
+                                custodianRelationships={allCustodianRelationships}/>}
                         sideNav={sideNav}
                         notifications={notifications}
                         onLogout={onLogout}/>

--- a/ui/src/components/CCP/ExchangeRelationships.tsx
+++ b/ui/src/components/CCP/ExchangeRelationships.tsx
@@ -34,12 +34,15 @@ const ExchangeRelationships: React.FC<Props> = ({ exchanges, sideNav, onLogout }
     const operator = useOperator();
     const [ showAddRelationshipModal, setShowAddRelationshipModal ] = useState(false);
 
-    const handleExchangeRelationshipRequest = async (party: string) => {
+    const handleExchangeRelationshipRequest = async (exchanges: string[]) => {
         const choice = CCP.CCP_RequestExchangeRelationship;
         const key = wrapDamlTuple([operator, ccp]);
-        const args = { exchange: party };
 
-        await ledger.exerciseByKey(choice, key, args);
+        await Promise.all(exchanges.map(exchange => {
+            return ledger.exerciseByKey(choice, key, {
+                exchange
+            })
+        }))
     }
 
     const registeredExchanges = useContractQuery(RegisteredExchange, AS_PUBLIC);
@@ -77,10 +80,10 @@ const ExchangeRelationships: React.FC<Props> = ({ exchanges, sideNav, onLogout }
                     <RequestFairValues exchanges={exchanges}/>
                     {showAddRelationshipModal &&
                         <AddRegisteredPartyModal
-                            title='Add Investor'
+                            multiple
+                            title='Add Exchange'
                             partyOptions={partyOptions}
                             onRequestClose={() => setShowAddRelationshipModal(false)}
-                            multiple={false}
                             emptyMessage='All registered investors have been added'
                             onSubmit={handleExchangeRelationshipRequest}/>
                     }

--- a/ui/src/components/CCP/Members.tsx
+++ b/ui/src/components/CCP/Members.tsx
@@ -40,12 +40,15 @@ const Members: React.FC<Props> = ({ members, sideNav, onLogout }) => {
 
     const notifications = useCCPCustomerNotifications();
 
-    const handleCCPCustomerInviteSubmit = async (party: string) => {
+    const handleCCPCustomerInviteSubmit = async (members: string[]) => {
         const choice = CCP.CCP_InviteCustomer;
         const key = wrapDamlTuple([operator, ccp]);
-        const args = { ccpCustomer: party };
 
-        await ledger.exerciseByKey(choice, key, args);
+        await Promise.all(members.map(ccpCustomer => {
+            return ledger.exerciseByKey(choice, key, {
+                ccpCustomer
+            })
+        }))
     }
 
     const registeredInvestors = useContractQuery(RegisteredInvestor, AS_PUBLIC);
@@ -98,10 +101,10 @@ const Members: React.FC<Props> = ({ members, sideNav, onLogout }) => {
                     <MarkToMarketCalc allCustomers={members}/>
                     {showAddRelationshipModal &&
                         <AddRegisteredPartyModal
+                            multiple
                             title='Add Member'
                             partyOptions={partyOptions}
                             onRequestClose={() => setShowAddRelationshipModal(false)}
-                            multiple={false}
                             emptyMessage='All registered investors have been added'
                             onSubmit={handleCCPCustomerInviteSubmit}/>
                     }

--- a/ui/src/components/Exchange/Exchange.tsx
+++ b/ui/src/components/Exchange/Exchange.tsx
@@ -7,7 +7,10 @@ import { useLedger, useParty } from '@daml/react'
 import { CustodianRelationship } from '@daml.js/da-marketplace/lib/Marketplace/Custodian'
 import { Derivative } from '@daml.js/da-marketplace/lib/Marketplace/Derivative'
 import { RegisteredExchange, RegisteredInvestor } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-import { ExchangeInvitation } from '@daml.js/da-marketplace/lib/Marketplace/Exchange'
+import {
+    Exchange as ExchangeTemplate,
+    ExchangeInvitation
+} from '@daml.js/da-marketplace/lib/Marketplace/Exchange'
 import { MarketRole } from '@daml.js/da-marketplace/lib/Marketplace/Utils'
 import { ExchangeParticipant, ExchangeParticipantInvitation } from '@daml.js/da-marketplace/lib/Marketplace/ExchangeParticipant'
 
@@ -152,7 +155,8 @@ const Exchange: React.FC<Props> = ({ onLogout }) => {
                             </FormErrorHandled>
                         }
                         marketRelationships={
-                            <MarketRelationships role={MarketRole.ExchangeRole}
+                            <MarketRelationships
+                                relationshipRequestChoice={ExchangeTemplate.Exchange_RequestCustodianRelationship}
                                 custodianRelationships={allCustodianRelationships}/>
                         }
                         sideNav={sideNav}

--- a/ui/src/components/Exchange/ExchangeParticipants.tsx
+++ b/ui/src/components/Exchange/ExchangeParticipants.tsx
@@ -39,12 +39,12 @@ const ExchangeParticipants: React.FC<Props> = ({ sideNav, onLogout, registeredIn
     const exchange = useParty();
     const operator = useOperator();
 
-    const handleExchParticipantInviteSubmit = async (party: string) => {
+    const handleExchParticipantInviteSubmit = async (investors: string[]) => {
         const choice = Exchange.Exchange_InviteParticipant;
         const key = wrapDamlTuple([operator, exchange]);
-        const args = { exchParticipant: party };
 
-        await ledger.exerciseByKey(choice, key, args);
+        // TO-DO: Modify choice to take in a list of parties directly. Got tricky with return types.
+        await ledger.exerciseByKey(choice, key, { exchParticipant: investors[0] });
     }
 
     const partyOptions = registeredInvestors.map(d => {
@@ -84,9 +84,9 @@ const ExchangeParticipants: React.FC<Props> = ({ sideNav, onLogout, registeredIn
                     {showAddRelationshipModal &&
                         <AddRegisteredPartyModal
                             title='Add Investor'
+                            multiple={false} // Keep single select for now
                             partyOptions={partyOptions}
                             onRequestClose={() => setShowAddRelationshipModal(false)}
-                            multiple={false}
                             emptyMessage='All registered investors have been added'
                             onSubmit={handleExchParticipantInviteSubmit}/>
                     }

--- a/ui/src/components/Investor/Investor.tsx
+++ b/ui/src/components/Investor/Investor.tsx
@@ -6,7 +6,10 @@ import { useLedger, useParty } from '@daml/react'
 
 import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { CustodianRelationship } from '@daml.js/da-marketplace/lib/Marketplace/Custodian'
-import { InvestorInvitation } from '@daml.js/da-marketplace/lib/Marketplace/Investor'
+import {
+    Investor as InvestorTemplate,
+    InvestorInvitation
+} from '@daml.js/da-marketplace/lib/Marketplace/Investor'
 import { RegisteredInvestor } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
 import { Exchange } from '@daml.js/da-marketplace/lib/Marketplace/Exchange'
 import { MarketRole } from '@daml.js/da-marketplace/lib/Marketplace/Utils'
@@ -204,8 +207,9 @@ const Investor: React.FC<Props> = ({ onLogout }) => {
                 }
                 sideNav={sideNav}
                 marketRelationships={
-                    <MarketRelationships role={MarketRole.InvestorRole}
-                                         custodianRelationships={allCustodianRelationships}/>}
+                    <MarketRelationships
+                        relationshipRequestChoice={InvestorTemplate.Investor_RequestCustodianRelationship}
+                        custodianRelationships={allCustodianRelationships}/>}
                 onLogout={onLogout}/>
         </Route>
 

--- a/ui/src/components/Issuer/Issuer.tsx
+++ b/ui/src/components/Issuer/Issuer.tsx
@@ -7,7 +7,10 @@ import { useLedger, useParty } from '@daml/react'
 import { CustodianRelationship } from '@daml.js/da-marketplace/lib/Marketplace/Custodian'
 import { Derivative } from '@daml.js/da-marketplace/lib/Marketplace/Derivative'
 import { RegisteredIssuer, RegisteredInvestor } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-import { IssuerInvitation } from '@daml.js/da-marketplace/lib/Marketplace/Issuer'
+import {
+    Issuer as IssuerTemplate,
+    IssuerInvitation
+} from '@daml.js/da-marketplace/lib/Marketplace/Issuer'
 import { MarketRole } from '@daml.js/da-marketplace/lib/Marketplace/Utils'
 import { Token } from '@daml.js/da-marketplace/lib/Marketplace/Token'
 import { ExchangeParticipant } from '@daml.js/da-marketplace/lib/Marketplace/ExchangeParticipant'
@@ -214,8 +217,9 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
                             </FormErrorHandled>
                         }
                         marketRelationships={
-                            <MarketRelationships role={MarketRole.IssuerRole}
-                                                custodianRelationships={allCustodianRelationships}/>}
+                            <MarketRelationships
+                                relationshipRequestChoice={IssuerTemplate.Issuer_RequestCustodianRelationship}
+                                custodianRelationships={allCustodianRelationships}/>}
                         sideNav={sideNav}
                         notifications={notifications}
                         onLogout={onLogout}/>

--- a/ui/src/components/Issuer/Issuer.tsx
+++ b/ui/src/components/Issuer/Issuer.tsx
@@ -51,7 +51,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
     const registeredIssuer = useContractQuery(RegisteredIssuer);
     const invitation = useContractQuery(IssuerInvitation);
     const allCustodianRelationships = useContractQuery(CustodianRelationship);
-    const allTokens = useContractQuery(Token);
+    const allTokens = useContractQuery(Token).filter(t => t.signatories.includes(issuer));
     const allDerivatives = useContractQuery(Derivative);
 
     const allRegisteredInvestors = useContractQuery(RegisteredInvestor, AS_PUBLIC)
@@ -176,7 +176,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
                                 </Menu.Item>
                             ))}
                             <Menu.Item>
-                                <p className='p2'>Issued Derivaties:</p>
+                                <p className='p2'>Issued Derivatives:</p>
                             </Menu.Item>
                             {allDerivatives.map(derivative => (
                                 <Menu.Item

--- a/ui/src/components/common/AddRegisteredPartyModal.tsx
+++ b/ui/src/components/common/AddRegisteredPartyModal.tsx
@@ -1,21 +1,29 @@
-import React, { useState } from 'react';
+import React, { useState } from 'react'
 
-import { Button, Modal, Form } from 'semantic-ui-react'
-
-import { IconClose } from '../../icons/Icons';
+import { Button, Modal, Form, DropdownProps } from 'semantic-ui-react'
 
 import FormErrorHandled from './FormErrorHandled'
 
 interface IProps {
+    onSubmit: (selectedParties: string[]) => void;
     onRequestClose: () => void;
     title: string;
     multiple?: boolean;
     emptyMessage?: string;
-    onSubmit: (selectedParties: any) => void;
     partyOptions: {
         text: string;
         value: string;
     }[]
+}
+
+function isStringArray(strArr: any): strArr is string[] {
+    if (Array.isArray(strArr)) {
+        return strArr.reduce((acc, elem) => {
+            return acc && typeof elem === 'string'
+        }, true);
+    } else {
+        return false
+    }
 }
 
 const AddRegisteredPartyModal = (props: IProps) => {
@@ -23,8 +31,12 @@ const AddRegisteredPartyModal = (props: IProps) => {
 
     const [ selectedParties, setSelectedParties ] = useState<string[]>([]);
 
-    const handleSelectNewParticipants = (event: React.SyntheticEvent, result: any) => {
-        setSelectedParties(result.value)
+    const handleSelectNewParticipants = (event: React.SyntheticEvent, result: DropdownProps) => {
+        if (typeof result.value === 'string') {
+            setSelectedParties([...selectedParties, result.value])
+        } else if (isStringArray(result.value)) {
+            setSelectedParties(result.value);
+        }
     }
 
     const handleSubmit = async () => {
@@ -45,10 +57,10 @@ const AddRegisteredPartyModal = (props: IProps) => {
                     :
                     <FormErrorHandled onSubmit={handleSubmit}>
                         <Form.Select
-                            multiple={multiple}
                             className='issue-asset-form-field select-observer'
-                            disabled={partyOptions.length === 0}
                             placeholder='Select...'
+                            multiple={multiple}
+                            disabled={partyOptions.length === 0}
                             options={partyOptions}
                             onChange={handleSelectNewParticipants}/>
                         <Button

--- a/ui/src/components/common/MarketRelationships.tsx
+++ b/ui/src/components/common/MarketRelationships.tsx
@@ -2,21 +2,19 @@ import React from 'react'
 
 import { Header } from 'semantic-ui-react'
 
-import { MarketRole } from '@daml.js/da-marketplace/lib/Marketplace/Utils'
-
 import { getAbbreviation } from '../common/utils';
 
-import { CustodianRelationshipInfo } from './damlTypes'
+import { CustodianRelationshipInfo, RelationshipRequestChoice } from './damlTypes'
 
 import { useRegistryLookup } from './RegistryLookup'
 import RequestCustodianRelationship from './RequestCustodianRelationship'
 
 type Props = {
-    role: MarketRole;
+    relationshipRequestChoice: RelationshipRequestChoice;
     custodianRelationships: CustodianRelationshipInfo[];
 }
 
-const MarketRelationships: React.FC<Props> = ({ role, custodianRelationships }) => {
+const MarketRelationships: React.FC<Props> = ({ relationshipRequestChoice, custodianRelationships }) => {
     const custodianMap = useRegistryLookup().custodianMap;
 
     const rows = custodianRelationships.map(relationship => {
@@ -42,7 +40,9 @@ const MarketRelationships: React.FC<Props> = ({ role, custodianRelationships }) 
     return (
         <div className='market-relationships'>
             <Header className='bold' as='h2'>Market Relationships</Header>
-            <RequestCustodianRelationship role={role} custodianRelationships={custodianRelationships}/>
+            <RequestCustodianRelationship
+                relationshipRequestChoice={relationshipRequestChoice}
+                custodianRelationships={custodianRelationships}/>
             {rows}
         </div>
     )

--- a/ui/src/components/common/damlTypes.ts
+++ b/ui/src/components/common/damlTypes.ts
@@ -13,7 +13,7 @@ import {
     Token,
     Derivative
 } from '@daml.js/da-marketplace/lib/Marketplace'
-import { ContractId } from '@daml/types';
+import { ContractId, List } from '@daml/types';
 
 type DamlTuple<T> = {
     [key: string]: T;
@@ -59,6 +59,7 @@ export function makeContractInfo<T extends object, K = unknown, I extends string
         key: event.key,
         templateId: event.templateId,
         contractId: event.contractId,
+        signatories: event.signatories,
         contractData: event.payload
     });
 }
@@ -77,6 +78,7 @@ export type ContractInfo<T, K = unknown> = {
     templateId: string;
     key: K;
     contractId: ContractId<T>;
+    signatories: List<string>;
     contractData: T;
 }
 

--- a/ui/src/components/common/damlTypes.ts
+++ b/ui/src/components/common/damlTypes.ts
@@ -3,12 +3,15 @@ import { CreateEvent } from '@daml/ledger'
 import { Asset } from '@daml.js/da-marketplace/lib/DA/Finance'
 import {
     CentralCounterpartyCustomer,
+    Broker,
     BrokerCustomer,
     ExchangeParticipant,
     Exchange,
     Registry,
     Custodian,
     Clearing,
+    Investor,
+    Issuer,
     Notification,
     Token,
     Derivative
@@ -73,6 +76,12 @@ export function wrapTextMap(items: string[]) {
 
     return { textMap: textMapValue }
 }
+
+export type RelationshipRequestChoice =
+    typeof Investor.Investor.Investor_RequestCustodianRelationship |
+    typeof Issuer.Issuer.Issuer_RequestCustodianRelationship |
+    typeof Broker.Broker.Broker_RequestCustodianRelationship |
+    typeof Exchange.Exchange.Exchange_RequestCustodianRelationship;
 
 export type ContractInfo<T, K = unknown> = {
     templateId: string;


### PR DESCRIPTION
This makes relationship dropdowns multi-selectable (except for the Exchange's investor invite, that will need some Daml treatment) 

Also fixes the Issuer nav to display only their own issued tokens

