### PR TITLE
get quick setup to build

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -19,7 +19,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-start-navigator: yes
+start-navigator: no
 sandbox-options:
   - --wall-clock-time
   - --ledgerid=da-marketplace-sandbox

--- a/daml.yaml
+++ b/daml.yaml
@@ -19,7 +19,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-start-navigator: no
+start-navigator: yes
 sandbox-options:
   - --wall-clock-time
   - --ledgerid=da-marketplace-sandbox

--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -4,6 +4,7 @@ import Daml.Script
 import DA.Finance.Asset (AssetDeposit)
 import DA.Finance.Types (Id(..), Asset(..), Account(..))
 import DA.Next.Set
+import DA.Optional
 import qualified Marketplace.Operator.Role as Operator
 import qualified Marketplace.Clearing.Role as Clearinghouse
 import qualified Marketplace.Clearing.Service as Clearing
@@ -17,7 +18,8 @@ import qualified Marketplace.Listing.Service as Listing
 import qualified Marketplace.Settlement.Service as Settlement
 import qualified Marketplace.Distribution.Role as Distributor
 import qualified Marketplace.Distribution.Bidding.Service as Bidding
-import qualified Marketplace.Regulator.Service as Regulator
+import qualified Marketplace.Regulator.Service as RegulatorService
+import qualified Marketplace.Regulator.Role as Regulator
 
 data Assets = Assets
   with
@@ -68,31 +70,40 @@ onboardProviders = do
 
   -- Roles
   operatorRoleCid           <- submit operator  do createCmd Operator.Role with ..
+
   custodianRoleOfferCid     <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferCustodianRole with provider = bank
   custodianRoleCid          <- submit bank      do exerciseCmd custodianRoleOfferCid Custodian.Accept
+
   exchangeRoleOfferCid      <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferExchangeRole with provider = exchange
   exchangeRoleCid           <- submit exchange  do exerciseCmd exchangeRoleOfferCid Exchange.Accept
+
   matchingServiceOfferCid   <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferMatchingService with provider = exchange
   matchingServiceCid        <- submit exchange  do exerciseCmd matchingServiceOfferCid Matching.Accept
+
   settlementServiceOfferCid <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferSettlementService with provider = exchange
   settlementServiceCid      <- submit exchange  do exerciseCmd settlementServiceOfferCid Settlement.Accept
+
   distributorRoleOfferCid   <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferDistributorRole with provider = bank
   distributorRoleCid        <- submit bank      do exerciseCmd distributorRoleOfferCid Distributor.Accept
 
   -- Identities
-  regulatorServiceOfferCid        <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferRegulatorService with provider = operator; customer = bank
-  regulatorServiceCid             <- submit bank      do exerciseCmd regulatorServiceOfferCid Regulator.Accept
-  identityVerificationRequestCid  <- submit bank      do exerciseCmd regulatorServiceCid Regulator.RequestIdentityVerification with legalName = "BankLegalName"; location = "BankLocation"; observers = [public]
-  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid Regulator.VerifyIdentity with ..
-  regulatorServiceOfferCid        <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferRegulatorService with provider = operator; customer = exchange
-  regulatorServiceCid             <- submit exchange  do exerciseCmd regulatorServiceOfferCid Regulator.Accept
-  identityVerificationRequestCid  <- submit exchange  do exerciseCmd regulatorServiceCid Regulator.RequestIdentityVerification with legalName = "ExchangeLegalName"; location = "ExchangeLocation"; observers = [public]
-  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid Regulator.VerifyIdentity with ..
+  regulatorRoleOfferCid     <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferRegulatorRole with provider = operator
+  regulatorRoleCid          <- submit operator  do exerciseCmd regulatorRoleOfferCid Regulator.Accept
 
