### PR TITLE
Add observers to issuance and credit requests, and pull through for all Asset Deposits

### DIFF
--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -93,17 +93,17 @@ onboardProviders = do
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = bank
   regulatorServiceCid             <- submit bank      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit bank      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Bank LegalName"; location = "Bank Location"; observers = [public]
+  identityVerificationRequestCid  <- submit bank      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Bank"; location = "Bank Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = exchange
   regulatorServiceCid             <- submit exchange      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit exchange      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Exchange LegalName"; location = "Exchange Location"; observers = [public]
+  identityVerificationRequestCid  <- submit exchange      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Exchange"; location = "Exchange Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = clearinghouse
   regulatorServiceCid             <- submit clearinghouse      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit clearinghouse      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "CCP LegalName"; location = "CCP Location"; observers = [public]
+  identityVerificationRequestCid  <- submit clearinghouse      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "CCP"; location = "CCP Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Clearing
@@ -171,7 +171,7 @@ onboardCustomer Providers{..} party = do
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = customer
   regulatorServiceCid             <- submit customer      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party <> " Legal Name"; location = party <> " Location"; observers = [public]
+  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party ; location = party <> " Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Bidding Service

--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -171,7 +171,7 @@ onboardCustomer Providers{..} party = do
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = customer
   regulatorServiceCid             <- submit customer      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party ; location = party <> " Location"; observers = [public]
+  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party; location = party <> " Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Bidding Service

--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -93,17 +93,17 @@ onboardProviders = do
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = bank
   regulatorServiceCid             <- submit bank      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit bank      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Bank"; location = "Bank Location"; observers = [public]
+  identityVerificationRequestCid  <- submit bank      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Bank LegalName"; location = "Bank Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = exchange
   regulatorServiceCid             <- submit exchange      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit exchange      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Exchange"; location = "Exchange Location"; observers = [public]
+  identityVerificationRequestCid  <- submit exchange      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "Exchange LegalName"; location = "Exchange Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = clearinghouse
   regulatorServiceCid             <- submit clearinghouse      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit clearinghouse      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "CCP"; location = "CCP Location"; observers = [public]
+  identityVerificationRequestCid  <- submit clearinghouse      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = "CCP LegalName"; location = "CCP Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Clearing
@@ -171,7 +171,7 @@ onboardCustomer Providers{..} party = do
 
   regulatorServiceOfferCid        <- submit operator  do exerciseCmd regulatorRoleCid Regulator.OfferRegulatorService with customer = customer
   regulatorServiceCid             <- submit customer      do exerciseCmd regulatorServiceOfferCid RegulatorService.Accept
-  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party; location = party <> " Location"; observers = [public]
+  identityVerificationRequestCid  <- submit customer      do exerciseCmd regulatorServiceCid RegulatorService.RequestIdentityVerification with legalName = party <> " Legal Name"; location = party <> " Location"; observers = [public]
   verifiedIdentity                <- submit operator  do exerciseCmd regulatorServiceCid RegulatorService.VerifyIdentity with ..
 
   -- Bidding Service
@@ -201,7 +201,7 @@ onboardAssets Providers{..} = do
 depositAsset : Providers -> Customer -> Asset -> Id -> Script (ContractId AssetDeposit)
 depositAsset Providers{..} Customer{..} asset accountId = do
   -- Assets
-  creditAccountRequestCid <- submit customer do exerciseCmd custodyServiceCid Custody.RequestCreditAccount with accountId = accountId; asset
+  creditAccountRequestCid <- submit customer do exerciseCmd custodyServiceCid Custody.RequestCreditAccount with accountId = accountId; asset; observers = fromList [bank, operator]
   depositCid <- submit bank do exerciseCmd custodyServiceCid Custody.CreditAccount with ..
   (Some deposit) <- queryContractId bank depositCid
   submit customer do exerciseCmd depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers

--- a/daml/Demo.daml
+++ b/daml/Demo.daml
@@ -4,6 +4,7 @@ import Common
 import ContingentClaims.Claim (Claim(Zero), serialize)
 import ContingentClaims.FinancialClaim (unrollDates)
 import Daml.Script
+import DA.Set
 import DA.Date (date, Month(..))
 import DA.Finance.Asset (AssetDeposit, AssetDeposit_Split(..))
 import DA.Finance.Asset.Settlement
