### PR TITLE
added position holdings view for issuer of asset

### DIFF
--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -4,6 +4,7 @@ import Daml.Script
 import DA.Finance.Asset (AssetDeposit)
 import DA.Finance.Types (Id(..), Asset(..), Account(..))
 import DA.Set
+import qualified DA.Finance.Asset as AssetDeposit
 import qualified Marketplace.Operator.Role as Operator
 import qualified Marketplace.Clearing.Role as Clearinghouse
 import qualified Marketplace.Clearing.Service as Clearing
@@ -153,7 +154,6 @@ onboardCustomer Providers{..} party = do
   openAccountRequestCid <- submit customer do exerciseCmd custodyServiceCid Custody.RequestOpenAllocationAccount with accountId = marginAccountId; observers = fromList [clearinghouse, bank]; nominee = clearinghouse
   submit bank do exerciseCmd custodyServiceCid Custody.OpenAllocationAccount with openAllocationAccountRequestCid = openAccountRequestCid
 
-
   -- Trading and Listing services
   tradingServiceOfferCid <- submit exchange do exerciseCmd exchangeRoleCid Exchange.OfferTradingService with ..
   tradingServiceCid <- submit customer do exerciseCmd tradingServiceOfferCid Trading.Accept with tradingAccount = mainAccount; allocationAccount = exchangeLockedAccount
@@ -197,8 +197,11 @@ onboardAssets Providers{..} = do
     libor = Asset with id = liborId; quantity = 0.0
   pure Assets with ..
 
+
 depositAsset : Providers -> Customer -> Asset -> Id -> Script (ContractId AssetDeposit)
 depositAsset Providers{..} Customer{..} asset accountId = do
   -- Assets
   creditAccountRequestCid <- submit customer do exerciseCmd custodyServiceCid Custody.RequestCreditAccount with accountId = accountId; asset
