### PR TITLE
add icon to table button

### DIFF
--- a/ui2/src/components/Table/StripedTable.tsx
+++ b/ui2/src/components/Table/StripedTable.tsx
@@ -16,9 +16,19 @@ const StripedTable = (props: {
   emptyLabel?: string;
   loading?: boolean;
   rowsClickable?: boolean;
+  clickableIcon?: JSX.Element;
   showLabel?: boolean;
 }) => {
-  const { headings, rows, rowsPerPage, emptyLabel, loading, rowsClickable, showLabel } = props;
+  const {
+    headings,
+    rows,
+    rowsPerPage,
+    emptyLabel,
+    loading,
+    rowsClickable,
+    showLabel,
+    clickableIcon,
+  } = props;
 
   const totalPages = rowsPerPage ? Math.ceil(rows.length / rowsPerPage) : 0;
 
@@ -46,6 +56,7 @@ const StripedTable = (props: {
                 {heading}
               </Table.HeaderCell>
             ))}
+            {!!clickableIcon && <Table.HeaderCell></Table.HeaderCell>}
           </Table.Row>
         </Table.Header>
         {loading ? (
@@ -73,6 +84,11 @@ const StripedTable = (props: {
                       {showLabel && <b className="label">{headings[j]}: </b>} {item}
                     </Table.Cell>
                   ))}
+                  {!!clickableIcon && (
+                    <Table.Cell key={row.elements.length + 1} textAlign={'right'}>
+                      {clickableIcon}
+                    </Table.Cell>
+                  )}
                 </Table.Row>
               ))
             ) : (

--- a/ui2/src/pages/clearing/Members.tsx
+++ b/ui2/src/pages/clearing/Members.tsx
@@ -17,6 +17,7 @@ import StripedTable from '../../components/Table/StripedTable';
 import MarginCallModal from './MarginCallModal';
 import MTMCalculationModal from './MTMCalculationModal';
 import { CreateEvent } from '@daml/ledger';
+import { ArrowRightIcon } from '../../icons/icons';
 
 const ClearingMembersComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = ({
   history,
@@ -59,6 +60,7 @@ const ClearingMembersComponent: React.FC<RouteComponentProps & ServicePageProps<
         headings={['Member', 'Clearing Account', 'Margin Account', 'In Good Standing']}
         loading={accountsLoading || depositsLoading || standingsLoading}
         rowsClickable
+        clickableIcon={<ArrowRightIcon />}
         rows={services.map(s => {
           const standing = standings.find(
             standing => standing.payload.customer === s.payload.customer

--- a/ui2/src/pages/custody/Assets.tsx
+++ b/ui2/src/pages/custody/Assets.tsx
@@ -11,6 +11,7 @@ import { Button, Header } from 'semantic-ui-react';
 import Tile from '../../components/Tile/Tile';
 import StripedTable from '../../components/Table/StripedTable';
 import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/Rule/AllocationAccount';
+import { ArrowRightIcon } from '../../icons/icons';
 
 const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = ({
   history,
@@ -51,6 +52,7 @@ const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>>
         headings={['Asset', 'Account', 'Owner']}
         loading={depositsLoading}
         rowsClickable
+        clickableIcon={<ArrowRightIcon />}
         rows={deposits.map(c => {
           return {
             elements: [
@@ -74,6 +76,7 @@ const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>>
       <StripedTable
         headings={['Account', 'Type', 'Provider', 'Owner', 'Role']}
         rowsClickable
+        clickableIcon={<ArrowRightIcon />}
         loading={accountsLoading || allocatedAccountsLoading}
         rows={allAccounts.map(a => {
           return {

--- a/ui2/src/pages/distribution/auction/Auctions.tsx
+++ b/ui2/src/pages/distribution/auction/Auctions.tsx
@@ -6,6 +6,7 @@ import { Auction } from '@daml.js/da-marketplace/lib/Marketplace/Distribution/Au
 import { getAuctionStatus } from '../Utils';
 import { Header, Icon } from 'semantic-ui-react';
 import StripedTable from '../../../components/Table/StripedTable';
+import { ArrowRightIcon } from '../../../icons/icons';
 
 const AuctionsComponent: React.FC<RouteComponentProps> = ({ history }: RouteComponentProps) => {
   const { contracts: auctions, loading: auctionsLoading } = useStreamQueries(Auction);
@@ -18,6 +19,7 @@ const AuctionsComponent: React.FC<RouteComponentProps> = ({ history }: RouteComp
         headings={['Provider', 'Client', 'Asset', 'Floor', 'Status']}
         loading={auctionsLoading}
         rowsClickable
+        clickableIcon={<ArrowRightIcon />}
         rows={auctions.map(c => {
           return {
             elements: [

--- a/ui2/src/pages/distribution/bidding/Auctions.tsx
+++ b/ui2/src/pages/distribution/bidding/Auctions.tsx
@@ -8,6 +8,7 @@ import { getBidStatus, getBidAllocation } from '../Utils';
 import StripedTable from '../../../components/Table/StripedTable';
 import Tile from '../../../components/Tile/Tile';
 import { Icon } from 'semantic-ui-react';
+import { ArrowRightIcon } from '../../../icons/icons';
 
 const BiddingAuctionsComponent: React.FC<RouteComponentProps> = ({
   history,
@@ -25,6 +26,7 @@ const BiddingAuctionsComponent: React.FC<RouteComponentProps> = ({
           headings={['Auction ID', 'Agent', 'Issuer', 'Asset', 'Quantity']}
           loading={biddingAuctionsLoading}
           rowsClickable
+          clickableIcon={<ArrowRightIcon />}
           rows={biddingAuctions.map(c => {
             return {
               elements: [

--- a/ui2/src/pages/issuance/Issuances.tsx
+++ b/ui2/src/pages/issuance/Issuances.tsx
@@ -6,6 +6,7 @@ import { usePartyName } from '../../config';
 import { Issuance } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/Model';
 import Tile from '../../components/Tile/Tile';
 import StripedTable from '../../components/Table/StripedTable';
+import { ArrowRightIcon } from '../../icons/icons';
 
 export const IssuancesTable: React.FC = () => {
   const { contracts: issuances, loading: issuancesLoading } = useStreamQueries(Issuance);
@@ -17,6 +18,7 @@ export const IssuancesTable: React.FC = () => {
       headings={['Issuing Agent', 'Issuer', 'Issuance ID', 'Issuance Account', 'Asset', 'Quantity']}
       loading={issuancesLoading}
       rowsClickable
+      clickableIcon={<ArrowRightIcon />}
       rows={issuances.map(c => {
         return {
           elements: [

--- a/ui2/src/pages/origination/Instruments.tsx
+++ b/ui2/src/pages/origination/Instruments.tsx
@@ -6,6 +6,7 @@ import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuan
 import StripedTable from '../../components/Table/StripedTable';
 import { Button } from 'semantic-ui-react';
 import Tile from '../../components/Tile/Tile';
+import { ArrowRightIcon } from '../../icons/icons';
 
 export const InstrumentsTable: React.FC = () => {
   const history = useHistory();
@@ -20,6 +21,7 @@ export const InstrumentsTable: React.FC = () => {
       headings={['Issuer', 'Signatories', 'Id', 'Version', 'Description']}
       loading={allInstrumentsLoading}
       rowsClickable
+      clickableIcon={<ArrowRightIcon />}
       rows={instruments.map(c => {
         return {
           elements: [

--- a/ui2/src/pages/origination/Requests.tsx
+++ b/ui2/src/pages/origination/Requests.tsx
@@ -11,6 +11,7 @@ import {
 } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/Service';
 import Tile from '../../components/Tile/Tile';
 import StripedTable from '../../components/Table/StripedTable';
+import { ArrowRightIcon } from '../../icons/icons';
 
 const RequestsComponent: React.FC<RouteComponentProps> = ({ history }: RouteComponentProps) => {
   const party = useParty();
@@ -50,6 +51,7 @@ const RequestsComponent: React.FC<RouteComponentProps> = ({ history }: RouteComp
           ]}
           loading={requestsLoading}
           rowsClickable
+          clickableIcon={<ArrowRightIcon />}
           rows={requests.map(c => {
             return {
               elements: [

--- a/ui2/src/pages/trading/Market.tsx
+++ b/ui2/src/pages/trading/Market.tsx
@@ -37,6 +37,7 @@ import {
 } from './Utils';
 import StripedTable from '../../components/Table/StripedTable';
 import { useHistory } from 'react-router-dom';
+import { ArrowRightIcon } from '../../icons/icons';
 
 type Props = {
   cid: string;
@@ -304,6 +305,7 @@ export const Market: React.FC<ServicePageProps<Service> & Props> = ({
               ]}
               loading={allOrders.loading}
               rowsClickable
+              clickableIcon={<ArrowRightIcon />}
               rows={orders.map(c => {
                 return {
                   elements: [

--- a/ui2/src/pages/trading/Order.tsx
+++ b/ui2/src/pages/trading/Order.tsx
@@ -19,7 +19,7 @@ import {
 } from './Utils';
 import { useHistory, useParams } from 'react-router-dom';
 import StripedTable from '../../components/Table/StripedTable';
-import { ArrowLeftIcon } from '../../icons/icons';
+import { ArrowLeftIcon, ArrowRightIcon } from '../../icons/icons';
 
 type Props = {
   listings: Readonly<CreateEvent<Listing, any, any>[]>;
@@ -176,6 +176,7 @@ export const TradingOrder: React.FC<Props> = ({ listings }: Props) => {
                 headings={['Match Id', 'Quantity', 'Price', 'Execution Date']}
                 loading={allOrders.loading}
                 rowsClickable
+                clickableIcon={<ArrowRightIcon />}
                 rows={order.payload.executions.map(e => {
                   return {
                     elements: [


### PR DESCRIPTION
adds a prop to `StripedTable` to show an icon

![Screen Shot 2021-05-04 at 4 27 53 PM](https://user-images.githubusercontent.com/71082197/117067109-9a445080-acf7-11eb-9456-c457894622ae.png)