@@ -50,7 +51,7 @@ examples Providers{..} Assets{..} issuer = do
       submit bank do exerciseCmd (issuer.issuanceServiceCid) Issuance.Originate with ..
 
     issue issuanceId assetId quantity = do
-      createIssuanceRequestCid <- submit issuer.customer $ exerciseCmd issuer.issuanceServiceCid Issuance.RequestCreateIssuance with ..
+      createIssuanceRequestCid <- submit issuer.customer $ exerciseCmd issuer.issuanceServiceCid Issuance.RequestCreateIssuance with observers = fromList [issuer.customer], ..
       submit bank $ exerciseCmd issuer.issuanceServiceCid $ Issuance.CreateIssuance with ..
 
     transfer : Customer -> Customer -> ContractId AssetDeposit -> Decimal -> Script (ContractId AssetDeposit, Optional (ContractId AssetDeposit))

--- a/daml/Demo.daml
+++ b/daml/Demo.daml
@@ -4,6 +4,7 @@ import Common
 import ContingentClaims.Claim (Claim(Zero), serialize)
 import ContingentClaims.FinancialClaim (unrollDates)
 import Daml.Script
+import DA.Set qualified as Set
 import DA.Date (date, Month(..))
 import DA.Finance.Asset (AssetDeposit, AssetDeposit_Split(..))
 import DA.Finance.Asset.Settlement
@@ -12,8 +13,6 @@ import Marketplace.Distribution.Role qualified as Distributor
 import Marketplace.Distribution.Auction.Service qualified as Auction
 import Marketplace.Issuance.Service qualified as Issuance
 import Tests.Utils
-
-import DA.Set qualified as Set
 
 demo : Script ()
 demo = do

--- a/daml/Demo.daml
+++ b/daml/Demo.daml
@@ -4,7 +4,7 @@ import Common
 import ContingentClaims.Claim (Claim(Zero), serialize)
 import ContingentClaims.FinancialClaim (unrollDates)
 import Daml.Script
-import DA.Set qualified as Set
+import DA.Set
 import DA.Date (date, Month(..))
 import DA.Finance.Asset (AssetDeposit, AssetDeposit_Split(..))
 import DA.Finance.Asset.Settlement
@@ -51,7 +51,7 @@ examples Providers{..} Assets{..} issuer = do
       submit bank do exerciseCmd (issuer.issuanceServiceCid) Issuance.Originate with ..
 
     issue issuanceId assetId quantity = do
-      createIssuanceRequestCid <- submit issuer.customer $ exerciseCmd issuer.issuanceServiceCid Issuance.RequestCreateIssuance with observers = Set.fromList [issuer.customer], ..
+      createIssuanceRequestCid <- submit issuer.customer $ exerciseCmd issuer.issuanceServiceCid Issuance.RequestCreateIssuance with observers = fromList [issuer.customer], ..
       submit bank $ exerciseCmd issuer.issuanceServiceCid $ Issuance.CreateIssuance with ..
 
     transfer : Customer -> Customer -> ContractId AssetDeposit -> Decimal -> Script (ContractId AssetDeposit, Optional (ContractId AssetDeposit))

--- a/daml/Demo.daml
+++ b/daml/Demo.daml
@@ -4,7 +4,6 @@ import Common
 import ContingentClaims.Claim (Claim(Zero), serialize)
 import ContingentClaims.FinancialClaim (unrollDates)
 import Daml.Script
-import DA.Set
 import DA.Date (date, Month(..))
 import DA.Finance.Asset (AssetDeposit, AssetDeposit_Split(..))
 import DA.Finance.Asset.Settlement
@@ -13,6 +12,8 @@ import Marketplace.Distribution.Role qualified as Distributor
 import Marketplace.Distribution.Auction.Service qualified as Auction
 import Marketplace.Issuance.Service qualified as Issuance
 import Tests.Utils
+
+import DA.Set qualified as Set
 
 demo : Script ()
 demo = do
@@ -51,7 +52,7 @@ examples Providers{..} Assets{..} issuer = do
       submit bank do exerciseCmd (issuer.issuanceServiceCid) Issuance.Originate with ..
 
     issue issuanceId assetId quantity = do