-  regulatorServiceOfferCid        <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferRegulatorService with provider = operator; customer = clearinghouse
-  regulatorServiceCid             <- submit clearinghouse  do exerciseCmd regulatorServiceOfferCid Regulator.Accept
-  identityVerificationRequestCid  <- submit clearinghouse  do exerciseCmd regulatorServiceCid Regulator.RequestIdentityVerification with legalName = "CCPLegalName"; location = "CCPLocation"; observers = [public]
-  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid Regulator.VerifyIdentity with ..
+  regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = bank
+  regulatorServiceCid             <- submit bank      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
+  identityVerificationRequestCid  <- submit bank      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Bankeee LegalName"; location = "Bank Location"; observers = [public]
+  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
+
+  regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = exchange
+  regulatorServiceCid             <- submit exchange      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
+  identityVerificationRequestCid  <- submit exchange      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Exchange LegalName"; location = "Exchange Location"; observers = [public]
+  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
+
+  regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = clearinghouse
+  regulatorServiceCid             <- submit clearinghouse      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
+  identityVerificationRequestCid  <- submit clearinghouse      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "CCP LegalName"; location = "CCP Location"; observers = [public]
+  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Clearing
   custodyServiceOfferCid <- submit bank do exerciseCmd custodianRoleCid Custodian.OfferCustodyService with customer = clearinghouse, ..
@@ -156,10 +167,12 @@ onboardCustomer Providers{..} party = do
   clearingServiceCid      <- submit customer do exerciseCmd clearingServiceOfferCid Clearing.Accept with ..
 
   -- Identity
-  regulatorServiceOfferCid <- submit operator do exerciseCmd operatorRoleCid Operator.OfferRegulatorService with provider = operator; ..
-  regulatorServiceCid <- submit customer do exerciseCmd regulatorServiceOfferCid Regulator.Accept
-  identityVerificationRequestCid <- submit customer do exerciseCmd regulatorServiceCid Regulator.RequestIdentityVerification with observers = [public]; legalName = party <> " Legal Name"; location = party <> " Location"
-  verifiedIdentity <- submit operator do exerciseCmd regulatorServiceCid Regulator.VerifyIdentity with ..
+  (Some (regulatorRoleCid,_))          <- queryContractKey @Regulator.Role operator (operator, operator)
+
+  regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = customer
+  regulatorServiceCid             <- submit customer      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
+  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party <> " Legal Name"; location = party <> " Location"; observers = [public]
+  verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Bidding Service
   biddingServiceOfferCid <- submit bank do exerciseCmd distributorRoleCid Distributor.OfferBiddingService with ..

--- a/daml/Marketplace/Operator/Role.daml
+++ b/daml/Marketplace/Operator/Role.daml
@@ -1,6 +1,6 @@
 module Marketplace.Operator.Role where
 
-import Marketplace.Regulator.Service qualified as Regulator
+import Marketplace.Regulator.Role qualified as Regulator
 import Marketplace.Custody.Role qualified as Custodian
 import Marketplace.Clearing.Role qualified as Clearing
 import Marketplace.Distribution.Role qualified as Distributor
@@ -30,10 +30,10 @@ template Role
         do
           create Exchange.Offer with ..
 
-      nonconsuming OfferRegulatorService : ContractId Regulator.Offer
+
+      nonconsuming OfferRegulatorRole: ContractId Regulator.Offer
         with
           provider : Party
-          customer : Party
         do
           create Regulator.Offer with ..
 

--- a/daml/Marketplace/Regulator/Role.daml
+++ b/daml/Marketplace/Regulator/Role.daml
@@ -1,0 +1,64 @@
+module Marketplace.Regulator.Role where
+import Marketplace.Regulator.Service qualified as Regulator
+
+template Role
+  with
+    operator : Party
+    provider : Party
+  where
+    signatory operator, provider
+
+    key (operator, provider) :  (Party, Party)
+    maintainer key._1
+
+    controller provider can
+
+      nonconsuming OfferRegulatorService : ContractId Regulator.Offer
+        with
+          customer : Party
+        do
+          create Regulator.Offer with ..
+
+      nonconsuming ApproveRegulatorRequest : ContractId Regulator.Service
+        with
+          regulatorRequestCid : ContractId Regulator.Request
+        do
+          exercise regulatorRequestCid Regulator.Approve with ..
+
+      nonconsuming TerminateRegulatorService : ()
+        with
+          regulatorServiceCid : ContractId Regulator.Service
+        do
+          archive regulatorServiceCid
+
+template Offer
+  with
+    operator : Party
+    provider : Party
+  where
+    signatory operator
+
+    controller provider can
+      Accept : ContractId Role
+        do
+          create Role with ..
+
+      Decline : ()
+        do
+          return ()
+
+template Request
+  with
+    provider : Party
+    operator : Party
+  where
+    signatory provider
+
+    controller operator can
+      Approve : ContractId Role
+        do
+          create Role with ..
+
+      Reject : ()
+        do
+          return ()

