### PR TITLE
add pooled websocket connections

### DIFF
--- a/ui2/src/Main.tsx
+++ b/ui2/src/Main.tsx
@@ -26,6 +26,7 @@ import { ServicesProvider } from './context/ServicesContext';
 import { httpBaseUrl, wsBaseUrl, ledgerId, publicParty } from './config';
 import { Query, StreamCloseEvent } from '@daml/ledger';
 import { computeCredentials } from './Credentials';
+import QueryStreamProvider, { useContractQuery } from './websocket/queryStream';
 
 type MainProps = {
   defaultPath: string;
@@ -122,22 +123,19 @@ const PublicDamlProvider: React.FC<PublicDamlProviderProps> = ({
       publicParty={publicParty}
       defaultToken={computeCredentials(publicParty).token}
     >
-      {children}
+      <QueryStreamProvider>{children}</QueryStreamProvider>
     </PublicLedger>
   </DamlLedger>
 );
 
 export function useStreamQueries<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
-  queryFactory?: () => Query<T>[],
-  queryDeps?: readonly unknown[],
-  closeHandler?: (e: StreamCloseEvent) => void
+  template: Template<T, K, I>
 ): QueryResult<T, K, I> {
-  const contractsAsPublic = usqp(template, queryFactory, queryDeps, closeHandler);
-  const contractsAsParty = usq(template, queryFactory, queryDeps, closeHandler);
+  const contractsAsParty = useContractQuery(template, false);
+  const contractsAsPublic = useContractQuery(template, true);
 
   const result = useMemo(() => {
-    const mergedContracts = [...contractsAsParty.contracts, ...contractsAsPublic.contracts];
+    const mergedContracts = [...contractsAsParty, ...contractsAsPublic];
 
     // deduplication for when a contract appears in both streams
     // ex., the current party is a signatory to a contract also visible to public
@@ -147,7 +145,7 @@ export function useStreamQueries<T extends object, K, I extends string>(
 
     return {
       contracts,
-      loading: contractsAsParty.loading && contractsAsPublic.loading,
+      loading: false,
     };
   }, [contractsAsPublic, contractsAsParty]);
 

--- a/ui2/src/Main.tsx
+++ b/ui2/src/Main.tsx
@@ -131,8 +131,8 @@ const PublicDamlProvider: React.FC<PublicDamlProviderProps> = ({
 export function useStreamQueries<T extends object, K, I extends string>(
   template: Template<T, K, I>
 ): QueryResult<T, K, I> {
-  const contractsAsParty = useContractQuery(template, false);
-  const contractsAsPublic = useContractQuery(template, true);
+  const { contracts: contractsAsParty, loading: partyLoading } = useContractQuery(template, false);
+  const { contracts: contractsAsPublic, loading: publicLoading } = useContractQuery(template, true);
 
   const result = useMemo(() => {
     const mergedContracts = [...contractsAsParty, ...contractsAsPublic];
@@ -145,9 +145,9 @@ export function useStreamQueries<T extends object, K, I extends string>(
 
     return {
       contracts,
-      loading: false,
+      loading: partyLoading || publicLoading,
     };
-  }, [contractsAsPublic, contractsAsParty]);
+  }, [contractsAsPublic, contractsAsParty, partyLoading, publicLoading]);
 
   return result;
 }

--- a/ui2/src/websocket/queryStream.ts
+++ b/ui2/src/websocket/queryStream.ts
@@ -22,6 +22,7 @@ export type QueryStream = {
   partyLoading: boolean;
   publicToken?: string;
   subscribeTemplate: (templateId: string, isPublic?: boolean) => void;
+  connectionActive: boolean;
 };
 
 export const QueryStreamContext = createContext<QueryStream | undefined>(undefined);
@@ -63,7 +64,9 @@ const QueryStreamProvider = <T extends object>(props: PropsWithChildren<any>) =>
 
   useEffect(() => {
     const token = retrieveCredentials()?.token;
-    setPartyToken(token);
+    if (token) {
+      setPartyToken(token);
+    }
   }, []);
 
   const publicParty = useWellKnownParties()?.parties?.publicParty || 'Public';
@@ -83,6 +86,7 @@ const QueryStreamProvider = <T extends object>(props: PropsWithChildren<any>) =>
     contracts: partyContracts,
     errors: partyStreamErrors,
     loading: partyLoading,
+    active: connectionActive,
   } = useDamlStreamQuery(partyTemplateIds, partyToken);
   const {
     contracts: publicContracts,
@@ -118,6 +122,7 @@ const QueryStreamProvider = <T extends object>(props: PropsWithChildren<any>) =>
     publicLoading,
     partyLoading,
     publicToken,
+    connectionActive,
   });
 
   useEffect(() => {
@@ -127,6 +132,14 @@ const QueryStreamProvider = <T extends object>(props: PropsWithChildren<any>) =>
       publicLoading,
     }));
   }, [partyLoading, publicLoading]);
