### PR TITLE
Point to new OSS claims repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 
 [submodule "contingent-claims"]
 	path = contingent-claims
-	url = git@github.com:DACH-NY/contingent-claims.git
+	url = git@github.com:digital-asset/contingent-claims.git
 	branch = master


### PR DESCRIPTION
This points to the new open-source repo under the digital-asset
organisation. The hashes differ as the history was re-written,
but the commit is the same.