--- a/triggers/daml/AutoApproval.daml
+++ b/triggers/daml/AutoApproval.daml
@@ -14,6 +14,8 @@ import Marketplace.Distribution.Bidding.Service qualified as BiddingService
 import Marketplace.Issuance.Service qualified as IssuanceService
 import Marketplace.Listing.Service qualified as ListingService
 import Marketplace.Regulator.Service qualified as RegulatorService
+import Marketplace.Regulator.Role qualified as RegulatorRole
+import Marketplace.Regulator.Model qualified as Regulator
 import Marketplace.Settlement.Service qualified as SettlementService
 import Marketplace.Trading.Role qualified as TradingRole
 import Marketplace.Trading.Service qualified as TradingService
@@ -31,8 +33,11 @@ autoApprovalTrigger = Trigger
     , registeredTemplate @DistributionRole.Request
     , registeredTemplate @IssuanceService.Offer
     , registeredTemplate @ListingService.Offer
+    , registeredTemplate @RegulatorRole.Offer
+    , registeredTemplate @RegulatorRole.Request
+    , registeredTemplate @RegulatorRole.Role
     , registeredTemplate @RegulatorService.Offer
-    , registeredTemplate @RegulatorService.Request -- TO-DO: Auto-approve requests
+    , registeredTemplate @RegulatorService.Request
     , registeredTemplate @RegulatorService.Service
     , registeredTemplate @RegulatorService.IdentityVerificationRequest
     , registeredTemplate @SettlementService.Offer
@@ -139,9 +144,12 @@ handleApprovalRule party = do
     generateServiceCommands IssuanceService.Originate      originationRequests issuanceServices ++
     generateServiceCommands IssuanceService.CreateIssuance issuanceRequests issuanceServices
 
-  idVerificationRequests  <- queryByParty @RegulatorService.IdentityVerificationRequest (.provider)
-  regulatorServices       <- queryByParty @RegulatorService.Service              (.provider)
+  idVerificationRequests     <- queryByParty @RegulatorService.IdentityVerificationRequest (.provider)
+  regulatorServicesRequests  <- queryByParty @RegulatorService.Request                     (.provider)
+  regulatorServices          <- queryByParty @RegulatorService.Service                     (.provider)
+  regulatorRoles             <- queryByParty @RegulatorRole.Role                           (.provider)
   submitCommands $
+    generateRoleCommands RegulatorRole.ApproveRegulatorRequest regulatorServicesRequests regulatorRoles ++
     generateServiceCommands RegulatorService.VerifyIdentity idVerificationRequests regulatorServices
 
   creditRequests          <- queryByParty @Custody.CreditAccountRequest         (.provider)

--- a/ui2/src/pages/login/QuickSetup.tsx
+++ b/ui2/src/pages/login/QuickSetup.tsx
@@ -46,11 +46,16 @@ import {
 } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Role';
 import {
   Offer as MatchingOffer,
-  Service as MarchingService,
+  Service as MatchingService,
 } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Matching/Service';
 
 import {
   Offer as RegulatorOffer,
+  Role as RegulatorRole,
+} from '@daml.js/da-marketplace/lib/Marketplace/Regulator/Role';
+
+import {
+  Offer as RegulatorServiceOffer,
   Service as RegulatorService,
   IdentityVerificationRequest,
 } from '@daml.js/da-marketplace/lib/Marketplace/Regulator/Service';
@@ -62,7 +67,6 @@ import { deployAutomation } from '../../automation';
 import { handleSelectMultiple } from '../common';
 import { useAutomations, AutomationProvider } from '../../context/AutomationContext';
 import { SetupAutomation, makeAutomationOptions } from '../setup/SetupAutomation';
-import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service';
 
 type Offer =
   | ClearingOffer
