### PR TITLE
Sdk 1.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ $(ui):
 
 .PHONY: clean
 clean: clean-ui
-	rm -rf $(state_dir) $(trigger) $(trigger_build) $(exberry_adapter_dir) $(dar) $(ui) $(dabl_meta) $(target_dir)/${NAME}.dit
+	rm -rf .daml triggers/.daml $(state_dir) $(trigger) $(trigger_build) $(exberry_adapter_dir) $(dar) $(ui) $(dabl_meta) $(target_dir)/${NAME}.dit
 
 clean-ui:
 	rm -rf $(ui) daml.js ui/node_modules ui/build ui/yarn.lock

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This can be done by rebuilding the project using `make clean && make package`.
 Alternatively, to only build the DAR file and regenerate the TypeScript bindings:
 ```
 daml build
-daml codegen js .daml/dist/da-marketplace-0.1.15.dar -o daml.js
+daml codegen js .daml/dist/da-marketplace-0.1.16.dar -o daml.js
 cd ui
 yarn install --force --frozen-lockfile
 ```

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -1,6 +1,6 @@
 catalog:
     name: da-marketplace
-    version: 0.1.15
+    version: 0.1.16
     short_description: DA Marketplace
     description: A marketplace for issuing and trading digital tokens.
     release_date: 2020-10-14
@@ -10,7 +10,7 @@ catalog:
     tags: [ dabl-sample-app, application ]
     icon_file: marketplace.svg
 subdeployments:
-    - da-marketplace-model-0.1.15.dar
-    - da-marketplace-triggers-0.1.15.dar
-    - da-marketplace-exberry-adapter-0.1.15.tar.gz
-    - da-marketplace-ui-0.1.15.zip
+    - da-marketplace-model-0.1.16.dar
+    - da-marketplace-triggers-0.1.16.dar
+    - da-marketplace-exberry-adapter-0.1.16.tar.gz
+    - da-marketplace-ui-0.1.16.zip

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 1.7.0
+sdk-version: 1.10.0
 name: da-marketplace
 source: daml
 init-script: Setup:setup
@@ -14,7 +14,7 @@ parties:
   - Exchange
   - Broker
   - Ccp
-version: 0.1.15
+version: 0.1.16
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/exberry_adapter/pyproject.toml
+++ b/exberry_adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot"
-version = "0.1.15"
+version = "0.1.16"
 description = "The DA Marketplace <> Exberry Adapter Bot"
 authors = ["Digital Asset"]
 

--- a/triggers/daml.yaml
+++ b/triggers/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 1.7.0
+sdk-version: 1.10.0
 name: da-marketplace-triggers
 source: daml
 parties:
@@ -11,13 +11,13 @@ parties:
   - Public
   - Exchange
   - Broker
-version: 0.1.15
+version: 0.1.16
 # trigger-dependencies-begin
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-trigger
 data-dependencies:
-  - ../.daml/dist/da-marketplace-0.1.15.dar
+  - ../.daml/dist/da-marketplace-0.1.16.dar
 sandbox-options:
   - --wall-clock-time

--- a/triggers/daml/OperatorTrigger.daml
+++ b/triggers/daml/OperatorTrigger.daml
@@ -46,7 +46,9 @@ handleOperatorRule party = do
   unless (null operators) $ do
     let public = (snd . head $ operators).public
     appInfos <- query @PublicAppInfo