-      createIssuanceRequestCid <- submit issuer.customer $ exerciseCmd issuer.issuanceServiceCid Issuance.RequestCreateIssuance with observers = fromList [issuer.customer], ..
+      createIssuanceRequestCid <- submit issuer.customer $ exerciseCmd issuer.issuanceServiceCid Issuance.RequestCreateIssuance with observers = Set.fromList [issuer.customer], ..
       submit bank $ exerciseCmd issuer.issuanceServiceCid $ Issuance.CreateIssuance with ..
 
     transfer : Customer -> Customer -> ContractId AssetDeposit -> Decimal -> Script (ContractId AssetDeposit, Optional (ContractId AssetDeposit))

--- a/daml/Marketplace/Custody/Model.daml
+++ b/daml/Marketplace/Custody/Model.daml
@@ -74,6 +74,7 @@ template CreditAccountRequest
     customer : Party
     accountId : Id
     asset : Asset
+    observers: Set Party
   where
     signatory operator, provider, customer
 

--- a/daml/Marketplace/Custody/Service.daml
+++ b/daml/Marketplace/Custody/Service.daml
@@ -118,7 +118,8 @@ template Service
         do
           Custody.CreditAccountRequest{accountId; asset; observers} <- fetchAndArchive creditAccountRequestCid
           depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
-          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = observers
+          deposit <- fetch depositCid
+          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = observers `union` deposit.observers
 
       nonconsuming DebitAccount : Asset
         with

--- a/daml/Marketplace/Custody/Service.daml
+++ b/daml/Marketplace/Custody/Service.daml
@@ -116,9 +116,9 @@ template Service
         with
           creditAccountRequestCid : ContractId Custody.CreditAccountRequest
         do
-          Custody.CreditAccountRequest{accountId; asset; observers = assetObservers} <- fetchAndArchive creditAccountRequestCid
+          Custody.CreditAccountRequest{accountId; asset; observers} <- fetchAndArchive creditAccountRequestCid
           depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
-          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers
+          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = observers
 
       nonconsuming DebitAccount : Asset
         with

--- a/daml/Marketplace/Custody/Service.daml
+++ b/daml/Marketplace/Custody/Service.daml
@@ -1,6 +1,7 @@
 module Marketplace.Custody.Service where
 
 import DA.Finance.Asset
+import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 import DA.Finance.Utils (fetchAndArchive)
@@ -51,6 +52,7 @@ template Service
         with
           accountId : Id
           asset : Asset
+          observers: Set Party
         do
           create Custody.CreditAccountRequest with ..
 
@@ -92,7 +94,7 @@ template Service
           Custody.OpenAllocationAccountRequest{nominee; accountId; observers} <- fetchAndArchive openAllocationAccountRequestCid
 
           let account = Account with provider; owner = customer; id = accountId
-          create AllocationAccountRule with ..
+          create AllocationAccountRule with assetObservers = observers, ..
 
       nonconsuming CloseAccount : ()
         with
@@ -114,8 +116,9 @@ template Service
         with
           creditAccountRequestCid : ContractId Custody.CreditAccountRequest
         do
-          Custody.CreditAccountRequest{accountId; asset} <- fetchAndArchive creditAccountRequestCid
-          exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
+          Custody.CreditAccountRequest{accountId; asset; observers = assetObservers} <- fetchAndArchive creditAccountRequestCid
+          depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
+          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers
 
       nonconsuming DebitAccount : Asset
         with

--- a/daml/Marketplace/Issuance/Service.daml
+++ b/daml/Marketplace/Issuance/Service.daml
@@ -92,7 +92,7 @@ template Service
           let asset = Asset with id = assetId; quantity
           depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
           deposit <- fetch depositCid
-          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = observers `union` deposit.observers
+          depositCid <- exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = observers `union` deposit.observers
           pure (issuanceCid, depositCid)
 
       nonconsuming ReduceIssuance : ContractId Issuance

--- a/daml/Marketplace/Issuance/Service.daml
+++ b/daml/Marketplace/Issuance/Service.daml
@@ -1,6 +1,7 @@
 module Marketplace.Issuance.Service where
 
 import DA.Finance.Asset
+import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 import DA.Map qualified as Map
@@ -38,6 +39,7 @@ template Service
           accountId : Id
           assetId : Id
           quantity : Decimal
+          observers: Set Party
         do
           create CreateIssuanceRequest with ..
 
@@ -81,7 +83,7 @@ template Service
         with
           createIssuanceRequestCid : ContractId CreateIssuanceRequest
         do