-  submit bank do exerciseCmd custodyServiceCid Custody.CreditAccount with ..
+  depositCid <- submit bank do exerciseCmd custodyServiceCid Custody.CreditAccount with ..
+  (Some deposit) <- queryContractId bank depositCid
+  submit customer do exerciseCmd depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,306 @@
+{
+  "name": "da-marketplace-ui",
+  "version": "0.1.8",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@types/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
+    },
+    "@types/d3-scale": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.2.2.tgz",
+      "integrity": "sha512-qpQe8G02tzUwt9sdWX1h8A/W0Q1+N48wMnYXVOkrzeLUkCfvzJYV9Ee3aORCS4dN4ONRLFmMvaXdziQ29XGLjQ==",
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-shape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.0.0.tgz",
+      "integrity": "sha512-NLzD02m5PiD1KLEDjLN+MtqEcFYn4ZL9+Rqc9ZwARK1cpKZXd91zBETbe6wpBB6Ia0D0VZbpmbW3+BsGPGnCpA==",
+      "requires": {
+        "@types/d3-path": "^1"
+      }
+    },
+    "@types/d3-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.0.0.tgz",
+      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
+    },
+    "@types/resize-observer-browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+      "integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ=="
+    },
+    "css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
+    },
+    "d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "requires": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "requires": {
+        "d3-array": "2"
+      }
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "requires": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "fast-equals": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
+      "integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+    },
+    "internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "react-is": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-resize-detector": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.1.tgz",
+      "integrity": "sha512-54l8LWPBIRdtv0I/W/fMkmtgWX0mUIxKKAJKKimihNFueXtHuElDdXDyinQRmV7iku99AoyrSAhkCU/zjFG5+Q==",
+      "requires": {
+        "@types/resize-observer-browser": "^0.1.5",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "react-smooth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.0.tgz",
+      "integrity": "sha512-wK4dBBR6P21otowgMT9toZk+GngMplGS1O5gk+2WSiHEXIrQgDvhR5IIlT74Vtu//qpTcipkgo21dD7a7AUNxw==",
+      "requires": {
+        "fast-equals": "^2.0.0",
+        "raf": "^3.4.0",
+        "react-transition-group": "2.9.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
+    "recharts": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.0.9.tgz",
+      "integrity": "sha512-JNsXE80PuF3hugUCE7JqDOMSvu5xQLxtjOaqFKKZI2pCJ1PVJzhwDv4TWk0nO4AvADbeWzYEHbg8C5Hcrh42UA==",
+      "requires": {
+        "@types/d3-scale": "^3.0.0",
+        "@types/d3-shape": "^2.0.0",
+        "classnames": "^2.2.5",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "16.10.2",
+        "react-resize-detector": "^6.6.3",
+        "react-smooth": "^2.0.0",
+        "recharts-scale": "^0.4.4",
+        "reduce-css-calc": "^2.1.8"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "requires": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.0.1",
     "react-swipeable-views": "^0.13.9",
+    "recharts": "^2.0.9",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3",
     "tinycolor2": "^1.4.1",

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -20,6 +20,8 @@
 @use 'pages/custody/Account';
 @use 'pages/custody/New';
 @use 'pages/origination/New' as OriginationNew;
+@use 'pages/origination/Instrument';
+
 @use 'pages/notifications/Notifications';
 @use 'pages/distribution/auction/Auction';
 @use 'pages/distribution/bidding/Bidding';
@@ -205,6 +207,8 @@ html {
         @include Page.page();
         @include OverflowMenu.overflow-menu();
         @include OriginationNew.origination-new();
+        @include Instrument.instrument();
+
         @include Login.login-screen();
         @include QuickSetup.quick-setup();
         @include Landing.landing();

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -208,7 +208,6 @@ html {
         @include OverflowMenu.overflow-menu();
         @include OriginationNew.origination-new();
         @include Instrument.instrument();
-
         @include Login.login-screen();
         @include QuickSetup.quick-setup();
         @include Landing.landing();

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -56,15 +56,9 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
 
     return Promise.all(
       deposits.map(d => {
-        damlSetValues(d.payload.asset.id.signatories).map(signatory =>
-          console.log(d.payload.asset.id.label, signatory, !d.observers.includes(signatory))
-        );
-
         const newObservers = damlSetValues(d.payload.asset.id.signatories).filter(
           signatory => !d.observers.includes(signatory)
         );
-        console.log(newObservers);
-
         if (newObservers.length > 0) {
           addSignatoryAsDepositObserver(d, newObservers);
         }

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -40,7 +40,10 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
   const { contracts: assets, loading: assetsLoading } = useStreamQueries(AssetDescription);
   const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
 
-  const addSignatoryAsDepositObserver = async (deposit: CreateEvent<AssetDeposit>, newObs: any) => {
+  const addSignatoryAsDepositObserver = async (
+    deposit: CreateEvent<AssetDeposit>,
+    newObs: string[]
+  ) => {
     const newObservers = makeDamlSet([...deposit.observers, ...newObs]);
 
     await ledger.exercise(AssetDeposit.AssetDeposit_SetObservers, deposit.contractId, {
@@ -53,7 +56,6 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
       await halfSecondPromise();
       return updateDeposits(retries - 1);
     }
-
     return Promise.all(
       deposits.map(d => {
         const newObservers = damlSetValues(d.payload.asset.id.signatories).filter(

--- a/ui/src/pages/custody/Accounts.tsx
+++ b/ui/src/pages/custody/Accounts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import {
   Button,
@@ -23,9 +23,8 @@ import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asse
 import { InputDialog, InputDialogProps } from '../../components/InputDialog/InputDialog';
 import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
 import { Id } from '@daml.js/da-marketplace/lib/DA/Finance/Types';
+import { damlSetValues } from '../common';
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
-import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset';
-import { ServicePageProps, damlSetValues, makeDamlSet } from '../common';
 
 type Props = {
   services: Readonly<CreateEvent<Service, any, any>[]>;

--- a/ui/src/pages/custody/Accounts.tsx
+++ b/ui/src/pages/custody/Accounts.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import {
   Button,
@@ -23,8 +23,9 @@ import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asse
 import { InputDialog, InputDialogProps } from '../../components/InputDialog/InputDialog';
 import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
 import { Id } from '@daml.js/da-marketplace/lib/DA/Finance/Types';
-import { damlSetValues } from '../common';
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
+import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset';
+import { ServicePageProps, damlSetValues, makeDamlSet } from '../common';
 
 type Props = {
   services: Readonly<CreateEvent<Service, any, any>[]>;

--- a/ui/src/pages/landing/Landing.tsx
+++ b/ui/src/pages/landing/Landing.tsx
@@ -411,9 +411,6 @@ const Landing = () => {
             <Relationship key={p.provider} provider={p.provider} services={p.services} />
           ))}
         </div>
-        <div className="col col-2">
-          <h2>Exchanges</h2>
-        </div>
       </div>
     </div>
   );

--- a/ui/src/pages/origination/Instrument.scss
+++ b/ui/src/pages/origination/Instrument.scss
@@ -1,8 +1,14 @@
+@use '../../themes/variables' as v;
+
 @mixin instrument {
   .instrument {
     .position-holdings {
       display: flex;
       flex-direction: row;
+
+      .tile:nth-of-type(2) {
+        margin-left: v.$spacing-l;
+      }
       .pie-chart {
         display: flex;
         justify-content: center;
@@ -16,6 +22,12 @@
           path.recharts-pie-label-line {
             stroke: black;
           }
+        }
+      }
+      @media screen and (max-width: 1300px) {
+        flex-direction: column;
+        .tile:nth-of-type(2) {
+          margin-left: 0px;
         }
       }
     }

--- a/ui/src/pages/origination/Instrument.scss
+++ b/ui/src/pages/origination/Instrument.scss
@@ -1,0 +1,23 @@
+@mixin instrument {
+    .instrument {
+        .position-holdings {
+            display: flex;
+            flex-direction: row;
+            .pie-chart {
+                display: flex;
+                justify-content: center;
+                width: 100%;
+
+                .recharts-surface {
+                    overflow: overlay;
+                    text {
+                        fill: var(--text-color);
+                    }
+                    path.recharts-pie-label-line {
+                        stroke: black;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/src/pages/origination/Instrument.scss
+++ b/ui/src/pages/origination/Instrument.scss
@@ -1,23 +1,23 @@
 @mixin instrument {
-    .instrument {
-        .position-holdings {
-            display: flex;
-            flex-direction: row;
-            .pie-chart {
-                display: flex;
-                justify-content: center;
-                width: 100%;
+  .instrument {
+    .position-holdings {
+      display: flex;
+      flex-direction: row;
+      .pie-chart {
+        display: flex;
+        justify-content: center;
+        width: 100%;
 
-                .recharts-surface {
-                    overflow: overlay;
-                    text {
-                        fill: var(--text-color);
-                    }
-                    path.recharts-pie-label-line {
-                        stroke: black;
-                    }
-                }
-            }
+        .recharts-surface {
+          overflow: overlay;
+          text {
+            fill: var(--text-color);
+          }
+          path.recharts-pie-label-line {
+            stroke: black;
+          }
         }
+      }
     }
+  }
 }

--- a/ui/src/pages/origination/Instrument.tsx
+++ b/ui/src/pages/origination/Instrument.tsx
@@ -7,6 +7,8 @@ import { usePartyName } from '../../config';
 import { render } from '../../components/Claims/render';
 import { transformClaim } from '../../components/Claims/util';
 import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
+import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset';
+import { PieChart, Pie, Cell } from 'recharts';
 import Tile from '../../components/Tile/Tile';
 import StripedTable from '../../components/Table/StripedTable';
 import { ArrowLeftIcon } from '../../icons/icons';
@@ -21,6 +23,7 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
 
   const { contracts: instruments, loading: instrumentsLoading } =
     useStreamQueries(AssetDescription);
+  const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
   const instrument = instruments.find(c => c.contractId === cid);
 
   useEffect(() => {
@@ -29,14 +32,32 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
     render(el.current, data);
   }, [el, instrument]);
 
-  if (instrumentsLoading) {
+  if (instrumentsLoading || depositsLoading) {
     return <h5>Loading instrument...</h5>;
   }
 
   if (!instrument) return <h5>Instrument not found</h5>;
 
+  const COLORS = ['#5AF6AC', '#131720', '#FF29D0', '#835AF6', '#CBD0CB'];
+
+  let groupedDeposits = new Map<string, number>();
+
+  deposits
+    .filter(d => d.payload.asset.id.label === instrument.payload.assetId.label)
+    .map(d => {
+      let current = groupedDeposits.get(getName(d.payload.account.owner)) || 0;
+      groupedDeposits.set(getName(d.payload.account.owner), current + +d.payload.asset.quantity);
+    });
+
+  const pieData: {
+    name: string;
+    value: number;
+  }[] = Array.from(groupedDeposits.keys()).map(key => {
+    return { name: key, value: groupedDeposits.get(key) || 0 };
+  });
+
   return (
-    <div>
+    <div className="instrument">
       <Button className="ghost back-button" onClick={() => history.goBack()}>
         <ArrowLeftIcon /> back
       </Button>
@@ -60,7 +81,37 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
           ]}
         />
       </Tile>
+      <Tile header={<h3>Position Holdings</h3>}>
+        <div className="position-holdings">
+          <StripedTable
+            headings={['Investor', 'Quantity']}
+            loading={depositsLoading}
+            rows={Array.from(groupedDeposits.keys()).map(key => {
+              return {
+                elements: [key, groupedDeposits.get(key)],
+              };
+            })}
+          />
 
+          <div className="pie-chart">
+            <PieChart width={400} height={400}>
+              <Pie
+                dataKey="value"
+                data={pieData}
+                cx="50%"
+                cy="50%"
+                innerRadius={60}
+                outerRadius={80}
+                label={data => ` ${data.name} ${data.value} `}
+              >
+                {pieData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+            </PieChart>
+          </div>
+        </div>
+      </Tile>
       <Tile header={<h3>Claims</h3>}>
         <div ref={el} style={{ height: '100%' }} />
       </Tile>

--- a/ui/src/pages/origination/Instrument.tsx
+++ b/ui/src/pages/origination/Instrument.tsx
@@ -48,7 +48,7 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
       let current = groupedDeposits.get(getName(d.payload.account.owner)) || 0;
       groupedDeposits.set(getName(d.payload.account.owner), current + +d.payload.asset.quantity);
     });
-
+  const total = Array.from(groupedDeposits.values()).reduce((acc, item) => (acc += item), 0);
   const pieData: {
     name: string;
     value: number;
@@ -102,7 +102,7 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
                 cy="50%"
                 innerRadius={60}
                 outerRadius={80}
-                label={data => ` ${data.name} ${data.value} `}
+                label={data => ` ${data.name} ${((data.value / total) * 100).toFixed(1)}% `}
               >
                 {pieData.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />

--- a/ui/src/pages/origination/Instrument.tsx
+++ b/ui/src/pages/origination/Instrument.tsx
@@ -52,9 +52,11 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
   const pieData: {
     name: string;
     value: number;
-  }[] = Array.from(groupedDeposits.keys()).map(key => {
-    return { name: key, value: groupedDeposits.get(key) || 0 };
-  });
+  }[] = Array.from(groupedDeposits.keys())
+    .filter(key => getDataPercentage(groupedDeposits.get(key) || 0) > 5)
+    .map(key => {
+      return { name: key, value: groupedDeposits.get(key) || 0 };
+    });
 
   return (
     <div className="instrument">
@@ -81,8 +83,8 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
           ]}
         />
       </Tile>
-      <Tile header={<h3>Position Holdings</h3>}>
-        <div className="position-holdings">
+      <div className="position-holdings">
+        <Tile header={<h3>Position Holdings</h3>}>
           <StripedTable
             headings={['Investor', 'Quantity']}
             loading={depositsLoading}
@@ -92,7 +94,8 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
               };
             })}
           />
-
+        </Tile>
+        <Tile header={<h3>Allocations - Top 5%</h3>}>
           <div className="pie-chart">
             <PieChart width={400} height={400}>
               <Pie
@@ -102,7 +105,7 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
                 cy="50%"
                 innerRadius={60}
                 outerRadius={80}
-                label={data => ` ${data.name} ${((data.value / total) * 100).toFixed(1)}% `}
+                label={data => ` ${data.name} ${getDataPercentage(data.value)}% `}
               >
                 {pieData.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
@@ -110,11 +113,15 @@ export const Instrument: React.FC<RouteComponentProps> = () => {
               </Pie>
             </PieChart>
           </div>
-        </div>
-      </Tile>
+        </Tile>
+      </div>
       <Tile header={<h3>Claims</h3>}>
         <div ref={el} style={{ height: '100%' }} />
       </Tile>
     </div>
   );
+
+  function getDataPercentage(val: number) {
+    return +((val / total) * 100).toFixed(1);
+  }
 };

--- a/ui2/src/pages/issuance/Issuances.tsx
+++ b/ui2/src/pages/issuance/Issuances.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from "react"
+import { RouteComponentProps, withRouter } from "react-router-dom"
+import { Button, Form } from "semantic-ui-react"
+import { useStreamQueries } from "../../Main"
+import { usePartyName } from "../../config"
+import { Issuance } from "@daml.js/da-marketplace/lib/Marketplace/Issuance/Model"
+import Tile from "../../components/Tile/Tile"
+import StripedTable from "../../components/Table/StripedTable"
+import { ActionTile } from "../network/Actions"
+import { AssetDescription } from "@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription"
+import { AssetDeposit } from "@daml.js/da-marketplace/lib/DA/Finance/Asset"
+import { element } from "prop-types"
+
+export const IssuancesTable: React.FC = () => {
+    const { contracts: issuances, loading: issuancesLoading } = useStreamQueries(Issuance)
+    const { getName } = usePartyName("")
+
+    return (
+        <>
+            <ActionTile actions={[{ path: "/app/setup/issuance/new", label: "New Issuance" }]} />
+            <StripedTable
+                headings={[
+                    "Issuing Agent",
+                    "Issuer",
+                    "Issuance ID",
+                    "Issuance Account",
+                    "Asset",
+                    "Quantity",
+                ]}
+                loading={issuancesLoading}
+                rows={issuances.map(c => {
+                    return {
+                        elements: [
+                            getName(c.payload.provider),
+                            getName(c.payload.customer),
+                            c.payload.issuanceId,
+                            c.payload.accountId.label,
+                            c.payload.assetId.label,
+                            c.payload.quantity,
+                        ],
+                    }
+                })}
+            />
+        </>
+    )
+}
+
+export const groupDepositsByAsset = (deposits: AssetDeposit[]): Map<string, AssetDeposit[]> => {
+    let returnMap = new Map<string, AssetDeposit[]>()
+    deposits.map(d => {
+        const currentVal = returnMap.get(d.asset.id.label) || []
+        returnMap.set(d.asset.id.label, [...currentVal, d])
+    })
+    return returnMap
+}
+
+const IssuancesComponent: React.FC<RouteComponentProps> = ({ history }: RouteComponentProps) => {
+    return (
+        <div className='issuances'>
+            <Tile header={<h4>Actions</h4>}>
+                <Button
+                    secondary
+                    className='ghost'
+                    onClick={() => history.push("/app/issuance/new")}>
+                    New Issuance
+                </Button>
+            </Tile>
+
+            <Tile header={<h4>Issuances</h4>}>
+                <IssuancesTable />
+            </Tile>
+        </div>
+    )
+}
+
+export const Issuances = withRouter(IssuancesComponent)


### PR DESCRIPTION
The one caveat is that observers are added when the deposit is made by the investor from the UI, so when bootstrapping data locally the issuer will not be an observer of the asset until the investor's wallet screen is rendered. 

In a demo setting, when manually creating the deposits this should not be an issue.. 

<img width="1240" alt="Screen Shot 2021-05-19 at 11 29 48 AM" src="https://user-images.githubusercontent.com/40438835/118840616-8ff88980-b895-11eb-96c6-3dacd0fe5873.png">