@@ -140,12 +144,15 @@ const QuickSetupTable = (props: {
   const custodianRoles = useStreamQueries(CustodianRole);
   const exchangeRoles = useStreamQueries(ExchangeRole);
   const distributorRoles = useStreamQueries(DistributorRole);
-  const settlementServices = useStreamQueries(SettlementService);
-  const matchingServices = useStreamQueries(MarchingService);
-  const operatorService = useStreamQueries(OperatorService);
+  const regulatorRoles = useStreamQueries(RegulatorRole);
   const regulatorServices = useStreamQueries(RegulatorService);
+  const settlementServices = useStreamQueries(SettlementService);
+  const matchingServices = useStreamQueries(MatchingService);
+  const operatorService = useStreamQueries(OperatorService);
 
   const clearingOffers = useStreamQueries(ClearingOffer);
+  const regulatorOffers = useStreamQueries(RegulatorOffer);
+  const regulatorServiceOffers = useStreamQueries(RegulatorServiceOffer);
   const custodianOffers = useStreamQueries(CustodianOffer);
   const distributorOffers = useStreamQueries(DistributorOffer);
   const settlementOffers = useStreamQueries(SettlementOffer);
@@ -159,6 +166,8 @@ const QuickSetupTable = (props: {
     setLoading(
       custodianRoles.loading ||
         clearingRoles.loading ||
+        regulatorRoles.loading ||
+        regulatorServices.loading ||
         distributorRoles.loading ||
         settlementServices.loading ||
         exchangeRoles.loading ||
@@ -176,6 +185,8 @@ const QuickSetupTable = (props: {
     custodianRoles.loading,
     clearingRoles.loading,
     distributorRoles.loading,
+    regulatorRoles.loading,
+    regulatorServices.loading,
     settlementServices.loading,
     exchangeRoles.loading,
     matchingServices.loading,
@@ -308,6 +319,19 @@ const QuickSetupTable = (props: {
       createOperatorService();
     }
   }, [operatorService.loading, operatorService]);
+
+  useEffect(() => {
+    const createRegulatorRole = async () => {
+      await ledger.create(RegulatorRole, {
+        operator: credentials.party,
+        provider: credentials.party,
+      });
+    };
+
+    if (!regulatorRoles.loading && regulatorRoles.contracts.length === 0) {
+      createRegulatorRole();
+    }
+  }, [regulatorRoles.loading, regulatorRoles]);
 
   const partyOptions = parties.map(party => {
     return { text: party.partyName, value: party.party };
@@ -481,8 +505,8 @@ const QuickSetupTable = (props: {
     const id = operatorServiceContract.contractId;
 
     if (!findExistingOffer(ServiceKind.REGULATOR)) {
-      await ledger.exercise(OperatorService.OfferRegulatorService, id, {
-        provider: operator,
+      const regId = regulatorRoles.contracts[0].contractId;
+      await ledger.exercise(RegulatorRole.OfferRegulatorService, regId, {
         customer: provider,
       });
     }
@@ -526,7 +550,7 @@ const QuickSetupTable = (props: {
       case ServiceKind.SETTLEMENT:
         return !!settlementOffers.contracts.find(c => c.payload.provider === provider);
       case ServiceKind.REGULATOR:
-        return !!settlementOffers.contracts.find(c => c.payload.provider === provider);
+        return !!regulatorServiceOffers.contracts.find(c => c.payload.provider === provider);
     }
   }
 
@@ -734,6 +758,8 @@ const CreateRoleContract = (props: {
             return acceptAllOffers(settlementOffers.contracts, SettlementOffer.Accept);
           case ServiceKind.LISTING:
             return acceptAllOffers(distributorOffers.contracts, DistributorOffer.Accept);
+          case ServiceKind.REGULATOR:
+            return acceptAllOffers(regulatorOffers.contracts, RegulatorOffer.Accept);
         }
       })
     );


### PR DESCRIPTION
This adds a regulator role template, which was necessary in order to be automated in the auto-approve trigger. Now the entire flow of requesting a regulator service, acceptance, then requesting identity verification, and acceptance is covered end-to-end by the trigger. 

I had to make some changes to Quick Setup due to the new codegen, and I got to build successfully but the identity requests made through there have broken again... I will keep looking into that later today/tmrrw