-          CreateIssuanceRequest{issuanceId; assetId; accountId; quantity} <- fetch createIssuanceRequestCid
+          CreateIssuanceRequest{issuanceId; assetId; accountId; quantity; observers = assetObservers} <- fetch createIssuanceRequestCid
           archive createIssuanceRequestCid
 
           Some _ <- lookupByKey @AssetDescription assetId
@@ -89,6 +91,7 @@ template Service
 
           let asset = Asset with id = assetId; quantity
           depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
+          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers
           pure (issuanceCid, depositCid)
 
       nonconsuming ReduceIssuance : ContractId Issuance
@@ -157,6 +160,7 @@ template CreateIssuanceRequest
     assetId : Id
     accountId : Id
     quantity : Decimal
+    observers: Set Party
   where
     signatory operator, provider, customer
 

--- a/daml/Marketplace/Issuance/Service.daml
+++ b/daml/Marketplace/Issuance/Service.daml
@@ -5,7 +5,7 @@ import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 import DA.Map qualified as Map
-import DA.Set (Set, fromList)
+import DA.Set
 import Marketplace.Issuance.Model (Issuance(..))
 import Marketplace.Issuance.AssetDescription (AssetDescription(..), Claims)
 import Marketplace.Issuance.AssetDescription qualified as AssetDescription
@@ -83,7 +83,7 @@ template Service
         with
           createIssuanceRequestCid : ContractId CreateIssuanceRequest
         do
-          CreateIssuanceRequest{issuanceId; assetId; accountId; quantity; observers = assetObservers} <- fetch createIssuanceRequestCid
+          CreateIssuanceRequest{issuanceId; assetId; accountId; quantity; observers} <- fetch createIssuanceRequestCid
           archive createIssuanceRequestCid
 
           Some _ <- lookupByKey @AssetDescription assetId
@@ -91,7 +91,8 @@ template Service
 
           let asset = Asset with id = assetId; quantity
           depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
-          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers
+          deposit <- fetch depositCid
+          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = observers `union` deposit.observers
           pure (issuanceCid, depositCid)
 
       nonconsuming ReduceIssuance : ContractId Issuance

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -38,7 +38,7 @@ template AllocationAccountRule
         deposit <- fetch depositCid
         exerciseByKey @AssetSettlementRule deposit.account.id AssetSettlement_Debit with ..
       credit : Asset -> Update (ContractId AssetDeposit)
-      credit = \asset -> create AssetDeposit with observers = assetObservers, ..
+      credit = \asset -> create AssetDeposit with observers = assetObservers `union` observers, ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
       creditAccount = \account asset -> do
        depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -1,7 +1,7 @@
 module Marketplace.Rule.AllocationAccount where
 
 import DA.Record
-import DA.Set (Set, insert)
+import DA.Set 
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
 import DA.Finance.Asset (AssetDeposit(..))
@@ -41,8 +41,9 @@ template AllocationAccountRule
       credit = \asset -> create AssetDeposit with observers = assetObservers, ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
       creditAccount = \account asset -> do
-       depocitCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
-       exercise depocitCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers
+       depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+       deposit <- fetch depositCid
+       exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers `union` deposit.observers
 
     controller nominee, account.owner can
       nonconsuming Transfer : ContractId AssetDeposit

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -5,6 +5,8 @@ import DA.Set (Set, insert)
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
 import DA.Finance.Asset (AssetDeposit(..))
+import DA.Finance.Asset qualified as AssetDeposit
+
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_Credit(..), AssetSettlement_Debit(..), AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 
 type T = AllocationAccountRule
@@ -16,6 +18,7 @@ template AllocationAccountRule
     account : Account
     nominee : Party
     observers : Set Party
+    assetObservers : Set Party
   where
     signatory operator, provider, account.owner
     observer insert nominee observers
@@ -35,9 +38,11 @@ template AllocationAccountRule
         deposit <- fetch depositCid
         exerciseByKey @AssetSettlementRule deposit.account.id AssetSettlement_Debit with ..
       credit : Asset -> Update (ContractId AssetDeposit)
-      credit = \asset -> create AssetDeposit with ..
+      credit = \asset -> create AssetDeposit with observers = assetObservers, ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
-      creditAccount = \account asset -> exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+      creditAccount = \account asset -> do
+       depocitCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+       exercise depocitCid AssetDeposit.AssetDeposit_SetObservers with newObservers = assetObservers
 
     controller nominee, account.owner can
       nonconsuming Transfer : ContractId AssetDeposit