-    when (null appInfos) $ dedupCreate PublicAppInfo with operator = party, ..
+    when (null appInfos)
+      $ dedupCreate PublicAppInfo with operator = party, ..
+      >> debug "Setting up PublicAppInfo..."
 
     -- Acknowledge all active 'UserSession's
     userSessions <- query @UserSession

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "da-marketplace",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "dependencies": {
-    "@daml.js/da-marketplace": "file:../daml.js/da-marketplace-0.1.15",
+    "@daml.js/da-marketplace": "file:../daml.js/da-marketplace-0.1.16",
     "@daml/hub-react": "0.1.0",
-    "@daml/ledger": "1.7.0",
-    "@daml/react": "1.7.0",
-    "@daml/types": "1.7.0",
+    "@daml/ledger": "1.10.0",
+    "@daml/react": "1.10.0",
+    "@daml/types": "1.10.0",
     "classnames": "^2.2.6",
     "dotenv": "^8.2.0",
     "jsonwebtoken": "^8.5.1",

--- a/ui/src/components/Broker/BrokerOrders.tsx
+++ b/ui/src/components/Broker/BrokerOrders.tsx
@@ -3,10 +3,11 @@ import { Button, Card, Form, Header } from 'semantic-ui-react'
 
 import { useParty, useLedger } from '@daml/react'
 
+import { ContractId } from '@daml/types'
+import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { Order, BrokerOrderRequest, BrokerOrder } from '@daml.js/da-marketplace/lib/Marketplace/Trading'
 import { BrokerCustomer } from '@daml.js/da-marketplace/lib/Marketplace/BrokerCustomer'
 import { RegisteredInvestor } from '@daml.js/da-marketplace/lib/Marketplace/Registry'
-import { ContractId } from '@daml/types'
 
 import { ExchangeIcon, OrdersIcon } from '../../icons/Icons'
 import { useContractQuery, AS_PUBLIC } from '../../websocket/queryStream'
@@ -139,7 +140,7 @@ type BrokerOrderCardProps = {
 };
 
 const BrokerOrderCard: React.FC<BrokerOrderCardProps> = (props) => {
-    const [ depositCid, setDepositCid ] = useState<string>('');
+    const [ depositCid, setDepositCid ] = useState<ContractId<AssetDeposit> | undefined>(undefined);
     const broker = useParty();
     const ledger = useLedger();
 
@@ -160,9 +161,11 @@ const BrokerOrderCard: React.FC<BrokerOrderCardProps> = (props) => {
 
     const handleAcceptBrokerOrderFill = async () => {
         const key = wrapDamlTuple([props.cdata.broker, props.cdata.brokerOrderId])
+        if (!depositCid) { return; }
+
         const args = { depositCid }
         await ledger.exerciseByKey(BrokerOrder.BrokerOrder_Fill, key, args);
-        setDepositCid('');
+        setDepositCid(undefined);
     }
 
     const handleDepositChange = (event: React.SyntheticEvent, result: any) => {
@@ -184,7 +187,7 @@ const BrokerOrderCard: React.FC<BrokerOrderCardProps> = (props) => {
                         <div>{`@ ${price}`}</div>
                         <div>{`customer: ${customer}`}</div>
                         <div>{`id: ${props.cdata.brokerOrderId}`}</div>
-                        <div>{`deposit: ${depositCid.substr(depositCid.length - 8) || ''}`}</div>
+                        <div>{`deposit: ${depositCid?.substr(depositCid.length - 8) || ''}`}</div>
                     </div>
                     <div className='actions'>
                         <Form.Group>

--- a/ui/src/components/Exchange/Exchange.tsx
+++ b/ui/src/components/Exchange/Exchange.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Switch, Route, useRouteMatch } from 'react-router-dom'
-import { Header } from 'semantic-ui-react'
+import { Header, Form } from 'semantic-ui-react'
 
 import { useLedger, useParty } from '@daml/react'
 
@@ -51,6 +51,7 @@ const Exchange: React.FC<Props> = ({ onLogout }) => {
     const loading = usePartyLoading();
     const investorMap = useRegistryLookup().investorMap;
 
+    const [ deployMatchingEngine, setDeployMatchingEngine ] = useState<boolean>(true);
     const registeredExchange = useContractQuery(RegisteredExchange);
     const invitation = useContractQuery(ExchangeInvitation);
     const allCustodianRelationships = useContractQuery(CustodianRelationship);
@@ -98,6 +99,9 @@ const Exchange: React.FC<Props> = ({ onLogout }) => {
     const acceptInvite = async () => {
         if (deploymentMode == DeploymentMode.PROD_DABL && TRIGGER_HASH && token) {
             deployTrigger(TRIGGER_HASH, MarketplaceTrigger.ExchangeTrigger, token, publicParty);
+            if (deployMatchingEngine) {
+                deployTrigger(TRIGGER_HASH, MarketplaceTrigger.MatchingEngine, token, publicParty);
+            }
         }
         const key = wrapDamlTuple([operator, exchange]);
         const args = {
@@ -114,6 +118,7 @@ const Exchange: React.FC<Props> = ({ onLogout }) => {
                                     {to: `${url}/market-pairs`, label: 'Market Pairs', icon: <PublicIcon/>},
                                     {to: `${url}/participants`, label: 'Investors', icon: <UserIcon/>}
                                  ]}/>
+
     const inviteScreen = (
         <InviteAcceptTile role={MarketRole.ExchangeRole} onSubmit={acceptInvite} onLogout={onLogout}>
             <ExchangeProfile
@@ -122,7 +127,15 @@ const Exchange: React.FC<Props> = ({ onLogout }) => {
                 role={MarketRole.ExchangeRole}
                 inviteAcceptTile
                 defaultProfile={profile}
-                submitProfile={profile => setProfile(profile)}/>
+                submitProfile={profile => setProfile(profile)}>
+                { deploymentMode === DeploymentMode.PROD_DABL &&
+                    <Form.Checkbox
+                        defaultChecked
+                        label='Deploy matching engine (uncheck if you plan to use the Exberry Integration)'
+                        onChange={event => setDeployMatchingEngine(!deployMatchingEngine)}
+                    />
+                }
+                </ExchangeProfile>
         </InviteAcceptTile>
     );
 

--- a/ui/src/components/SetupRequired.tsx
+++ b/ui/src/components/SetupRequired.tsx
@@ -97,8 +97,9 @@ const SetupRequired  = () => {
       { automations?.length === 0 || !automations ? (
         <div>
           <p>
-            Please make the "da-marketplace-triggers" artifact deployable to continue and to perform automatic setup.
-            You can find this option by clicking on the trigger in the "Deployments" tab in the console, then clicking on "Settings."
+            Please create a "UserAdmin" party and make the "da-marketplace-triggers" artifact deployable to continue and to perform automatic setup.<br/><br/>
+            You can create the party on the "Users" tab and find the deployable option by clicking on the trigger in the "Deployments"
+            tab in the console, then clicking on "Settings".
            </p>
         </div>
       ) : setupForm }

--- a/ui/src/components/SetupRequired.tsx
+++ b/ui/src/components/SetupRequired.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import Ledger from '@daml/ledger';
 import { Form, Button, Loader } from 'semantic-ui-react';
 
+import { useWellKnownParties } from '@daml/hub-react/lib';
 import { Operator } from '@daml.js/da-marketplace/lib/Marketplace/Operator';
 import { httpBaseUrl, deploymentMode, DeploymentMode } from "../config";
 import deployTrigger, { TRIGGER_HASH, MarketplaceTrigger, PublicAutomation, getPublicAutomation } from '../automation';
@@ -13,7 +14,7 @@ const SetupRequired  = () => {
   const [ deploying, setDeploying ] = useState(false);
   const [ setupError, setSetupError ] = useState<string | undefined>(undefined);
   const [ adminJwt, setAdminJwt ] = useState('');
-  const { parties } = useDablParties();
+  const { parties } = useWellKnownParties();
   const [ automations, setAutomations ] = useState<PublicAutomation[] | undefined>([]);
   const publicParty = useDablParties().parties.publicParty;
 
@@ -32,6 +33,7 @@ const SetupRequired  = () => {
 
   const handleSetup = async (event: React.FormEvent) => {
     setDeploying(true);
+    if (!parties) { return }
     try {
       const ledger = new Ledger({token: adminJwt, httpBaseUrl})
       if (deploymentMode == DeploymentMode.PROD_DABL && TRIGGER_HASH) {
@@ -64,6 +66,11 @@ const SetupRequired  = () => {
       <p>{setupError}</p>
     </div>
   )
+
+  const userAdminRequired = (
+      <p className='login-details dark'>Please create the 'UserAdmin' party and refresh this page. You can create the party
+                                        on the "Users" tab of the console.</p>
+  );
 
   const setupForm = (
     <>
@@ -102,7 +109,7 @@ const SetupRequired  = () => {
             tab in the console, then clicking on "Settings".
            </p>
         </div>
-      ) : setupForm }
+      ) : !!parties ? setupForm : userAdminRequired }
       <h4>See <a className='dark' href='https://github.com/digital-asset/da-marketplace#add-the-operator-role-contract'>here</a> for more information.</h4>
     </>
   );

--- a/ui/src/components/common/FormToggle.tsx
+++ b/ui/src/components/common/FormToggle.tsx
@@ -31,7 +31,7 @@ const FormToggle: React.FC<Props> = ({
         <div className={className}>
             {enabled?
                 <>
-                    <p>{onLabel} </p>
+                    <p>{onLabel}</p>
                     <p><i>{onInfo}</i></p>
                 </>
             :

--- a/ui/src/components/common/Holdings.tsx
+++ b/ui/src/components/common/Holdings.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import { Button, Header, Form } from 'semantic-ui-react'
 
 import { useParty, useLedger } from '@daml/react'
+import { ContractId } from '@daml/types'
+import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset'
 import { CCPCustomer } from '@daml.js/da-marketplace/lib/Marketplace/CentralCounterpartyCustomer'
 import { Broker } from '@daml.js/da-marketplace/lib/Marketplace/Broker'
 import { Investor } from '@daml.js/da-marketplace/lib/Marketplace/Investor'
@@ -192,7 +194,7 @@ const DepositRow: React.FC<DepositRowProps> = ({
 }
 
 type ProviderFormProps = {
-    depositCids: string[];
+    depositCids: ContractId<AssetDeposit>[];
     providers: IPartyInfo[];
     providerLabel?: string;
     totalQty: number;

--- a/ui/src/components/common/Profile.scss
+++ b/ui/src/components/common/Profile.scss
@@ -35,6 +35,10 @@
                 }
             }
 
+            .ui .checkbox label {
+                color: var(--white);
+            }
+
             .button-row {
                 display: flex;
 

--- a/ui/src/components/common/WalletTransaction.tsx
+++ b/ui/src/components/common/WalletTransaction.tsx
@@ -126,21 +126,19 @@ const WalletTransaction = (props: {
     )
 
     async function onSubmit() {
+        if (!token || !custodianId) { return; }
         const key = wrapDamlTuple([operator, party]);
-
         setShowSuccessMessage(false)
-
-        let args = {}
 
         switch(transactionType) {
             case 'Deposit':
-                args = {
-                    tokenId: token?.contractData.id,
+                const depositArgs = {
+                    tokenId: token.contractData.id,
                     depositQuantity: quantity,
                     custodian: custodianId
                 };
 
-                return await ledger.exerciseByKey(Investor.Investor_RequestDeposit, key, args)
+                return await ledger.exerciseByKey(Investor.Investor_RequestDeposit, key, depositArgs)
                     .then(_ => history.goBack())
 
             case 'Withdraw':
@@ -151,12 +149,12 @@ const WalletTransaction = (props: {
                     throw new AppError("Invalid withdrawal amount", "Withdraw amount exceeds asset total");
                 }
 
-                args = {
+                const withdrawlArgs = {
                     depositCids: selectedAssetDeposits?.map(d => d.contractId),
                     withdrawalQuantity: quantity,
                 };
 
-                return await ledger.exerciseByKey(Investor.Investor_RequestWithdrawl, key, args)
+                return await ledger.exerciseByKey(Investor.Investor_RequestWithdrawl, key, withdrawlArgs)
                     .then(_ => history.goBack())
         }
     }


### PR DESCRIPTION
Updated to SDK 1.10, added another failsafe step on the `SetupRequired` page, and allowed the exchange to deploy the matching engine trigger during onboarding