+
+  useEffect(() => {
+    console.log(`active changed: ${connectionActive}`);
+    setQueryStream(queryStream => ({
+      ...queryStream,
+      connectionActive,
+    }));
+  }, [connectionActive]);
 
   useEffect(() => {
     if (!_.isEqual(queryStream.partyContracts, partyContracts)) {
@@ -178,6 +191,11 @@ export function usePartyLoading() {
 export function useLoading() {
   const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
   return queryStream?.publicLoading || queryStream?.partyLoading;
+}
+
+export function useConnectionActive() {
+  const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
+  return queryStream?.connectionActive;
 }
 
 export function useContractQuery<T extends object, K, I extends string = string>(

--- a/ui2/src/websocket/queryStream.ts
+++ b/ui2/src/websocket/queryStream.ts
@@ -1,0 +1,229 @@
+import React, { PropsWithChildren, createContext, useEffect, useState, useMemo } from 'react';
+import _ from 'lodash';
+
+import { Template } from '@daml/types';
+
+import { computeCredentials, retrieveCredentials } from '../Credentials';
+import { DeploymentMode, deploymentMode, httpBaseUrl, ledgerId, dablHostname } from '../config';
+
+import useDamlStreamQuery, { StreamErrors } from './websocket';
+import { CreateEvent } from '@daml/ledger';
+import { useWellKnownParties } from '@daml/hub-react/lib';
+
+export const AS_PUBLIC = true;
+
+export type QueryStream = {
+  publicTemplateIds: string[];
+  publicContracts: CreateEvent<any, any, any>[];
+  partyTemplateIds: string[];
+  partyContracts: CreateEvent<any, any, any>[];
+  streamErrors: any[] | undefined;
+  publicLoading: boolean;
+  partyLoading: boolean;
+  publicToken?: string;
+  subscribeTemplate: (templateId: string, isPublic?: boolean) => void;
+};
+
+export const QueryStreamContext = createContext<QueryStream | undefined>(undefined);
+
+type PublicTokenAPIResult =
+  | {
+      access_token: string;
+    }
+  | undefined;
+
+export const getPublicToken = async (publicParty: string): Promise<string | undefined> => {
+  let publicToken = undefined;
+
+  if (deploymentMode === DeploymentMode.DEV) {
+    publicToken = computeCredentials(publicParty).token;
+  } else {
+    const url = new URL(httpBaseUrl || 'http://localhost:3000');
+
+    const result: PublicTokenAPIResult = await fetch(
+      `https://${url.hostname}/api/ledger/${ledgerId}/public/token`,
+      { method: 'POST' }
+    ).then(response => response.json());
+
+    publicToken = result?.access_token;
+  }
+
+  return publicToken;
+};
+
+const QueryStreamProvider = <T extends object>(props: PropsWithChildren<any>) => {
+  const { children } = props;
+  const [publicTemplateIds, setPublicTemplateIds] = useState<string[]>([]);
+  const [partyTemplateIds, setPartyTemplateIds] = useState<string[]>([]);
+
+  const [partyToken, setPartyToken] = useState<string>();
+  const [publicToken, setPublicToken] = useState<string>();
+
+  const [streamErrors, setStreamErrors] = useState<StreamErrors[]>();
+
+  useEffect(() => {
+    const token = retrieveCredentials()?.token;
+    setPartyToken(token);
+  }, []);
+
+  const publicParty = useWellKnownParties()?.parties?.publicParty || 'Public';
+  useEffect(() => {
+    getPublicToken(publicParty).then(token => {
+      if (token) {
+        setPublicToken(token);
+        setQueryStream(queryStream => ({
+          ...queryStream,
+          publicToken: token,
+        }));
+      }
+    });
+  }, [publicParty]);
+
+  const {
+    contracts: partyContracts,
+    errors: partyStreamErrors,
+    loading: partyLoading,
+  } = useDamlStreamQuery(partyTemplateIds, partyToken);
+  const {
+    contracts: publicContracts,
+    errors: publicStreamErrors,
+    loading: publicLoading,
+  } = useDamlStreamQuery(publicTemplateIds, publicToken);
+
+  useEffect(() => {
+    if (partyStreamErrors) {
+      setStreamErrors(errors => errors?.concat([partyStreamErrors]) || [partyStreamErrors]);
+    }
+
+    if (publicStreamErrors) {
+      setStreamErrors(errors => errors?.concat([publicStreamErrors]) || [publicStreamErrors]);
+    }
+  }, [partyStreamErrors, publicStreamErrors]);
+
+  const subscribeTemplate = (templateId: string, asPublic?: boolean) => {
+    if (asPublic) {
+      setPublicTemplateIds(templateIds => [...templateIds, templateId]);
+    } else {
+      setPartyTemplateIds(templateIds => [...templateIds, templateId]);
+    }
+  };
+
+  const [queryStream, setQueryStream] = useState<QueryStream>({
+    publicTemplateIds: [],
+    publicContracts: [],
+    partyTemplateIds: [],
+    partyContracts: [],
+    streamErrors: [],
+    subscribeTemplate,
+    publicLoading,
+    partyLoading,
+    publicToken,
+  });
+
+  useEffect(() => {
+    setQueryStream(queryStream => ({
+      ...queryStream,
+      partyLoading,
+      publicLoading,
+    }));
+  }, [partyLoading, publicLoading]);
+
+  useEffect(() => {
+    if (!_.isEqual(queryStream.partyContracts, partyContracts)) {
+      setQueryStream(queryStream => ({
+        ...queryStream,
+        partyTemplateIds,
+        partyContracts,
+      }));
+    }
+  }, [partyContracts, partyTemplateIds, queryStream.partyContracts]);
+
+  useEffect(() => {
+    if (!_.isEqual(queryStream.publicContracts, publicContracts)) {
+      setQueryStream(queryStream => ({
+        ...queryStream,
+        publicTemplateIds,
+        publicContracts,
+      }));
+    }
+  }, [publicContracts, publicTemplateIds, queryStream.publicContracts]);
+
+  useEffect(() => {
+    if (!_.isEqual(queryStream.streamErrors, streamErrors)) {
+      setQueryStream(queryStream => ({
+        ...queryStream,
+        streamErrors,
+      }));
+    }
+  }, [streamErrors, queryStream.streamErrors]);
+
+  return React.createElement(QueryStreamContext.Provider, { value: queryStream }, children);
+};
+
+export function usePublicToken() {
+  const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
+  return queryStream?.publicToken;
+}
+
+export function usePublicLoading() {
+  const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
+  return queryStream?.publicLoading;
+}
+
+export function usePartyLoading() {
+  const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
+  return queryStream?.partyLoading;
+}
+
+export function useLoading() {
+  const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
+  return queryStream?.publicLoading || queryStream?.partyLoading;
+}
+
+export function useContractQuery<T extends object, K, I extends string = string>(
+  template: Template<T, K, I>,
+  asPublic?: boolean
+) {
+  const queryStream: QueryStream | undefined = React.useContext(QueryStreamContext);
+
+  if (queryStream === undefined) {
+    throw new Error('useContractQuery must be called within a QueryStreamProvider');
+  }
+
+  const { templateId } = template;
+  const {
+    publicTemplateIds,
+    publicContracts,
+    partyTemplateIds,
+    partyContracts,
+    subscribeTemplate,
+  } = queryStream;
+
+  const filtered = useMemo(() => {
+    if (!!asPublic) {
+      return publicContracts.filter(c => c.templateId === templateId);
+    } else {
+      return partyContracts.filter(c => c.templateId === templateId);
+    }
+  }, [asPublic, templateId, publicContracts, partyContracts]);
+
+  useEffect(() => {
+    if (asPublic === AS_PUBLIC) {
+      if (!publicTemplateIds.find(id => id === templateId)) {
+        subscribeTemplate(templateId, AS_PUBLIC);
+      }
+    }
+  }, [asPublic, templateId, publicTemplateIds, subscribeTemplate]);
+
+  useEffect(() => {
+    if (asPublic !== AS_PUBLIC) {
+      if (!partyTemplateIds.find(id => id === templateId)) {
+        subscribeTemplate(templateId);
+      }
+    }
+  }, [asPublic, templateId, partyTemplateIds, subscribeTemplate]);
+
+  return filtered;
+}
+
+export default QueryStreamProvider;

--- a/ui2/src/websocket/queryStream.ts
+++ b/ui2/src/websocket/queryStream.ts
@@ -196,14 +196,22 @@ export function useContractQuery<T extends object, K, I extends string = string>
     publicContracts,
     partyTemplateIds,
     partyContracts,
+    partyLoading,
+    publicLoading,
     subscribeTemplate,
   } = queryStream;
 
   const filtered = useMemo(() => {
     if (!!asPublic) {
-      return publicContracts.filter(c => c.templateId === templateId);
+      return {
+        contracts: publicContracts.filter(c => c.templateId === templateId),
+        loading: publicLoading,
+      };
     } else {
-      return partyContracts.filter(c => c.templateId === templateId);
+      return {
+        contracts: partyContracts.filter(c => c.templateId === templateId),
+        loading: partyLoading,
+      };
     }
   }, [asPublic, templateId, publicContracts, partyContracts]);
 

--- a/ui2/src/websocket/websocket.ts
+++ b/ui2/src/websocket/websocket.ts
@@ -1,0 +1,149 @@
+import { useState, useEffect, useCallback } from 'react';
+
+import { ArchiveEvent, CreateEvent } from '@daml/ledger';
+
+import { deploymentMode, DeploymentMode, httpBaseUrl, ledgerId } from '../config';
+
+// A custom code to indicate that the websocket should not be reopened.
+// 4001 was picked arbitrarily from the range 4000-4999, which are codes that the official
+//     WebSocket spec defines as unreserved, and available for use by the application.
+const KEEP_CLOSED = 4001;
+
+const newDamlWebsocket = (token: string): WebSocket => {
+  const url = new URL(httpBaseUrl || 'http://localhost:7575');
+
+  const subprotocols = [`jwt.token.${token}`, 'daml.ws.auth'];
+  const apiUrl =
+    deploymentMode === DeploymentMode.DEV
+      ? `ws://${url.host}/v1/stream/query`
+      : `wss://${url.host}/data/${ledgerId}/v1/stream/query`;
+
+  return new WebSocket(apiUrl, subprotocols);
+};
+
+function isCreateEvent<T extends object, K, I extends string = string>(
+  event: object
+): event is { created: CreateEvent<T, K, I> } {
+  return 'created' in event;
+}
+
+function isArchiveEvent<T extends object, I extends string = string>(
+  event: object
+): event is { archived: ArchiveEvent<T, I> } {
+  return 'archived' in event;
+}
+
+function isWarningMessage(event: object): event is { warnings: object } {
+  return 'warnings' in event;
+}
+
+export type StreamErrors = {
+  errors: string[];
+};
+
+function isErrorMessage(event: object): event is StreamErrors {
+  return 'errors' in event;
+}
+
+function useDamlStreamQuery<T extends object, K, I extends string>(
+  templateIds: string[],
+  token?: string
+) {
+  const [websocket, setWebsocket] = useState<WebSocket | null>(null);
+  const [contracts, setContracts] = useState<CreateEvent<T, K, I>[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<StreamErrors>();
+
+  const messageHandlerScoped = useCallback(() => {
+    return (message: { data: string }) => {
+      const data: { events: any[]; offset: string | undefined } = JSON.parse(message.data);
+
+      if (data.offset !== undefined) {
+        setLoading(false);
+      }
+
+      if (isWarningMessage(data)) {
+        console.warn('Warning emitted from DAML websocket: ', data.warnings);
+      }
+
+      if (isErrorMessage(data)) {
+        console.error(`Errors emitted from DAML websocket: ${data.errors}. Shutting down stream.`);
+        setErrors(data);
+      }
+
+      const { events } = data;
+
+      if (events && events.length > 0) {
+        events.forEach(e => {
+          if (isCreateEvent(e)) {
+            const contract = e.created as CreateEvent<T, K, I>;
+            if (!contracts.find(c => c.contractId === contract.contractId)) {
+              setContracts(contracts => [...contracts, contract]);
+            }
+          }
+
+          if (isArchiveEvent(e)) {
+            const contractId = e.archived.contractId;
+            if (contracts.find(c => c.contractId === contractId)) {
+              setContracts(contracts => [...contracts.filter(c => c.contractId !== contractId)]);
+            }
+          }
+        });
+      }
+    };
+  }, [contracts, loading]);
+
+  const openWebsocket = useCallback(async (token: string, templateIds: string[]) => {
+    const ws = newDamlWebsocket(token);
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ templateIds }));
+    };
+
+    return ws;
+  }, []);
+
+  const closeWebsocket = useCallback(
+    (token: string, templateIds: string[]) => {
+      return (event: CloseEvent) => {
+        // if this connection was closed unintentionally, reopen it
+        if (event.code !== KEEP_CLOSED) {
+          openWebsocket(token, templateIds);
+        }
+      };
+    },
+    [openWebsocket]
+  );
+
+  useEffect(() => {
+    // initialize websocket
+    if (!websocket && !errors && token && templateIds.length > 0) {
+      openWebsocket(token, templateIds).then(ws => {
+        setWebsocket(ws);
+      });
+    }
+
+    return () => {
+      if (websocket) {
+        websocket.close(KEEP_CLOSED);
+        setWebsocket(null);
+      }
+    };
+  }, [errors, token, templateIds, websocket, setWebsocket, openWebsocket]);
+
+  useEffect(() => {
+    if (websocket && token) {
+      websocket.onclose = closeWebsocket(token, templateIds);
+    }
+  }, [templateIds, token, websocket, closeWebsocket]);
+
+  useEffect(() => {
+    if (websocket && token) {
+      websocket.onmessage = messageHandlerScoped();
+    }
+  }, [token, websocket, messageHandlerScoped]);
+
+  return { contracts, errors, loading };
+}
+
+export default useDamlStreamQuery;

--- a/ui2/src/websocket/websocket.ts
+++ b/ui2/src/websocket/websocket.ts
@@ -9,6 +9,15 @@ import { deploymentMode, DeploymentMode, httpBaseUrl, ledgerId } from '../config
 //     WebSocket spec defines as unreserved, and available for use by the application.
 const KEEP_CLOSED = 4001;
 
+// Number of retries allowed before waiting
+const RETRIES_ALLOWED = 2;
+
+// Time between retries
+const RETRY_TIME_INTERVAL = 5000;
+
+// Time between messages until websocket is considered inactive
+const TIME_UNTIL_INACTIVE = 10000;
+
 const newDamlWebsocket = (token: string): WebSocket => {
   const url = new URL(httpBaseUrl || 'http://localhost:7575');
 
@@ -51,11 +60,26 @@ function useDamlStreamQuery<T extends object, K, I extends string>(
 ) {
   const [websocket, setWebsocket] = useState<WebSocket | null>(null);
   const [contracts, setContracts] = useState<CreateEvent<T, K, I>[]>([]);
+  const [active, setActive] = useState(false);
   const [loading, setLoading] = useState(true);
   const [errors, setErrors] = useState<StreamErrors>();
+  const [timer, setTimer] = useState<ReturnType<typeof setInterval>>(
+    setInterval(() => clearInterval(timer), 1000)
+  );
+  const [retries, setRetries] = useState(0);
 
   const messageHandlerScoped = useCallback(() => {
     return (message: { data: string }) => {
+      if (timer != null) {
+        clearInterval(timer);
+        setTimer(
+          setInterval(() => {
+            setActive(false);
+            clearInterval(timer);
+          }, TIME_UNTIL_INACTIVE)
+        );
+      }
+      setActive(true);
       setLoading(false);
 
       const data: { events: any[]; offset: string | undefined } = JSON.parse(message.data);
@@ -104,13 +128,23 @@ function useDamlStreamQuery<T extends object, K, I extends string>(
   const closeWebsocket = useCallback(
     (token: string, templateIds: string[]) => {
       return (event: CloseEvent) => {
-        // if this connection was closed unintentionally, reopen it
+        // If this connection was closed unintentionally, set it to `null` to mark for the
+        // initialization effect hook to restart it.
         if (event.code !== KEEP_CLOSED) {
-          openWebsocket(token, templateIds);
+          setActive(false);
+          if (retries <= RETRIES_ALLOWED) {
+            setRetries(retries + 1);
+            setWebsocket(null);
+          } else {
+            setTimeout(() => {
+              setRetries(0);
+              setWebsocket(null);
+            }, RETRY_TIME_INTERVAL);
+          }
         }
       };
     },
-    [openWebsocket]
+    [openWebsocket, retries]
   );
 
   useEffect(() => {
@@ -123,6 +157,7 @@ function useDamlStreamQuery<T extends object, K, I extends string>(
 
     return () => {
       if (websocket) {
+        clearInterval(timer);
         websocket.close(KEEP_CLOSED);
         setWebsocket(null);
       }
@@ -141,7 +176,7 @@ function useDamlStreamQuery<T extends object, K, I extends string>(
     }
   }, [token, websocket, messageHandlerScoped]);
 
-  return { contracts, errors, loading };
+  return { contracts, errors, loading, active };
 }
 
 export default useDamlStreamQuery;

--- a/ui2/src/websocket/websocket.ts
+++ b/ui2/src/websocket/websocket.ts
@@ -56,11 +56,9 @@ function useDamlStreamQuery<T extends object, K, I extends string>(
 
   const messageHandlerScoped = useCallback(() => {
     return (message: { data: string }) => {
-      const data: { events: any[]; offset: string | undefined } = JSON.parse(message.data);
+      setLoading(false);
 
-      if (data.offset !== undefined) {
-        setLoading(false);
-      }
+      const data: { events: any[]; offset: string | undefined } = JSON.parse(message.data);
 
       if (isWarningMessage(data)) {
         console.warn('Warning emitted from DAML websocket: ', data.warnings);


### PR DESCRIPTION
pulls in the code from the old marketplace that pools query streams into a single websocket connection. Template names are subscribed to, and the connection is reestablished with the initial message resent to include the new template ID. 