--- a/daml/Tests/BinaryOption.daml
+++ b/daml/Tests/BinaryOption.daml
@@ -93,7 +93,7 @@ requestExercise underlyingPrice observationDate = script do
       description = "Tesla Binary Option"
       safekeepingAccount = alice.mainAccount
       claims = serialize boClaims
-      observers = []
+      observers = [alice.mainAccount.provider, bob.mainAccount.provider]
   (optionDescCid, optionDesc) <- submit providers.bank $ exerciseCmd alice.issuanceServiceCid $ Originate origReqCid
 
   -- Alice issues the option
@@ -103,6 +103,7 @@ requestExercise underlyingPrice observationDate = script do
       accountId = Id (Set.fromList [alice.customer, providers.bank]) alice.mainAccount.id.label 0
       assetId = optionDesc.assetId
       quantity = 1000.0
+      observers = Set.fromList [alice.mainAccount.provider, bob.mainAccount.provider]
   (_issuanceCid, optionDepositCid) <- submit providers.bank $ exerciseCmd alice.issuanceServiceCid $ CreateIssuance createReqCid
 
   -- Alice gifts the option to Bob
@@ -118,6 +119,8 @@ requestExercise underlyingPrice observationDate = script do
   corpActReqCid <- submit alice.customer $ exerciseCmd alice.custodyServiceCid RequestCreditAccount with
     accountId = alice.mainAccount.id
     asset = usdAsset
+    observers = Set.fromList [alice.mainAccount.provider, bob.mainAccount.provider]
+
   corpActDepositCid <- submit providers.bank $ exerciseCmd alice.custodyServiceCid CreditAccount with
     creditAccountRequestCid = corpActReqCid
 

--- a/daml/Tests/Bond.daml
+++ b/daml/Tests/Bond.daml
@@ -110,6 +110,7 @@ requestExerciseBond usdAmount notional coupon dates = script do
       accountId = Id (Set.fromList [alice.customer, providers.bank]) alice.mainAccount.id.label 0
       assetId = optionDesc.assetId
       quantity = 1.0
+      observers = Set.fromList [alice.mainAccount.provider, bob.mainAccount.provider]
   (_, bondCid) <- submit providers.bank $ exerciseCmd alice.issuanceServiceCid $ CreateIssuance createReqCid
 
   -- Alice gifts the bond to Bob
@@ -122,6 +123,8 @@ requestExerciseBond usdAmount notional coupon dates = script do
   corpActReqCid <- submit alice.customer $ exerciseCmd alice.custodyServiceCid RequestCreditAccount with
     accountId = alice.mainAccount.id
     asset = usdAsset
+    observers = Set.fromList [alice.mainAccount.provider, bob.mainAccount.provider]
+
   corpActDepositCid <- submit providers.bank $ exerciseCmd alice.custodyServiceCid CreditAccount with
     creditAccountRequestCid = corpActReqCid
 

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -128,9 +128,7 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
       const service = clientServices.find(
         s => s.payload.provider === targetAccount.account.provider
       );
-      if (!service || !transferToAccount) {
-        return;
-      }
+      if (!service || !transferToAccount) return;
 
       await ledger.exercise(Service.RequestTransferDeposit, service.contractId, {
         accountId: targetAccount.account.id,

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -74,7 +74,6 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
       account: { label: 'Account', type: 'selection', items: [] },
       asset: { label: 'Asset', type: 'selection', items: assetNames },
       quantity: { label: 'Quantity', type: 'number' },
-      observers: { label: 'Add Asset Signatories as Observers', type: 'checkbox' },
     },
     onClose: async function (state: any | null) {},
   };
@@ -129,7 +128,9 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
       const service = clientServices.find(
         s => s.payload.provider === targetAccount.account.provider
       );
