### PR TITLE
Reusable tables & Issuance

### DIFF
--- a/ui2/src/App.tsx
+++ b/ui2/src/App.tsx
@@ -19,6 +19,9 @@ import { Requests as AuctionRequests } from "./pages/distribution/auction/Reques
 import { Assets } from "./pages/distribution/Assets";
 import { New as DistributionNew } from "./pages/distribution/auction/New";
 import { BiddingAuction } from "./pages/distribution/bidding/Auction";
+import { Instruments } from "./pages/origination/Instruments";
+import { New as InstrumentsNew } from "./pages/origination/New";
+import { Requests as InstrumentsRequests } from "./pages/origination/Requests";
 import { Issuances } from "./pages/issuance/Issuances";
 import { New as IssuanceNew } from "./pages/issuance/New";
 import { Requests as IssuanceRequests } from "./pages/issuance/Requests";
@@ -33,6 +36,8 @@ import { Custody as CustodyNetwork } from "./pages/network/Custody";
 import { Trading as TradingNetwork } from "./pages/network/Trading";
 import { BiddingAuctions } from "./pages/distribution/bidding/Auctions";
 import Page from "./pages/page/Page";
+import { PublicIcon } from "./icons/icons";
+import { Instrument } from "./pages/origination/Instrument";
 
 type Entry = {
   displayEntry: () => boolean,
@@ -83,9 +88,13 @@ const AppComponent = () => {
   entries.push({
     displayEntry: () => issuanceService.length > 0,
     sidebar: [
-      { label: "Issuances", path: "/app/issuance/issuances", render: () => (<Issuances />), icon: (<PlayArrow />), children: [] },
-      { label: "New Issuances", path: "/app/issuance/new", render: () => (<IssuanceNew services={issuanceService} />), icon: (<PlayArrow />), children: [] },
-      { label: "Issuance Requests", path: "/app/issuance/requests", render: () => (<IssuanceRequests services={issuanceService} />), icon: (<PlayArrow />), children: [] }
+      { label: "Instruments", path: "/app/instrument/instruments", render: () => (<Instruments />), icon: (<PublicIcon />), children: [] },
+      { label: "New Instruments", path: "/app/instrument/new", render: () => (<InstrumentsNew />), icon: (<PublicIcon />), children: [] },
+      { label: "Instrument Requests", path: "/app/instrument/requests", render: () => (<InstrumentsRequests />), icon: (<PublicIcon />), children: [] },
+
+      { label: "Issuances", path: "/app/issuance/issuances", render: () => (<Issuances />), icon: (<PublicIcon />), children: [] },
+      { label: "New Issuances", path: "/app/issuance/new", render: () => (<IssuanceNew services={issuanceService} />), icon: (<PublicIcon />), children: [] },
+      { label: "Issuance Requests", path: "/app/issuance/requests", render: () => (<IssuanceRequests services={issuanceService} />), icon: (<PublicIcon />), children: [] }
     ]
   });
   entries.push({
@@ -126,6 +135,7 @@ const AppComponent = () => {
               <Route key={"account"} path={"/app/custody/account/:contractId"} render={() => <Account services={custodyService} />} />
               <Route key={"auction"} path={"/app/distribution/auctions/:contractId"} render={(props) => <Auction auctionServices={auctionService} biddingServices={biddingService} {...props} />} />
               <Route key={"request"} path={"/app/distribution/auction/:contractId"} render={() => <BiddingAuction services={biddingService} />} />
+              <Route key={"instruments"} path={"/app/registry/instruments/:contractId"} component={Instrument}/>
               <Route key={"market"} path={"/app/trading/markets/:contractId"} render={() => <Market services={tradingService} />} />
               { routeEntries(entriesToDisplay) }
             </Switch>

--- a/ui2/src/components/Table/PaginationControls.scss
+++ b/ui2/src/components/Table/PaginationControls.scss
@@ -1,5 +1,7 @@
+@use '../../themes/variables' as *;
+
 @mixin pagination-controls {
-    .paginataion-controls {
+    .pagination-controls {
         margin: $spacing-s 0;
     }
 }

--- a/ui2/src/components/Table/PaginationControls.scss
+++ b/ui2/src/components/Table/PaginationControls.scss
@@ -1,0 +1,5 @@
+@mixin pagination-controls {
+    .paginataion-controls {
+        margin: $spacing-s 0;
+    }
+}

--- a/ui2/src/components/Table/PaginationControls.tsx
+++ b/ui2/src/components/Table/PaginationControls.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Pagination } from 'semantic-ui-react'
+
+const PaginationControls = (props: {
+  totalPages: number,
+  onPageChange: (activePage: number) => void
+}) => (
+  <Pagination
+    className='paginataion-controls'
+    boundaryRange={0}
+    defaultActivePage={1}
+    ellipsisItem={null}
+    firstItem={null}
+    lastItem={null}
+    onPageChange={(_, data) => data.activePage && props.onPageChange(+data.activePage)}
+    totalPages={props.totalPages}/>
+)
+
+export default PaginationControls;

--- a/ui2/src/components/Table/PaginationControls.tsx
+++ b/ui2/src/components/Table/PaginationControls.tsx
@@ -6,7 +6,7 @@ const PaginationControls = (props: {
   onPageChange: (activePage: number) => void
 }) => (
   <Pagination
-    className='paginataion-controls'
+    className='pagination-controls'
     boundaryRange={0}
     defaultActivePage={1}
     ellipsisItem={null}

--- a/ui2/src/components/Table/StripedTable.scss
+++ b/ui2/src/components/Table/StripedTable.scss
@@ -1,0 +1,62 @@
+
+@mixin striped-table {
+  .striped-table {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      align-items: flex-start;
+      animation: fadeIn .5s;
+
+      table {
+          border-collapse: collapse;
+          border: none;
+          margin: 0px;
+
+          th {
+              border: none;
+              background-color: var(--cool-grey-100);
+          }
+
+          tr td {
+              border-top: 0px !important;
+
+              .label {
+                  display: none;
+              }
+          }
+
+          tbody {
+              background-color: var(--white);
+              border: 1px solid var(--cool-grey-90);
+          }
+
+          tr:nth-child(odd) {
+              background-color: var(--blue-100);
+          }
+      }
+
+
+      @media screen and (max-width: 769px) {
+          table {
+              border-bottom: none;
+
+              thead {
+                  display: none !important;
+              }
+
+              tr {
+                  background-color: var(--cool-grey-100);
+
+                  td {
+                      font-weight: normal;
+                      text-align: left;
+
+                      .label {
+                          display: inline-flex;
+                      }
+                  }
+              }
+          }
+      }
+  }
+}

--- a/ui2/src/components/Table/StripedTable.scss
+++ b/ui2/src/components/Table/StripedTable.scss
@@ -1,3 +1,4 @@
+@use './PaginationControls';
 
 @mixin striped-table {
   .striped-table {
@@ -6,6 +7,8 @@
       width: 100%;
       align-items: flex-start;
       animation: fadeIn .5s;
+
+      @include PaginationControls.pagination-controls();
 
       table {
           border-collapse: collapse;

--- a/ui2/src/components/Table/StripedTable.tsx
+++ b/ui2/src/components/Table/StripedTable.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react'
+import { Table } from 'semantic-ui-react'
+
+import PaginationControls from './PaginationControls';
+
+const StripedTable = (props: {
+    headings: React.ReactNode[],
+    rows: React.ReactNode[][],
+    rowsPerPage?: number,
+    emptyLabel?: string
+}) => {
+    const { headings, rows, rowsPerPage, emptyLabel } = props
+
+    const totalPages = rowsPerPage ? Math.ceil(rows.length / rowsPerPage) : 0;
+
+    const [ activePage, setActivePage ] = useState<number>(1);
+    const [ activePageRows, setActivePageRows ] = useState<React.ReactNode[][]>([])
+
+    useEffect(()=> {
+        if (rowsPerPage) {
+            setActivePageRows(rows.slice((activePage-1)*rowsPerPage, activePage*rowsPerPage))
+        } else {
+            setActivePageRows(rows);
+        }
+    },[activePage, rows, rowsPerPage])
+
+    return (
+        <div className='striped-table'>
+            <Table>
+                <Table.Header>
+                    <Table.Row>
+                        {headings.map((heading, index) =>
+                            <Table.HeaderCell
+                                key={index}
+                                textAlign={index+1 > headings.length/2 ? 'right': 'left'}>
+                                {heading}
+                            </Table.HeaderCell>
+                        )}
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {rows.length > 0 ?
+                        activePageRows.map((row, i) =>
+                            <Table.Row key={i}>
+                                {row.map((item, j) =>
+                                    <Table.Cell
+                                        key={j}
+                                        textAlign={j+1 > row.length/2 ? 'right': 'left'}>
+                                        <b className='label'>{headings[j]}: </b> {item}
+                                    </Table.Cell>
+                                )}
+                            </Table.Row>
+                        )
+                    :
+                        <Table.Row className='empty-table' >
+                            <Table.Cell textAlign={'center'} colSpan={4}>
+                                <i>{emptyLabel || 'none'}</i>
+                            </Table.Cell>
+                        </Table.Row>
+                    }
+                </Table.Body>
+            </Table>
+            {totalPages > 1 &&
+                <PaginationControls
+                    totalPages={totalPages}
+                    onPageChange={(num: number) => setActivePage(num)}/>}
+        </div>
+    )
+}
+
+export default StripedTable;

--- a/ui2/src/components/Tile/Tile.scss
+++ b/ui2/src/components/Tile/Tile.scss
@@ -3,12 +3,120 @@
 
 @mixin tile {
   .tile {
-    background-color: var(--cool-grey-10);
+    width: 100%;
+    border: 1px solid var(--cool-grey-90);
+    background-color: white;
+    color: var(--textcolor);
     padding: v.$spacing-l;
     border-radius: 2px;
-    margin-bottom: 2px;
-    max-width: 550px;
+    margin-bottom: v.$spacing-l;
     text-align: left;
+
+    &.thin-gap {
+        margin-bottom: 2px;
+    }
+
+    &.dark {
+        background-color: var(--cool-grey-10);
+        border: none;
+        color: var(--white);
+
+        .subtitle {
+            color: var(--white);
+            font-size: 16px;
+        }
+
+        .tile-content {
+            text-align: left;
+
+            form .field input {
+                background-color: var(--cool-grey-30);
+                color: var(--white);
+            }
+
+            form .field .dropdown {
+                background-color: var(--cool-grey-30);
+                color: var(--white);
+            }
+
+            .username-login {
+                margin: v.$spacing-m;
+                .ui.input {
+                    width: 100%;
+                }
+            }
+
+            form button, .login-form button {
+                text-align: left;
+                min-height: 42px;
+                display: flex;
+
+                &.dabl-login-button {
+                    display: unset;
+                    height: 70px;
+                    font-size: 16px;
+                    background-color: var(--white);
+                    border: 1px solid var(--cool-grey-30);
+                    border-radius: 4px;
+
+                    &:hover {
+                        transform: scale(1.02);
+                    }
+                }
+            }
+
+            .login-details {
+                line-height: 26px;
+            }
+
+            .login-form {
+                padding: v.$spacing-s 0;
+
+                .field.upload-file-input {
+                    display: flex;
+                }
+
+                .field > .ui.input {
+                    display: flex;
+                    align-self: flex-end;
+                    width: 100%;
+                }
+
+                .dropdown, .dropdown .menu {
+                    background-color: var(--cool-grey-30);
+                    color: var(--white);
+                    .text {
+                        color: var(--white);
+                    }
+                }
+
+                .custom-file-upload {
+                    height: 44px;
+                    width: 100%;
+                    margin: 0;
+                    cursor: pointer;
+                    display: flex;
+                    align-items: center;
+                    justify-content: flex-start;
+                    align-self: flex-end;
+                    border-radius: 2px;
+                    background-color: var(--cool-grey-30);
+
+                    > input[type="file"] {
+                        display: none;
+                    }
+
+                    i.white.icon {
+                        color: var(--white)
+                    }
+
+                    .icon {
+                        margin-right: v.$spacing-s;
+                    }
+                }
+            }
+        }
+    }
 
     .tile-header {
         margin-bottom: v.$spacing-m;
@@ -22,102 +130,9 @@
             font-size: 34px;
             line-height: 32px;
             margin: 0;
-            color: var(--white);
-        }
-    }
 
-    .subtitle {
-        color: var(--white);
-        font-size: 16px;
-    }
-
-    .tile-content {
-        text-align: left;
-
-        form .field input {
-            background-color: var(--cool-grey-30);
-            color: var(--white);
-        }
-
-        form .field .dropdown {
-            background-color: var(--cool-grey-30);
-            color: var(--white);
-        }
-
-        .username-login {
-            margin: v.$spacing-m;
-            .ui.input {
-                width: 100%;
-            }
-        }
-
-        form button, .login-form button {
-            text-align: left;
-            min-height: 42px;
-            display: flex;
-
-            &.dabl-login-button {
-                display: unset;
-                height: 70px;
-                font-size: 16px;
-                background-color: var(--white);
-                border: 1px solid var(--cool-grey-30);
-                border-radius: 4px;
-
-                &:hover {
-                    transform: scale(1.02);
-                }
-            }
-        }
-
-        .login-details {
-            line-height: 26px;
-        }
-
-        .login-form {
-            padding: v.$spacing-s 0;
-
-            .field.upload-file-input {
-                display: flex;
-            }
-
-            .field > .ui.input {
-                display: flex;
-                align-self: flex-end;
-                width: 100%;
-            }
-
-            .dropdown, .dropdown .menu {
-                background-color: var(--cool-grey-30);
+            &.dark {
                 color: var(--white);
-                .text {
-                    color: var(--white);
-                }
-            }
-
-            .custom-file-upload {
-                height: 44px;
-                width: 100%;
-                margin: 0;
-                cursor: pointer;
-                display: flex;
-                align-items: center;
-                justify-content: flex-start;
-                align-self: flex-end;
-                border-radius: 2px;
-                background-color: var(--cool-grey-30);
-
-                > input[type="file"] {
-                    display: none;
-                }
-
-                i.white.icon {
-                    color: var(--white)
-                }
-
-                .icon {
-                    margin-right: v.$spacing-s;
-                }
             }
         }
     }

--- a/ui2/src/components/Tile/Tile.tsx
+++ b/ui2/src/components/Tile/Tile.tsx
@@ -13,12 +13,14 @@ type TileProps = {
   className?: string;
   header?: React.ReactElement;
   key?: string | number;
+  dark?: boolean;
+  thinGap?: boolean;
   subtitle?: string;
 }
 
-export const Tile: React.FC<TileProps> = ({ children, className, subtitle, header }) => {
+export const Tile: React.FC<TileProps> = ({ children, className, dark, thinGap, subtitle, header }) => {
   return (
-    <div className={classNames('tile', className)}>
+    <div className={classNames('tile', className, { dark, 'thin-gap': thinGap })}>
       { !!header && <div className='tile-header'>{header}</div> }
       { !!subtitle && <p className='subtitle'>{subtitle}</p> }
       <div className='tile-content'>

--- a/ui2/src/index.scss
+++ b/ui2/src/index.scss
@@ -1,5 +1,7 @@
 @use 'themes/colors';
 @use 'components/Tile/TilePage';
+@use 'components/Tile/Tile';
+@use 'components/Table/StripedTable';
 @use 'pages/login/Login';
 @use 'pages/page/Page';
 @use 'pages/page/WelcomeHeader';
@@ -167,7 +169,9 @@ html {
         @include overrides.overrides();
         @include WelcomeHeader.welcome-header();
         @include icons.icons();
+        @include Tile.tile();
         @include TilePage.tile-page();
+        @include StripedTable.striped-table();
         @include Apps.apps();
         @include Page.page();
         @include Login.login-screen();

--- a/ui2/src/pages/issuance/New.tsx
+++ b/ui2/src/pages/issuance/New.tsx
@@ -33,7 +33,7 @@ const NewComponent : React.FC<RouteComponentProps & Props> = ({ history, service
   const party = useParty();
   const customerServices = services.filter(s => s.payload.customer === party);
   const allAssets = useStreamQueries(AssetDescription).contracts;
-  const assets = allAssets//.filter(c => c.payload.issuer === party && c.payload.assetId.version === "0");
+  const assets = allAssets.filter(c => c.payload.issuer === party && c.payload.assetId.version === "0");
   const asset = assets.find(c => c.payload.assetId.label === assetLabel);
   const assetSettlementRules = useStreamQueries(AssetSettlementRule).contracts;
   const accounts = assetSettlementRules.map(c => c.payload.account);

--- a/ui2/src/pages/issuance/New.tsx
+++ b/ui2/src/pages/issuance/New.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import classnames from "classnames";
 import { useLedger, useParty, useStreamQueries } from "@daml/react";
-import { Typography, Grid, Paper, Select, MenuItem, TextField, Button, MenuProps, FormControl, InputLabel, Box, IconButton } from "@material-ui/core";
+import { IconButton } from "@material-ui/core";
 import useStyles from "../styles";
 import { render } from "../../components/Claims/render";
 import { transformClaim } from "../../components/Claims/util";
@@ -11,6 +10,9 @@ import { Visibility, VisibilityOff } from "@material-ui/icons";
 import { AssetDescription } from "@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription";
 import { Service } from "@daml.js/da-marketplace/lib/Marketplace/Issuance/Service";
 import {CreateEvent} from "@daml/ledger";
+import FormErrorHandled from "../../components/Form/FormErrorHandled";
+import { Button, Form } from "semantic-ui-react";
+import Tile from "../../components/Tile/Tile";
 
 type Props = {
   services : Readonly<CreateEvent<Service, any, any>[]>
@@ -31,7 +33,7 @@ const NewComponent : React.FC<RouteComponentProps & Props> = ({ history, service
   const party = useParty();
   const customerServices = services.filter(s => s.payload.customer === party);
   const allAssets = useStreamQueries(AssetDescription).contracts;
-  const assets = allAssets.filter(c => c.payload.issuer === party && c.payload.assetId.version === "0");
+  const assets = allAssets//.filter(c => c.payload.issuer === party && c.payload.assetId.version === "0");
   const asset = assets.find(c => c.payload.assetId.label === assetLabel);
   const assetSettlementRules = useStreamQueries(AssetSettlementRule).contracts;
   const accounts = assetSettlementRules.map(c => c.payload.account);
@@ -55,57 +57,75 @@ const NewComponent : React.FC<RouteComponentProps & Props> = ({ history, service
     history.push("/app/issuance/requests");
   }
 
-  const menuProps : Partial<MenuProps> = { anchorOrigin: { vertical: "bottom", horizontal: "left" }, transformOrigin: { vertical: "top", horizontal: "left" }, getContentAnchorEl: null };
   return (
-    <Grid container direction="column" spacing={2}>
-      <Grid item xs={12}>
-        <Typography variant="h3" className={classes.heading}>New Issuance</Typography>
-      </Grid>
-      <Grid item xs={12}>
-        <Grid container spacing={4}>
-          <Grid item xs={4}>
-            <Grid container direction="column" spacing={2}>
-              <Grid item xs={12}>
-                <Paper className={classnames(classes.fullWidth, classes.paper)}>
-                  <Typography variant="h5" className={classes.heading}>Details</Typography>
-                  <FormControl className={classes.inputField} fullWidth>
-                    <Box className={classes.fullWidth}>
-                      <InputLabel>Asset</InputLabel>
-                      <Select className={classes.width90} value={assetLabel} onChange={e => setAssetLabel(e.target.value as string)} MenuProps={menuProps}>
-                        {assets.map((c, i) => (<MenuItem key={i} value={c.payload.assetId.label}>{c.payload.assetId.label}</MenuItem>))}
-                      </Select>
-                      <IconButton className={classes.marginLeft10} color="primary" size="small" component="span" onClick={() => setShowAsset(!showAsset)}>
-                        {showAsset ? <VisibilityOff fontSize="small"/> : <Visibility fontSize="small"/>}
-                      </IconButton>
-                    </Box>
-                  </FormControl>
-                  <FormControl className={classes.inputField} fullWidth>
-                    <InputLabel>Issuance Account</InputLabel>
-                    <Select value={accountLabel} onChange={e => setAccountLabel(e.target.value as string)} MenuProps={menuProps}>
-                      {accounts.map((a, i) => (<MenuItem key={i} value={a.id.label}>{a.id.label}</MenuItem>))}
-                    </Select>
-                  </FormControl>
-                  <TextField className={classes.inputField} fullWidth label="Issuance ID" type="text" value={issuanceId} onChange={e => setIssuanceId(e.target.value as string)} />
-                  <TextField className={classes.inputField} fullWidth label="Quantity" type="number" value={quantity} onChange={e => setQuantity(e.target.value as string)} />
-                  <Button className={classnames(classes.fullWidth, classes.buttonMargin)} size="large" variant="contained" color="primary" disabled={!canRequest} onClick={requestIssuance}>Request Issuance</Button>
-                </Paper>
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item xs={8}>
-            <Grid container direction="column" spacing={2}>
-              {showAsset && (
-                <Grid item xs={12}>
-                  <Paper className={classnames(classes.fullWidth, classes.paper)}>
-                    <Typography variant="h5" className={classes.heading}>Instrument</Typography>
-                    <div ref={el} style={{ height: "100%" }}/>
-                  </Paper>
-                </Grid>)}
-            </Grid>
-          </Grid>
-        </Grid>
-      </Grid>
-    </Grid>
+    <div className='issuance-new'>
+      <div>
+      <h3>New Issuance</h3>
+        <Tile header={<h3>Details</h3>}>
+          <FormErrorHandled onSubmit={requestIssuance}>
+            <Form.Input>
+              <Form.Select
+                selection
+                placeholder='Asset'
+                options={assets.map(c => ({
+                  text: c.payload.assetId.label,
+                  value: c.payload.assetId.label
+                }))}
+                value={assetLabel}
+                onChange={(_, d) => setAssetLabel((d.value && d.value as string) || "")}/>
+              <IconButton
+                className={classes.marginLeft10}
+                color="primary"
+                size="small"
+                component="span"
+                onClick={() => setShowAsset(!showAsset)}>
+                  {showAsset ? <VisibilityOff fontSize="small"/> : <Visibility fontSize="small"/>}
+              </IconButton>
+            </Form.Input>
+
+            <Form.Select
+              selection
+              placeholder='Issuance Account'
+              options={accounts.map(c => ({
+                text: c.id.label,
+                value: c.id.label
+              }))}
+              value={accountLabel}
+              onChange={(_, d) => setAccountLabel((d.value && d.value as string) || "")}/>
+
+            <Form.Input
+              required
+              fluid
+              placeholder='Issuance ID'
+              value={issuanceId}
+              onChange={e => setIssuanceId(e.currentTarget.value)}
+            />
+
+            <Form.Input
+              required
+              fluid
+              placeholder='Quantity'
+              value={quantity}
+              onChange={e => setQuantity(e.currentTarget.value)}
+            />
+
+            <Button
+              secondary
+              type='submit'
+              disabled={!canRequest}
+              icon='right arrow'
+              labelPosition='right'
+              className='ghost'
+              content='Request Issuance'/>
+          </FormErrorHandled>
+        </Tile>
+      </div>
+
+      { showAsset && <Tile header={<h3>Instrument</h3>}>
+          <div ref={el} style={{ height: "400px", overflow: 'hidden' }}/>
+        </Tile>
+      }
+    </div>
   );
 };
 

--- a/ui2/src/pages/login/Login.tsx
+++ b/ui2/src/pages/login/Login.tsx
@@ -76,13 +76,13 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
   }, [onLogin, query, history, userDispatch]);
 
   const localTiles = [
-    <Tile key='login' header={logoHeader}><LocalLoginForm onLogin={onLogin}/></Tile>
+    <Tile dark thinGap key='login' header={logoHeader}><LocalLoginForm onLogin={onLogin}/></Tile>
   ];
 
   const dablTiles = [
-    <Tile key='login' header={logoHeader}><DablLoginForm onLogin={onLogin}/></Tile>,
-    <Tile key='parties'><PartiesLoginForm onLogin={onLogin}/></Tile>,
-    <Tile key='jwt'><JWTLoginForm onLogin={onLogin}/></Tile>
+    <Tile dark thinGap key='login' header={logoHeader}><DablLoginForm onLogin={onLogin}/></Tile>,
+    <Tile dark thinGap key='parties'><PartiesLoginForm onLogin={onLogin}/></Tile>,
+    <Tile dark thinGap key='jwt'><JWTLoginForm onLogin={onLogin}/></Tile>
   ];
 
   // const tiles = appInfos.length !== 0

--- a/ui2/src/pages/origination/Instruments.tsx
+++ b/ui2/src/pages/origination/Instruments.tsx
@@ -1,71 +1,49 @@
 import React from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
-import { Table, TableBody, TableCell, TableRow, TableHead, Button, Grid, Paper, Typography } from "@material-ui/core";
 import { IconButton } from "@material-ui/core";
 import { KeyboardArrowRight } from "@material-ui/icons";
 import { useStreamQueries } from "@daml/react";
-import useStyles from "../styles";
 import { getName } from "../../config";
 import { AssetDescription } from "@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription";
+import StripedTable from "../../components/Table/StripedTable";
+import { Button } from "semantic-ui-react";
+import Tile from "../../components/Tile/Tile";
 
 const InstrumentsComponent : React.FC<RouteComponentProps> = ({ history } : RouteComponentProps) => {
-  const classes = useStyles();
-
   const allInstruments = useStreamQueries(AssetDescription).contracts;
   const instruments = allInstruments.filter(c => c.payload.assetId.version === "0");
 
   return (
-    <>
-      <Grid container direction="column">
-        <Grid container direction="row">
-          <Grid item xs={12}>
-            <Paper className={classes.paper}>
-              <Grid container direction="row" justify="center" className={classes.paperHeading}><Typography variant="h2">Actions</Typography></Grid>
-              <Grid container direction="row" justify="center">
-                <Grid item xs={12}>
-                  <Grid container justify="center">
-                    <Button color="primary" size="large" className={classes.actionButton} variant="outlined" onClick={() => history.push("/app/registry/instruments/new")}>New Instrument</Button>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Paper>
-          </Grid>
-          <Grid item xs={12}>
-            <Paper className={classes.paper}>
-              <Grid container direction="row" justify="center" className={classes.paperHeading}><Typography variant="h2">Instruments</Typography></Grid>
-              <Table size="small">
-                <TableHead>
-                  <TableRow className={classes.tableRow}>
-                    <TableCell key={0} className={classes.tableCell}><b>Issuer</b></TableCell>
-                    <TableCell key={1} className={classes.tableCell}><b>Signatories</b></TableCell>
-                    <TableCell key={2} className={classes.tableCell}><b>Id</b></TableCell>
-                    <TableCell key={3} className={classes.tableCell}><b>Version</b></TableCell>
-                    <TableCell key={4} className={classes.tableCell}><b>Description</b></TableCell>
-                    <TableCell key={5} className={classes.tableCell}><b>Details</b></TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {instruments.map((c, i) => (
-                    <TableRow key={i} className={classes.tableRow}>
-                      <TableCell key={0} className={classes.tableCell}>{getName(c.payload.issuer)}</TableCell>
-                      <TableCell key={1} className={classes.tableCell}>{Object.keys(c.payload.assetId.signatories.textMap).join(", ")}</TableCell>
-                      <TableCell key={2} className={classes.tableCell}>{c.payload.assetId.label}</TableCell>
-                      <TableCell key={3} className={classes.tableCell}>{c.payload.assetId.version}</TableCell>
-                      <TableCell key={4} className={classes.tableCell}>{c.payload.description}</TableCell>
-                      <TableCell key={5} className={classes.tableCell}>
-                        <IconButton color="primary" size="small" component="span" onClick={() => history.push("/app/registry/instruments/" + c.contractId.replace("#", "_"))}>
-                          <KeyboardArrowRight fontSize="small"/>
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </Paper>
-          </Grid>
-        </Grid>
-      </Grid>
-    </>
+    <div className='instruments'>
+      <Tile header={<h2>Actions</h2>}>
+        <Button
+          secondary
+          className='ghost'
+          onClick={() => history.push("/app/instrument/new")}>New Instrument</Button>
+      </Tile>
+
+      <StripedTable
+        headings={[
+          'Issuer',
+          'Signatories',
+          'Id',
+          'Version',
+          'Description',
+          'Details'
+        ]}
+        rows={
+          instruments.map(c => [
+            getName(c.payload.issuer),
+            Object.keys(c.payload.assetId.signatories.textMap).join(", "),
+            c.payload.assetId.label,
+            c.payload.assetId.version,
+            c.payload.description,
+            <IconButton color="primary" size="small" component="span" onClick={() => history.push("/app/registry/instruments/" + c.contractId.replace("#", "_"))}>
+              <KeyboardArrowRight fontSize="small"/>
+            </IconButton>
+          ])
+        }/>
+    </div>
   );
 };
 

--- a/ui2/src/pages/page/Page.tsx
+++ b/ui2/src/pages/page/Page.tsx
@@ -44,8 +44,14 @@ const Page: React.FC<Props> = ({
 
             <Menu.Menu>
               { sideBarItems?.map(item => (
-                <Menu.Item exact as={NavLink} to={item.path}>
-                  <p className='sidemenu-item-normal'>{item.label}</p>
+                <Menu.Item
+                  exact
+                  key={item.label+item.path}
+                  as={NavLink}
+                  to={item.path}
+                  className='sidemenu-item-normal'
+                >
+                  <p>{item.icon}{item.label}</p>
                 </Menu.Item>
               )) }
             </Menu.Menu>


### PR DESCRIPTION
This PR starts some work of substituting Material UI components with ones more line with the rest of the styles. I decided to include some simple documentation in this PR description, hopefully you guys will find it helpful when making these substitutions elsewhere! 

### `StripedTable`

Importable from `components/Table/StripedTable`, this is (one of) the component that we used in `ui` on master for displaying tables.  We should be able to convert all the existing Material UI tables to StripedTables pretty easily. The table headers and rows are passed in as props. 

See `Instruments.tsx` in origination (in this PR) for an example. 

### `Tile`

Tile can be used for blocks of content on a page. Pretty self-explanatory, it takes in children for content but also has a `header` prop for a title. 

### `FormErrorHandled`

This is a component that we wrapped around the Semantic UI `Form` in the old codebase, which has built-in reusable functionality for dealing with any errors thrown inside the `onSubmit` callback, and displays an error toast message on screen. Also automatically handles `loading` states if the `onSubmit` callback is async. 

In the children, use the typical [Semantic UI form components](https://react.semantic-ui.com/collections/form/). 

An example of usage in this PR can be found in `pages/issuance/New.tsx`. 


# Comparison shots!

Before
![Screen Shot 2021-03-24 at 3 46 34 PM](https://user-images.githubusercontent.com/64022527/112379178-34a78200-8cbe-11eb-8d2b-952ea049a181.png)

After
![Screen Shot 2021-03-24 at 3 41 52 PM](https://user-images.githubusercontent.com/64022527/112379176-340eeb80-8cbe-11eb-9915-476b5b9f476b.png)