-      if (!service || !transferToAccount) return;
+      if (!service || !transferToAccount) {
+        return;
+      }
 
       await ledger.exercise(Service.RequestTransferDeposit, service.contractId, {
         accountId: targetAccount.account.id,
@@ -163,14 +164,17 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
       const service = clientServices.find(
         s => s.payload.provider === targetAccount.account.provider
       );
-      if (!service) return;
+      if (!service) {
+        return displayErrorMessage({
+          message: 'The account provider does not offer issuance services.',
+        });
+      }
 
-      await ledger
-        .exercise(Service.RequestCreditAccount, service.contractId, {
-          accountId: targetAccount.account.id,
-          asset: { id: asset.payload.assetId, quantity: state.quantity },
-          observers: makeDamlSet(state.observers ? asset.signatories : [])
-        })
+      await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
+        accountId: targetAccount.account.id,
+        asset: { id: asset.payload.assetId, quantity: state.quantity },
+        observers: makeDamlSet(asset.signatories),
+      });
     };
     setCreditDialogProps({
       ...defaultCreditRequestDialogProps,

--- a/ui/src/pages/custody/Accounts.tsx
+++ b/ui/src/pages/custody/Accounts.tsx
@@ -71,7 +71,6 @@ const AccountsComponent: React.FC<RouteComponentProps & Props> = ({
       account: { label: 'Account', type: 'selection', items: [] },
       asset: { label: 'Asset', type: 'selection', items: assetNames },
       quantity: { label: 'Quantity', type: 'number' },
-      observers: { label: 'Add Asset Signatories as Observers', type: 'checkbox' },
     },
     onClose: async function (state: any | null) {},
   };
@@ -93,8 +92,8 @@ const AccountsComponent: React.FC<RouteComponentProps & Props> = ({
       await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
         accountId: account.payload.account.id,
         asset: { id: asset.payload.assetId, quantity: state.quantity },
-        observers: makeDamlSet(state.observers ? asset.signatories : [])
-    });
+        observers: makeDamlSet(asset.signatories),
+      });
     };
     setCreditDialogProps({
       ...defaultCreditRequestDialogProps,

--- a/ui/src/pages/custody/Accounts.tsx
+++ b/ui/src/pages/custody/Accounts.tsx
@@ -71,6 +71,7 @@ const AccountsComponent: React.FC<RouteComponentProps & Props> = ({
       account: { label: 'Account', type: 'selection', items: [] },
       asset: { label: 'Asset', type: 'selection', items: assetNames },
       quantity: { label: 'Quantity', type: 'number' },
+      observers: { label: 'Add Asset Signatories as Observers', type: 'checkbox' },
     },
     onClose: async function (state: any | null) {},
   };
@@ -92,7 +93,8 @@ const AccountsComponent: React.FC<RouteComponentProps & Props> = ({
       await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
         accountId: account.payload.account.id,
         asset: { id: asset.payload.assetId, quantity: state.quantity },
-      });
+        observers: makeDamlSet(state.observers ? asset.signatories : [])
+    });
     };
     setCreditDialogProps({
       ...defaultCreditRequestDialogProps,

--- a/ui/src/pages/issuance/New.tsx
+++ b/ui/src/pages/issuance/New.tsx
@@ -48,12 +48,7 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
   const account = accounts.find(a => a.id.label === accountLabel);
 
   const canRequest =
-    !!assetLabel &&
-    !!asset &&
-    !!accountLabel &&
-    !!account &&
-    !!issuanceId &&
-    !!quantity;
+    !!assetLabel && !!asset && !!accountLabel && !!account && !!issuanceId && !!quantity;
 
   useEffect(() => {
     if (!el.current || !asset) return;

--- a/ui/src/pages/issuance/New.tsx
+++ b/ui/src/pages/issuance/New.tsx
@@ -15,6 +15,7 @@ import FormErrorHandled from '../../components/Form/FormErrorHandled';
 import { Button, Form, Header } from 'semantic-ui-react';
 import Tile from '../../components/Tile/Tile';
 import BackButton from '../../components/Common/BackButton';
+import { makeDamlSet } from '../common';
 
 type Props = {
   services: Readonly<CreateEvent<Service, any, any>[]>;
@@ -32,6 +33,7 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
   const [assetLabel, setAssetLabel] = useState('');
   const [accountLabel, setAccountLabel] = useState('');
   const [issuanceId, setIssuanceId] = useState('');
+  const [addObservers, setAddObservers] = useState<boolean>();
   const [quantity, setQuantity] = useState('');
 
   const ledger = useLedger();
@@ -47,7 +49,13 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
   const account = accounts.find(a => a.id.label === accountLabel);
 
   const canRequest =
-    !!assetLabel && !!asset && !!accountLabel && !!account && !!issuanceId && !!quantity;
+    !!assetLabel &&
+    !!asset &&
+    !!accountLabel &&
+    !!account &&
+    !!issuanceId &&
+    !!quantity &&
+    !!addObservers;
 
   useEffect(() => {
     if (!el.current || !asset) return;
@@ -71,6 +79,7 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
       accountId: account.id,
       assetId: asset.payload.assetId,
       quantity,
+      observers: makeDamlSet(addObservers ? asset.signatories : []),
     });
     history.push('/app/manage/issuance');
   };
@@ -127,6 +136,10 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
           placeholder="Quantity"
           value={quantity}
           onChange={e => setQuantity(e.currentTarget.value)}
+        />
+        <Form.Checkbox
+          label={<Header as="h4">Add Asset Signatories as Observers</Header>}
+          onChange={(_, change) => setAddObservers(change.checked)}
         />
 
         <Button type="submit" disabled={!canRequest} className="ghost">

--- a/ui/src/pages/issuance/New.tsx
+++ b/ui/src/pages/issuance/New.tsx
@@ -33,7 +33,6 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
   const [assetLabel, setAssetLabel] = useState('');
   const [accountLabel, setAccountLabel] = useState('');
   const [issuanceId, setIssuanceId] = useState('');
-  const [addObservers, setAddObservers] = useState<boolean>();
   const [quantity, setQuantity] = useState('');
 
   const ledger = useLedger();
@@ -54,8 +53,7 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
     !!accountLabel &&
     !!account &&
     !!issuanceId &&
-    !!quantity &&
-    !!addObservers;
+    !!quantity;
 
   useEffect(() => {
     if (!el.current || !asset) return;
@@ -79,7 +77,7 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
       accountId: account.id,
       assetId: asset.payload.assetId,
       quantity,
-      observers: makeDamlSet(addObservers ? asset.signatories : []),
+      observers: makeDamlSet(asset.signatories),
     });
     history.push('/app/manage/issuance');
   };
@@ -136,10 +134,6 @@ const NewComponent: React.FC<RouteComponentProps & Props> = ({
           placeholder="Quantity"
           value={quantity}
           onChange={e => setQuantity(e.currentTarget.value)}
-        />
-        <Form.Checkbox
-          label={<Header as="h4">Add Asset Signatories as Observers</Header>}
-          onChange={(_, change) => setAddObservers(change.checked)}
         />
 
         <Button type="submit" disabled={!canRequest} className="ghost">

--- a/ui/src/pages/origination/Instrument.scss
+++ b/ui/src/pages/origination/Instrument.scss
@@ -2,10 +2,6 @@
 
 @mixin instrument {
   .instrument {
-    .position-holdings {
-      display: flex;
-      flex-direction: row;
-
       .tile:nth-of-type(2) {
         margin-left: v.$spacing-l;
       }
@@ -29,7 +25,6 @@
         .tile:nth-of-type(2) {
           margin-left: 0px;
         }
-      }
     }
   }
 }

--- a/ui/src/pages/origination/Instrument.scss
+++ b/ui/src/pages/origination/Instrument.scss
@@ -2,29 +2,26 @@
 
 @mixin instrument {
   .instrument {
-      .tile:nth-of-type(2) {
-        margin-left: v.$spacing-l;
-      }
-      .pie-chart {
-        display: flex;
-        justify-content: center;
-        width: 100%;
+    .pie-chart {
+      display: flex;
+      justify-content: center;
+      width: 100%;
 
-        .recharts-surface {
-          overflow: overlay;
-          text {
-            fill: var(--text-color);
-          }
-          path.recharts-pie-label-line {
-            stroke: black;
-          }
+      .recharts-surface {
+        overflow: overlay;
+        text {
+          fill: var(--text-color);
+        }
+        path.recharts-pie-label-line {
+          stroke: black;
         }
       }
-      @media screen and (max-width: 1300px) {
-        flex-direction: column;
-        .tile:nth-of-type(2) {
-          margin-left: 0px;
-        }
+    }
+    @media screen and (max-width: 1300px) {
+      flex-direction: column;
+      .tile:nth-of-type(2) {
+        margin-left: 0px;
+      }
     }
   }
 }


### PR DESCRIPTION
We can make this optional for the user, but for now I just added the observers in all requests (the field is not part of the form that a user fills out to create an issuance or asset deposit)