### PR TITLE
Self ref services

### DIFF
--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -113,7 +113,7 @@ onboardProviders = do
   submit bank do exerciseCmd custodyServiceCid Custody.OpenAccount with openAccountRequestCid = openAccountRequestCid
 
   clearingRoleOfferCid  <- submit operator do exerciseCmd operatorRoleCid Operator.OfferClearingRole with provider = clearinghouse
-  (clearingRoleCid, clearingServiceCid, marketServiceCid)       <- submit clearinghouse do exerciseCmd clearingRoleOfferCid Clearinghouse.Accept with ccpAccount = clearinghouseAccount; ..
+  (clearingRoleCid, marketServiceCid)       <- submit clearinghouse do exerciseCmd clearingRoleOfferCid Clearinghouse.Accept with ccpAccount = clearinghouseAccount; ..
   pure Providers with ..
 
 onboardCustomer : Providers -> Text -> Script Customer

--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -74,7 +74,7 @@ onboardProviders = do
   (custodianRoleCid, issuanceServiceCid, custodyServiceCid)          <- submit bank      do exerciseCmd custodianRoleOfferCid Custodian.Accept
 
   exchangeRoleOfferCid  <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferExchangeRole with provider = exchange
-  (exchangeRoleCid, matchingServiceCid, settlementServiceCid) <- submit exchange  do exerciseCmd exchangeRoleOfferCid Exchange.Accept
+  (exchangeRoleCid, matchingServiceCid, listingServiceCid, settlementServiceCid) <- submit exchange  do exerciseCmd exchangeRoleOfferCid Exchange.Accept
 
   distributorRoleOfferCid   <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferDistributorRole with provider = bank
   distributorRoleCid        <- submit bank      do exerciseCmd distributorRoleOfferCid Distributor.Accept

--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -71,7 +71,7 @@ onboardProviders = do
   operatorRoleCid           <- submit operator  do createCmd Operator.Role with observers = fromList [public]; ..
 
   custodianRoleOfferCid     <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferCustodianRole with provider = bank
-  custodianRoleCid          <- submit bank      do exerciseCmd custodianRoleOfferCid Custodian.Accept
+  (custodianRoleCid, issuanceServiceCid, custodyServiceCid)          <- submit bank      do exerciseCmd custodianRoleOfferCid Custodian.Accept
 
   exchangeRoleOfferCid  <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferExchangeRole with provider = exchange
   (exchangeRoleCid, matchingServiceCid, settlementServiceCid) <- submit exchange  do exerciseCmd exchangeRoleOfferCid Exchange.Accept
@@ -113,8 +113,7 @@ onboardProviders = do
   submit bank do exerciseCmd custodyServiceCid Custody.OpenAccount with openAccountRequestCid = openAccountRequestCid
 
   clearingRoleOfferCid  <- submit operator do exerciseCmd operatorRoleCid Operator.OfferClearingRole with provider = clearinghouse
-  clearingRoleCid       <- submit clearinghouse do exerciseCmd clearingRoleOfferCid Clearinghouse.Accept with ccpAccount = clearinghouseAccount; ..
-
+  (clearingRoleCid, clearingServiceCid, marketServiceCid)       <- submit clearinghouse do exerciseCmd clearingRoleOfferCid Clearinghouse.Accept with ccpAccount = clearinghouseAccount; ..
   pure Providers with ..
 
 onboardCustomer : Providers -> Text -> Script Customer

--- a/daml/Common.daml
+++ b/daml/Common.daml
@@ -68,10 +68,10 @@ onboardProviders = do
   public <- allocatePartyWithHint "Public" $ PartyIdHint "Public"
 
   -- Roles
-  operatorRoleCid           <- submit operator  do createCmd Operator.Role with observers = fromList [public]; ..
+  operatorRoleCid <- submit operator  do createCmd Operator.Role with observers = fromList [public]; ..
 
-  custodianRoleOfferCid     <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferCustodianRole with provider = bank
-  (custodianRoleCid, issuanceServiceCid, custodyServiceCid)          <- submit bank      do exerciseCmd custodianRoleOfferCid Custodian.Accept
+  custodianRoleOfferCid  <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferCustodianRole with provider = bank
+  (custodianRoleCid, issuanceServiceCid, custodyServiceCid)  <- submit bank  do exerciseCmd custodianRoleOfferCid Custodian.Accept
 
   exchangeRoleOfferCid  <- submit operator  do exerciseCmd operatorRoleCid Operator.OfferExchangeRole with provider = exchange
   (exchangeRoleCid, matchingServiceCid, listingServiceCid, settlementServiceCid) <- submit exchange  do exerciseCmd exchangeRoleOfferCid Exchange.Accept

--- a/daml/Marketplace/Clearing/Role.daml
+++ b/daml/Marketplace/Clearing/Role.daml
@@ -105,8 +105,8 @@ template Request
         with
           observers : Set Party
         do
-          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount= ccpAccount, marginAccount=ccpAccount, ..
           marketCid      <- createOrLookup Market.Service with customer = provider, ..
+          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount= ccpAccount, marginAccount=ccpAccount, ..
           roleCid        <- createOrLookup Role with ..
           return (roleCid, clearingCid, marketCid)
 

--- a/daml/Marketplace/Clearing/Role.daml
+++ b/daml/Marketplace/Clearing/Role.daml
@@ -83,8 +83,8 @@ template Offer
         with
           ccpAccount : Account
         do
-          marketCid      <- createOrLookup Market.Service with customer = provider, ..
-          roleCid        <- createOrLookup Role with ..
+          marketCid <- createOrLookup Market.Service with customer = provider, ..
+          roleCid   <- createOrLookup Role with ..
           return (roleCid, marketCid)
 
       Decline : ()
@@ -104,8 +104,8 @@ template Request
         with
           observers : Set Party
         do
-          marketCid      <- createOrLookup Market.Service with customer = provider, ..
-          roleCid        <- createOrLookup Role with ..
+          marketCid <- createOrLookup Market.Service with customer = provider, ..
+          roleCid   <- createOrLookup Role with ..
           return (roleCid, marketCid)
 
       Reject : ()

--- a/daml/Marketplace/Clearing/Role.daml
+++ b/daml/Marketplace/Clearing/Role.daml
@@ -83,7 +83,7 @@ template Offer
         with
           ccpAccount : Account
         do
-          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount= ccpAccount, marginAccount=ccpAccount, ..
+          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount = ccpAccount, marginAccount = ccpAccount, ..
           marketCid      <- createOrLookup Market.Service with customer = provider, ..
           roleCid        <- createOrLookup Role with ..
           return (roleCid, clearingCid, marketCid)
@@ -106,7 +106,7 @@ template Request
           observers : Set Party
         do
           marketCid      <- createOrLookup Market.Service with customer = provider, ..
-          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount= ccpAccount, marginAccount=ccpAccount, ..
+          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount = ccpAccount, marginAccount = ccpAccount, ..
           roleCid        <- createOrLookup Role with ..
           return (roleCid, clearingCid, marketCid)
 

--- a/daml/Marketplace/Clearing/Role.daml
+++ b/daml/Marketplace/Clearing/Role.daml
@@ -79,14 +79,13 @@ template Offer
     signatory operator
 
     controller provider can
-      Accept : (ContractId Role, ContractId Clearing.Service, ContractId Market.Service)
+      Accept : (ContractId Role, ContractId Market.Service)
         with
           ccpAccount : Account
         do
-          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount = ccpAccount, marginAccount = ccpAccount, ..
           marketCid      <- createOrLookup Market.Service with customer = provider, ..
           roleCid        <- createOrLookup Role with ..
-          return (roleCid, clearingCid, marketCid)
+          return (roleCid, marketCid)
 
       Decline : ()
         do
@@ -101,14 +100,13 @@ template Request
     signatory provider
 
     controller operator can
-      Approve : (ContractId Role, ContractId Clearing.Service, ContractId Market.Service)
+      Approve : (ContractId Role, ContractId Market.Service)
         with
           observers : Set Party
         do
           marketCid      <- createOrLookup Market.Service with customer = provider, ..
-          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount = ccpAccount, marginAccount = ccpAccount, ..
           roleCid        <- createOrLookup Role with ..
-          return (roleCid, clearingCid, marketCid)
+          return (roleCid, marketCid)
 
       Reject : ()
         do

--- a/daml/Marketplace/Clearing/Role.daml
+++ b/daml/Marketplace/Clearing/Role.daml
@@ -79,11 +79,14 @@ template Offer
     signatory operator
 
     controller provider can
-      Accept : ContractId Role
+      Accept : (ContractId Role, ContractId Clearing.Service, ContractId Market.Service)
         with
           ccpAccount : Account
         do
-          createOrLookup Role with ..
+          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount= ccpAccount, marginAccount=ccpAccount, ..
+          marketCid      <- createOrLookup Market.Service with customer = provider, ..
+          roleCid        <- createOrLookup Role with ..
+          return (roleCid, clearingCid, marketCid)
 
       Decline : ()
         do
@@ -98,11 +101,14 @@ template Request
     signatory provider
 
     controller operator can
-      Approve : ContractId Role
+      Approve : (ContractId Role, ContractId Clearing.Service, ContractId Market.Service)
         with
           observers : Set Party
         do
-          createOrLookup Role with ..
+          clearingCid    <- createOrLookup Clearing.Service with customer = provider, clearingAccount= ccpAccount, marginAccount=ccpAccount, ..
+          marketCid      <- createOrLookup Market.Service with customer = provider, ..
+          roleCid        <- createOrLookup Role with ..
+          return (roleCid, clearingCid, marketCid)
 
       Reject : ()
         do

--- a/daml/Marketplace/Custody/Role.daml
+++ b/daml/Marketplace/Custody/Role.daml
@@ -2,6 +2,7 @@ module Marketplace.Custody.Role where
 
 import Marketplace.Custody.Service qualified as Custody
 import Marketplace.Issuance.Service qualified as Issuance
+import Marketplace.Utils
 import DA.Set (Set)
 
 template Role
@@ -63,9 +64,12 @@ template Offer
     signatory operator
 
     controller provider can
-      Accept : ContractId Role
+      Accept : (ContractId Role, ContractId Issuance.Service, ContractId Custody.Service)
         do
-          create Role with ..
+          custodyCid    <- createOrLookup Custody.Service with customer = provider, ..
+          issuanceCid   <- createOrLookup Issuance.Service with customer = provider, ..
+          roleCid       <- createOrLookup Role with ..
+          return (roleCid, issuanceCid, custodyCid)
 
       Decline : ()
         do
@@ -79,11 +83,14 @@ template Request
     signatory provider
 
     controller operator can
-      Approve : ContractId Role
+      Approve : (ContractId Role, ContractId Issuance.Service, ContractId Custody.Service)
         with
           observers : Set Party
         do
-          create Role with ..
+          custodyCid    <- createOrLookup Custody.Service with customer = provider, ..
+          issuanceCid   <- createOrLookup Issuance.Service with customer = provider, ..
+          roleCid <- createOrLookup Role with ..
+          return (roleCid, issuanceCid, custodyCid)
 
       Reject : ()
         do

--- a/daml/Marketplace/Custody/Role.daml
+++ b/daml/Marketplace/Custody/Role.daml
@@ -66,9 +66,9 @@ template Offer
     controller provider can
       Accept : (ContractId Role, ContractId Issuance.Service, ContractId Custody.Service)
         do
-          custodyCid    <- createOrLookup Custody.Service with customer = provider, ..
-          issuanceCid   <- createOrLookup Issuance.Service with customer = provider, ..
-          roleCid       <- createOrLookup Role with ..
+          custodyCid  <- createOrLookup Custody.Service with customer = provider, ..
+          issuanceCid <- createOrLookup Issuance.Service with customer = provider, ..
+          roleCid     <- createOrLookup Role with ..
           return (roleCid, issuanceCid, custodyCid)
 
       Decline : ()
@@ -87,9 +87,9 @@ template Request
         with
           observers : Set Party
         do
-          custodyCid    <- createOrLookup Custody.Service with customer = provider, ..
-          issuanceCid   <- createOrLookup Issuance.Service with customer = provider, ..
-          roleCid <- createOrLookup Role with ..
+          custodyCid  <- createOrLookup Custody.Service with customer = provider, ..
+          issuanceCid <- createOrLookup Issuance.Service with customer = provider, ..
+          roleCid     <- createOrLookup Role with ..
           return (roleCid, issuanceCid, custodyCid)
 
       Reject : ()

--- a/daml/Marketplace/Operator/Role.daml
+++ b/daml/Marketplace/Operator/Role.daml
@@ -7,7 +7,6 @@ import Marketplace.Distribution.Role qualified as Distributor
 import Marketplace.Settlement.Service qualified as Settlement
 import Marketplace.Issuance.Service qualified as Issuance
 import Marketplace.Custody.Service qualified as Custody
-import Marketplace.Clearing.Service qualified as ClearingService
 import Marketplace.Clearing.Market.Service qualified as Market
 import Marketplace.Trading.Role qualified as Exchange
 import Marketplace.Trading.Matching.Service qualified as Matching
@@ -105,7 +104,7 @@ template Role
         do
           create Clearing.Offer with ..
 
-      nonconsuming ApproveClearingRequest : (ContractId Clearing.Role, ContractId ClearingService.Service, ContractId Market.Service)
+      nonconsuming ApproveClearingRequest : (ContractId Clearing.Role, ContractId Market.Service)
         with
           clearingRequestCid : ContractId Clearing.Request
         do

--- a/daml/Marketplace/Operator/Role.daml
+++ b/daml/Marketplace/Operator/Role.daml
@@ -5,6 +5,10 @@ import Marketplace.Custody.Role qualified as Custodian
 import Marketplace.Clearing.Role qualified as Clearing
 import Marketplace.Distribution.Role qualified as Distributor
 import Marketplace.Settlement.Service qualified as Settlement
+import Marketplace.Issuance.Service qualified as Issuance
+import Marketplace.Custody.Service qualified as Custody
+import Marketplace.Clearing.Service qualified as ClearingService
+import Marketplace.Clearing.Market.Service qualified as Market
 import Marketplace.Trading.Role qualified as Exchange
 import Marketplace.Trading.Matching.Service qualified as Matching
 import DA.Set (Set)
@@ -27,7 +31,7 @@ template Role
         do
           create Custodian.Offer with ..
 
-      nonconsuming ApproveCustodianRequest : ContractId Custodian.Role
+      nonconsuming ApproveCustodianRequest : (ContractId Custodian.Role, ContractId Issuance.Service, ContractId Custody.Service)
         with
           custodianRequestCid : ContractId Custodian.Request
         do
@@ -99,7 +103,7 @@ template Role
         do
           create Clearing.Offer with ..
 
-      nonconsuming ApproveClearingRequest : ContractId Clearing.Role
+      nonconsuming ApproveClearingRequest : (ContractId Clearing.Role, ContractId ClearingService.Service, ContractId Market.Service)
         with
           clearingRequestCid : ContractId Clearing.Request
         do

--- a/daml/Marketplace/Operator/Role.daml
+++ b/daml/Marketplace/Operator/Role.daml
@@ -11,6 +11,8 @@ import Marketplace.Clearing.Service qualified as ClearingService
 import Marketplace.Clearing.Market.Service qualified as Market
 import Marketplace.Trading.Role qualified as Exchange
 import Marketplace.Trading.Matching.Service qualified as Matching
+import Marketplace.Listing.Service qualified as Listing
+
 import DA.Set (Set)
 
 template Role
@@ -43,7 +45,7 @@ template Role
         do
           create Exchange.Offer with ..
 
-      nonconsuming ApproveExchangeRequest : (ContractId Exchange.Role, ContractId Matching.Service, ContractId Settlement.Service)
+      nonconsuming ApproveExchangeRequest : (ContractId Exchange.Role, ContractId Matching.Service, ContractId Listing.Service, ContractId Settlement.Service)
         with
           exchangeRequestCid : ContractId Exchange.Request
         do

--- a/daml/Marketplace/Trading/Role.daml
+++ b/daml/Marketplace/Trading/Role.daml
@@ -21,7 +21,7 @@ template Role
 
     controller provider can
 
-      nonconsuming c : ContractId Trading.Offer
+      nonconsuming OfferTradingService : ContractId Trading.Offer
         with
           customer : Party
         do

--- a/daml/Marketplace/Trading/Role.daml
+++ b/daml/Marketplace/Trading/Role.daml
@@ -21,7 +21,7 @@ template Role
 
     controller provider can
 
-      nonconsuming OfferTradingService : ContractId Trading.Offer
+      nonconsuming c : ContractId Trading.Offer
         with
           customer : Party
         do

--- a/daml/Marketplace/Trading/Role.daml
+++ b/daml/Marketplace/Trading/Role.daml
@@ -66,12 +66,13 @@ template Offer
     signatory operator
 
     controller provider can
-      Accept : (ContractId Role, ContractId Matching.Service, ContractId Settlement.Service)
+      Accept : (ContractId Role, ContractId Matching.Service, ContractId Listing.Service, ContractId Settlement.Service)
         do
           matchingCid   <- createOrLookup Matching.Service with ..
           settlementCid <- createOrLookup Settlement.Service with ..
+          listingCid    <- createOrLookup Listing.Service with customer = provider, ..
           roleCid       <- createOrLookup Role with ..
-          return (roleCid, matchingCid, settlementCid)
+          return (roleCid, matchingCid, listingCid, settlementCid)
 
       Decline : ()
         do
@@ -85,14 +86,15 @@ template Request
     signatory provider
 
     controller operator can
-      Approve : (ContractId Role, ContractId Matching.Service, ContractId Settlement.Service)
+      Approve : (ContractId Role, ContractId Matching.Service,ContractId Listing.Service,  ContractId Settlement.Service)
         with
           observers : Set Party
         do
           matchingCid   <- createOrLookup Matching.Service with ..
           settlementCid <- createOrLookup Settlement.Service with ..
+          listingCid    <- createOrLookup Listing.Service with customer = provider, ..
           roleCid       <- createOrLookup Role with ..
-          return (roleCid, matchingCid, settlementCid)
+          return (roleCid, matchingCid, listingCid, settlementCid)
 
       Reject : ()
         do

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -21,11 +21,7 @@
     - Assign `Bank` the `Custody`, `Distribution`, and `Settlement` roles
     - Assign `Exchange` the `Custody`, `Trading`, `Matching`, and `Settlement` roles
     - Assign `Ccp` the `Clearing` role
-9. Drag and drop automation to specific parties: (then click Next)
-    - Assign `Bank` the `SettlementInstructionTrigger`
-    - Assign `Exchange` the `MatchingEngine`, and `SettlementInstructionTrigger`
-    - Assign `Ccp` the `ClearingTrigger`
-9. Request services from specific parties: (then click Next)
+8. Request services from specific parties: (then click Next)
     - As `Issuer` request `Custody`, `Issuance` services from `Bank`
     - As `Bank` request `Custody` services from `Alice`
     - As `Ccp` request `Custody` services from `Bank`
@@ -35,22 +31,22 @@
 
 ## Issuing new assets
 
-11. Login as `Issuer`
-13. `Issuer`: go to Wallet and create a regular account
+1. Login as `Issuer`
+2. `Issuer`: go to Wallet and create a regular account
     - **Provider**: `Bank`
     - **Account Name** : `MainIssuer-Bank`
     - **Account Type** : `Regular`
-14. `Issuer`: go to Wallet and create an allocation account
+3. `Issuer`: go to Wallet and create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `AllocIssuer-Bank`
     - **Account Type** : `Allocation`
     - **Nominee** : `Bank`
-15. `Issuer`: go to Setup and create a base instrument for USD
-16. `Issuer`: go to Setup and create a base instrument for BTC
-17. `Issuer`: go to Setup and create an issuance of USD
+4. `Issuer`: go to Setup and create a base instrument for USD
+5. `Issuer`: go to Setup and create a base instrument for BTC
+6. `Issuer`: go to Setup and create an issuance of USD
     - **Issuance ID**: `iss1`
     - **Quantity**: `1000`
-18. `Issuer`: go to Setup and create an issuance of BTC
+7. `Issuer`: go to Setup and create an issuance of BTC
     - **Issuance ID**: `iss2`
     - **Quantity**: `1000`
 
@@ -58,48 +54,48 @@
 
 Auctioning off assets
 
-19. `Issuer`: on Landing, request `Auction` service from the `Bank`
+1. `Issuer`: on Landing, request `Auction` service from the `Bank`
     - **Provider**: `Bank`
     - **Trading Account**: `MainIssuer-Bank`
     - **Allocation Account**: `AllocIssuer-Bank`
     - **Receivable Account**: `MainIssuer-Bank`
-20. `Issuer`: go to Setup and create a new auction
+2. `Issuer`: go to Setup and create a new auction
     - **Auctioned Asset** : `BTC`
     - **Quoted Asset** : `USD`
     - **Quantity** : `500`
     - **Floor Price** : `300`
     - **Auction ID** : `auc1`
-21. Login as `Alice`
-23. `Alice`: Go to Wallet, create a regular account with `Bank`
+3. Login as `Alice`
+4. `Alice`: Go to Wallet, create a regular account with `Bank`
     - **Provider**: `Bank`
     - **Account Name** : `MainAlice-Bank`
     - **Account Type** : `Regular`
-24. `Alice`: Click on newly created account row
-25. `Alice`: Deposit 5000 US Dollars to account
-26. `Alice`: Go to Wallet, create an allocation account
+5. `Alice`: Click on newly created account row
+6. `Alice`: Deposit 5000 US Dollars to account
+7. `Alice`: Go to Wallet, create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `AllocAlice-Bank`
     - **Account Type** : `Allocation`
     - **Nominee** : `Bank`
-27. `Alice`: Request `Bidding` service from `Bank`
+8. `Alice`: Request `Bidding` service from `Bank`
     - **Trading Account**: `MainAlice-Bank`
     - **Allocation Account**: `AllocAlice-Bank`
-28. Login as `Bank`
-29. `Bank`: Go to Auctions, click on the auction opened by the Issuer, and Request Bid from `Alice`
-30. Login as `Alice`
-31. `Alice`: Go to Bidding Auctions, click on the auction, and submit a Bid
+9. Login as `Bank`
+10. `Bank`: Go to Auctions, click on the auction opened by the Issuer, and Request Bid from `Alice`
+11. Login as `Alice`
+12. `Alice`: Go to Bidding Auctions, click on the auction, and submit a Bid
     - **Quantity**: `2`
     - **Price**: `500`
     - **Publish Bid**: ✅
-32. Login as `Bank`
-33. Go to auction, click `Close Auction`
+13. Login as `Bank`
+14. Go to auction, click `Close Auction`
 
 ## Secondary distribution
 
 Setting up tradeable, collateralized markets
 
-34. Login as `Exchange`
-36. `Exchange`: Go to Setup, Create New Listing
+1. Login as `Exchange`
+2. `Exchange`: Go to Setup, Create New Listing
     - **Traded Asset** : `BTC`
     - **Traded Asset Precision**: `6`
     - **Quoted Asset** : `USD`
@@ -109,23 +105,23 @@ Setting up tradeable, collateralized markets
     - **Symbol**: `BTCUSD`
     - **Description**: `Bitcoin vs USD`
     - **Cleared by**: `-- Collateralized Market --`
-37. Login as `Alice`
-39. `Alice`: Go to Wallet, create a regular account
+3. Login as `Alice`
+4. `Alice`: Go to Wallet, create a regular account
     - **Provider**: `Exchange`
     - **Account Name** : `MainAlice-Exchange`
     - **Account Type** : `Regular`
-40. `Alice`: Go to Wallet, create an allocation account
+5. `Alice`: Go to Wallet, create an allocation account
     - **Provider**: `Exchange`
     - **Account Name** : `AllocAlice-Exchange`
     - **Account Type** : `Allocation`
     - **Nominee** : `Exchange`
-41. `Alice`: Go to Wallet, click on row for `MainAlice-Exchange`
-42. `Alice`: Deposit 1000 USD into `MainAlice-Exchange`
-43. `Alice`: Request `Trading` service from `Exchange`
+6. `Alice`: Go to Wallet, click on row for `MainAlice-Exchange`
+7. `Alice`: Deposit 1000 USD into `MainAlice-Exchange`
+8. `Alice`: Request `Trading` service from `Exchange`
     - **Provider**: `Exchange`
     - **Trading Account**: `MainAlice-Exchange`
     - **Allocation Account**: `AllocAlice-Exchange`
-44. `Alice`: Go to BTCUSD Market, place an order
+9. `Alice`: Go to BTCUSD Market, place an order
     - **Buy**
     - **Limit**
     - **Time in Force** : `Good Till Cancelled`

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -26,7 +26,7 @@
     - As `Alice` request `Custody` services from `Bank`
     - As `Bob` request `Custody` services from `Bank`
     - As `Ccp` request `Custody` services from `Bank`
-    - As `Exchange` request `Listing` services from `Exchange`, and `MarketClearing` services from `Ccp`
+    - As `Exchange` request `MarketClearing` services from `Ccp`
 
 ## Issuing new assets
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -40,11 +40,11 @@
     - **Account Name** : `AllocIssuer-Bank`
     - **Account Type** : `Allocation`
     - **Nominee** : `Bank`
-15. `Issuer`: go to Setup and create a base instrument for USD
+4. `Issuer`: go to Setup and create a base instrument for USD
     - **Account** : MainIssuer-Bank
-16. `Issuer`: go to Setup and create a base instrument for BTC
+5. `Issuer`: go to Setup and create a base instrument for BTC
     - **Account** : MainIssuer-Bank
-17. `Issuer`: go to Setup and create an issuance of USD
+6. `Issuer`: go to Setup and create an issuance of USD
     - **Issuance ID**: `iss1`
     - **Account** : MainIssuer-Bank
     - **Quantity**: `1000`
@@ -74,9 +74,9 @@ Auctioning off assets
     - **Account Name** : `MainAlice-Bank`
     - **Account Type** : `Regular`
     - **Observers** : `Exchange`
-24. `Alice`: Click on newly created account row
-25. `Alice`: Deposit 5000 US Dollars to account
-26. `Alice`: Go to Wallet, create an allocation account
+5. `Alice`: Click on newly created account row
+6. `Alice`: Deposit 5000 US Dollars to account
+7. `Alice`: Go to Wallet, create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `AllocAlice-Bank`
     - **Account Type** : `Allocation`
@@ -98,11 +98,11 @@ Auctioning off assets
 
 Setting up tradeable, collateralized markets
 
-34. Login as `Exchange`
-35. On "Setup" page, click "Setup Automations"
+1. Login as `Exchange`
+2. On "Setup" page, click "Setup Automations"
     - If you are planning to use Exberry, deploy the Exberry Adapter and set up the integration in the console.
     - If you are not planning to use Exberry, deploy the `Matching Engine trigger`
-36. `Exchange`: Go to Setup, Create New Listing
+3. `Exchange`: Go to Setup, Create New Listing
     - **Traded Asset** : `BTC`
     - **Traded Asset Precision**: `6`
     - **Quoted Asset** : `USD`
@@ -112,46 +112,46 @@ Setting up tradeable, collateralized markets
     - **Symbol**: `BTCUSD`
     - **Description**: `Bitcoin vs USD`
     - **Cleared by**: `-- Collateralized Market --`
-37. Login as `Alice`
-39. `Alice`: If you skipped the Auction section, go to Wallet, create a regular account
+4. Login as `Alice`
+5. `Alice`: If you skipped the Auction section, go to Wallet, create a regular account
     - **Provider**: `Bank`
     - **Account Name** : `MainAlice-Bank`
     - **Account Type** : `Regular`
     - **Observers** : `Exchange`
-40. `Alice`: Go to Wallet, create an allocation account
+6. `Alice`: Go to Wallet, create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `AllocAlice-Exchange`
     - **Account Type** : `Allocation`
     - **Nominee** : `Exchange`
-41. `Alice`: Go to Wallet, click on row for `MainAlice-Bank`
-42. `Alice`: Deposit 1000 USD into `MainAlice-Bank`
-43. `Alice`: Request `Trading` service from `Exchange`
+7. `Alice`: Go to Wallet, click on row for `MainAlice-Bank`
+8. `Alice`: Deposit 1000 USD into `MainAlice-Bank`
+9. `Alice`: Request `Trading` service from `Exchange`
     - **Provider**: `Exchange`
     - **Trading Account**: `MainAlice-Bank`
     - **Allocation Account**: `AllocAlice-Exchange`
-9. `Alice`: Go to BTCUSD Market, place an order
+10. `Alice`: Go to BTCUSD Market, place an order
     - **Buy**
     - **Limit**
     - **Time in Force** : `Good Till Cancelled`
     - **Price** : `500`
     - **Quantity** : `2`
-45. Login as `Bob`
-47. `Bob`: Go to Wallet, create a regular account
+11. Login as `Bob`
+12. `Bob`: Go to Wallet, create a regular account
     - **Provider**: `Bank`
     - **Account Name** : `MainBob-Bank`
     - **Account Type** : `Regular`
     - **Observers** : `Exchange`
-48. `Bob`: Go to Wallet, create an allocation account
+13. `Bob`: Go to Wallet, create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `AllocBob-Exchange`
     - **Account Type** : `Allocation`
     - **Nominee** : `Exchange`
-49. `Bob`: Go to Wallet, click on row for `MainBob-Bank`, Deposit 500 BTC
-50. `Bob`: Request `Trading` service from `Exchange`
+14. `Bob`: Go to Wallet, click on row for `MainBob-Bank`, Deposit 500 BTC
+15. `Bob`: Request `Trading` service from `Exchange`
     - **Provider**: `Exchange`
     - **Trading Account**: `MainBob-Bank`
     - **Allocation Account**: `AllocBob-Exchange`
-51. `Bob`: Go to BTCUSD Market, place an order (to partially match `Alice`'s Buy)
+16. `Bob`: Go to BTCUSD Market, place an order (to partially match `Alice`'s Buy)
     - **Sell**
     - **Limit**
     - **Time in Force** : `Good Till Cancelled`
@@ -159,81 +159,81 @@ Setting up tradeable, collateralized markets
     - **Quantity** : `1.0`
 
 ## Setup Clearinghouse
-52. Login as `Ccp`
-53. `Ccp`: Go to Wallet, create a regular account
+1. Login as `Ccp`
+2. `Ccp`: Go to Wallet, create a regular account
     - **Provider**: `Bank`
     - **Account Name** : `Clearing-Bank`
     - **Account Type** : `Regular`
-54. `Ccp`: Go to Manage/Clearing and "Accept" Clearing Role
+3. `Ccp`: Go to Manage/Clearing and "Accept" Clearing Role
     - **Clearing Account**: `Clearing-Bank`
-55. Login as `Alice`
-56. `Alice`: Go to Wallet, create a regular account
+4. Login as `Alice`
+5. `Alice`: Go to Wallet, create a regular account
     - **Provider**: `Bank`
     - **Account Name** : `ClearingAlice-Bank`
     - **Account Type** : `Regular`
     - **Observers** : `Ccp`
-57. `Alice`: Go to Wallet, create an allocation account
+6. `Alice`: Go to Wallet, create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `MarginAlice-Bank`
     - **Account Type** : `Allocation`
     - **Nominee** : `Ccp`
-58. `Alice`: On Landing, click "Request Clearing Service"
+7. `Alice`: On Landing, click "Request Clearing Service"
     - **Provider**: `CCP`
     - **Clearing Account**: `ClearingAlice-Bank`
     - **Margin Account**: `MarginAlice-Bank`
-59. `Alice`: Go to Wallet, click on row for `ClearingAlice-Bank`, Deposit 10,000 USD
-60. Login as `Bob`
-61. `Bob`: Go to Wallet, create a regular account
+8. `Alice`: Go to Wallet, click on row for `ClearingAlice-Bank`, Deposit 10,000 USD
+9. Login as `Bob`
+10. `Bob`: Go to Wallet, create a regular account
     - **Provider**: `Bank`
     - **Account Name** : `ClearingBob-Bank`
     - **Account Type** : `Regular`
     - **Observers** : `Ccp`
-62. `Bob`: Go to Wallet, create an allocation account
+11. `Bob`: Go to Wallet, create an allocation account
     - **Provider**: `Bank`
     - **Account Name** : `MarginBob-Bank`
     - **Account Type** : `Allocation`
     - **Nominee** : `Ccp`
-63. `Bob`: On Landing, click "Request Clearing Service"
+12. `Bob`: On Landing, click "Request Clearing Service"
     - **Provider**: `CCP`
     - **Clearing Account**: `ClearingBob-Bank`
     - **Margin Account**: `MarginBob-Bank`
-64. `Bob`: Go to Wallet, click on row for `ClearingBob-Bank`, Deposit 10,000 USD
+13. `Bob`: Go to Wallet, click on row for `ClearingBob-Bank`, Deposit 10,000 USD
 
 ### Test Margin Calls
 Perform successful margin call for Alice
 
-65. Login as `Ccp`
-66. `Ccp`: on `Members` page, click "Perform Margin Call":
+1. Login as `Ccp`
+2. `Ccp`: on `Members` page, click "Perform Margin Call":
     - **Customer**: `Alice`
     - **Amount**: 5000
 
 Fail and retry a margin calculation for `Bob`
 
-67. `Ccp`: on `Members` page, click "Perform Margin Call":
+1. `Ccp`: on `Members` page, click "Perform Margin Call":
     - **Customer** : `Bob`
     - **Amount** : 12000
-68. Login as `Bob`
-69. `Bob`: Go to Wallet, click on row for `ClearingBob-Bank`, Deposit 5000 USD
-70. `Bob`: Go to Clearing page, click "Retry" on failed Margin Call
+2. Login as `Bob`
+3. `Bob`: Go to Wallet, click on row for `ClearingBob-Bank`, Deposit 5000 USD
+4. `Bob`: Go to Clearing page, click "Retry" on failed Margin Call
 
 
 ### Test Mark to Market
 Transfer funds from Alice to Bob via central countrerparty.
 
-71. `Ccp`: on `Members` page, click "Perform Mark to Market":
+1. `Ccp`: on `Members` page, click "Perform Mark to Market":
     - **Customer**: `Alice`
     - **Amount**: 5000
-72. `Ccp`: on `Members` page, click "Perform Mark to Market":
+2. `Ccp`: on `Members` page, click "Perform Mark to Market":
     - **Customer** : `Bob`
     - **Amount** : -5000
 
 ## Cleared Secondary Market
 Setting up tradeable, cleared markets
 
-73. Login as `Exchange`
-74. On landing page, click "Request Market Clearing"
+1. Login as `Exchange`
+2. On landing page, click "Request Market Clearing"
     - **Provider** : `Ccp`
-75. `Exchange`: Go to Setup, Create New Listing
+3. `Exchange`: Go to Setup, Create New Listing
     - **Traded Asset** : `BTC`
     - **Traded Asset Precision**: `6`
     - **Quoted Asset** : `USD`
@@ -243,21 +243,21 @@ Setting up tradeable, cleared markets
     - **Symbol**: `BTCUSD-CLR`
     - **Description**: `Cleared Bitcoin vs USD`
     - **Cleared by**: `CCP`
-76. Login as `Alice`
-77. `Alice`: Go to BTCUSD-CLR Market, place an order
+4. Login as `Alice`
+5. `Alice`: Go to BTCUSD-CLR Market, place an order
     - **Buy**
     - **Limit**
     - **Time in Force** : `Good Till Cancelled`
     - **Price** : `500`
     - **Quantity** : `2`
-78. Login as `Bob`
-79. `Bob`: Go to BTCUSD-CLR Market, place an order (to partially match `Alice`'s Buy)
+6. Login as `Bob`
+7. `Bob`: Go to BTCUSD-CLR Market, place an order (to partially match `Alice`'s Buy)
     - **Sell**
     - **Market**
     - **Time in Force** : `Good Till Cancelled`
     - **Quantity** : `1.0`
-80. Login as `Ccp`
-81. On Manage/Clearing, click "Request FV" next to Exchange's Market.Clearing role
+8. Login as `Ccp`
+9. On Manage/Clearing, click "Request FV" next to Exchange's Market.Clearing role
     - **Currency** : USD
 
 # Read More

--- a/ui/src/pages/QuickSetup/AddPartiesPage.tsx
+++ b/ui/src/pages/QuickSetup/AddPartiesPage.tsx
@@ -125,6 +125,7 @@ const AddPartiesPage = (props: { adminCredentials: Credentials }) => {
 
       <Button
         className="ghost next"
+        disabled={storedParties.length === 0}
         onClick={() => setLoadingStatus(LoadingStatus.CREATING_ADMIN_CONTRACTS)}
       >
         Next

--- a/ui/src/pages/QuickSetup/AddPartiesPage.tsx
+++ b/ui/src/pages/QuickSetup/AddPartiesPage.tsx
@@ -134,7 +134,7 @@ const AddPartiesPage = (props: { adminCredentials: Credentials }) => {
 
       <Button
         className="ghost next"
-        disabled={storedParties.length === 0}
+        disabled={parties.length === 0}
         onClick={() => setLoadingStatus(LoadingStatus.CREATING_ADMIN_CONTRACTS)}
       >
         Next

--- a/ui/src/pages/QuickSetup/QuickSetup.scss
+++ b/ui/src/pages/QuickSetup/QuickSetup.scss
@@ -184,7 +184,6 @@
       }
 
       .ghost.next {
-          
       }
 
       .custom-file-upload {

--- a/ui/src/pages/QuickSetup/QuickSetup.scss
+++ b/ui/src/pages/QuickSetup/QuickSetup.scss
@@ -255,7 +255,12 @@
         justify-content: space-between;
       }
       .message {
+        margin-top: $spacing-m;
         max-width: 300px;
+        display: flex;
+        .icon {
+          margin-right: $spacing-xs;
+        }
       }
       .request-select {
         margin-bottom: $spacing-s;
@@ -263,6 +268,7 @@
 
         a.ui.label {
           background-color: var(--cool-grey-100);
+          color: var(--cool-grey-10);
           .delete.icon {
             height: unset;
             color: var(--blue-50);

--- a/ui/src/pages/QuickSetup/QuickSetup.scss
+++ b/ui/src/pages/QuickSetup/QuickSetup.scss
@@ -260,6 +260,16 @@
       .request-select {
         margin-bottom: $spacing-s;
         width: 300px;
+
+        a.ui.label {
+          background-color: var(--cool-grey-100);
+          .delete.icon {
+            height: unset;
+            color: var(--blue-50);
+            font-weight: 100;
+            stroke-width: 40%;
+          }
+        }
       }
       button.ghost.request {
         align-self: flex-start;

--- a/ui/src/pages/QuickSetup/QuickSetup.scss
+++ b/ui/src/pages/QuickSetup/QuickSetup.scss
@@ -168,6 +168,15 @@
     }
 
     .add-parties {
+      .page-content {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        .party-names {
+          max-height: 90%;
+        }
+      }
       .upload-parties {
         display: flex;
         align-items: center;
@@ -181,9 +190,6 @@
           margin-left: $spacing-xl;
           justify-content: center;
         }
-      }
-
-      .ghost.next {
       }
 
       .custom-file-upload {

--- a/ui/src/pages/QuickSetup/QuickSetup.scss
+++ b/ui/src/pages/QuickSetup/QuickSetup.scss
@@ -183,6 +183,10 @@
         }
       }
 
+      .ghost.next {
+          
+      }
+
       .custom-file-upload {
         width: fit-content;
         height: 44px;

--- a/ui/src/pages/QuickSetup/RequestServicesPage.tsx
+++ b/ui/src/pages/QuickSetup/RequestServicesPage.tsx
@@ -243,14 +243,14 @@ const RequestForm = (props: {
             {creatingRequest ? 'Creating Request...' : 'Request'}
           </Button>
           {addedSuccessfully ? (
-            <p className="message">
+            <p className="p2 message">
               <IconCheck /> {itemListAsText(requestInfo?.services || [])} Successfully Requested
             </p>
           ) : (
             existingServices.length > 0 &&
             requestInfo?.provider &&
             requestInfo?.customer && (
-              <p className="message">
+              <p className="p2 message">
                 <InformationIcon /> {getName(requestInfo?.provider)} already provides{' '}
                 {itemListAsText(existingServices || [])} services to{' '}
                 {getName(requestInfo?.customer)}

--- a/ui/src/pages/QuickSetup/RequestServicesPage.tsx
+++ b/ui/src/pages/QuickSetup/RequestServicesPage.tsx
@@ -278,7 +278,7 @@ export const CreateServiceRequests = (props: {
   onFinish: (success: boolean) => void;
 }) => {
   const { requestInfo, onFinish } = props;
-  console.log('creating reqyest');
+
   const ledger = useLedger();
 
   const { provider, customer, services } = requestInfo;

--- a/ui/src/pages/QuickSetup/RequestServicesPage.tsx
+++ b/ui/src/pages/QuickSetup/RequestServicesPage.tsx
@@ -41,7 +41,7 @@ export interface IRequestServiceInfo {
 }
 
 // without the ability to create accounts from quick setup, these requests are the only ones supported at this stage
-export const SUPPORTED_REQUESTS = [
+const SUPPORTED_REQUESTS = [
   ServiceKind.MARKET_CLEARING,
   ServiceKind.LISTING,
   ServiceKind.CUSTODY,
@@ -273,7 +273,7 @@ const RequestForm = (props: {
   );
 };
 
-export const CreateServiceRequests = (props: {
+const CreateServiceRequests = (props: {
   requestInfo: IRequestServiceInfo;
   onFinish: (success: boolean) => void;
 }) => {

--- a/ui/src/pages/QuickSetup/RequestServicesPage.tsx
+++ b/ui/src/pages/QuickSetup/RequestServicesPage.tsx
@@ -58,9 +58,9 @@ const RequestServicesPage = (props: { adminCredentials: Credentials }) => {
   const [creatingRequest, setCreatingRequest] = useState(false);
   const [addedSuccessfully, setAddedSuccessfully] = useState(false);
 
-  const customer = requestInfo?.customer;
-
   useEffect(() => {
+    const customer = requestInfo?.customer;
+
     if (customer) {
       if (isHubDeployment) {
         setRequestInfo({
@@ -74,7 +74,7 @@ const RequestServicesPage = (props: { adminCredentials: Credentials }) => {
         });
       }
     }
-  }, [userParties, customer]);
+  }, [userParties, requestInfo]);
 
   const onFinishCreatingRequest = (success: boolean) => {
     if (success) {
@@ -267,8 +267,8 @@ const RequestForm = (props: {
           {services.map((s, i) => (
             <div className="party-name" key={i}>
               <p>
-                {s.contract.payload.provider} provides {s.service} service to{' '}
-                {s.contract.payload.customer}{' '}
+                {getName(s.contract.payload.provider)} provides {s.service} service to{' '}
+                {getName(s.contract.payload.customer)}{' '}
               </p>
             </div>
           ))}

--- a/ui/src/pages/QuickSetup/RequestServicesPage.tsx
+++ b/ui/src/pages/QuickSetup/RequestServicesPage.tsx
@@ -242,16 +242,20 @@ const RequestForm = (props: {
           >
             {creatingRequest ? 'Creating Request...' : 'Request'}
           </Button>
-          {addedSuccessfully && (
+          {addedSuccessfully ? (
             <p className="message">
               <IconCheck /> {itemListAsText(requestInfo?.services || [])} Successfully Requested
             </p>
-          )}
-          {existingServices.length > 0 && requestInfo?.provider && requestInfo?.customer && (
-            <p className="message">
-              <InformationIcon /> {getName(requestInfo?.provider)} already provides{' '}
-              {itemListAsText(existingServices || [])} services to {getName(requestInfo?.customer)}
-            </p>
+          ) : (
+            existingServices.length > 0 &&
+            requestInfo?.provider &&
+            requestInfo?.customer && (
+              <p className="message">
+                <InformationIcon /> {getName(requestInfo?.provider)} already provides{' '}
+                {itemListAsText(existingServices || [])} services to{' '}
+                {getName(requestInfo?.customer)}
+              </p>
+            )
           )}
         </Form>
         <div className="party-names">

--- a/ui/src/pages/QuickSetup/SelectRolesPage.tsx
+++ b/ui/src/pages/QuickSetup/SelectRolesPage.tsx
@@ -22,7 +22,7 @@ import {
   deployAutomation,
 } from '../../automation';
 import { retrieveParties } from '../../Parties';
-import Credentials from '../../Credentials';
+import Credentials, { computeToken } from '../../Credentials';
 import {
   httpBaseUrl,
   wsBaseUrl,
@@ -123,8 +123,6 @@ const DragAndDropRoles = () => {
   );
 
   async function createRoleContract(partyId: string, token: string, role: string) {
-    const operatorServiceContract = operatorService[0];
-
     if (
       findExistingRoleOffer(partyId, role as RoleKind) ||
       findExistingRole(partyId, role as RoleKind)
@@ -136,57 +134,39 @@ const DragAndDropRoles = () => {
 
     switch (role) {
       case RoleKind.CUSTODY:
-        await ledger.exercise(
-          OperatorService.OfferCustodianRole,
-          operatorServiceContract.contractId,
-          provider
-        );
+        doCreate(OperatorService.OfferCustodianRole, provider);
         return;
       case RoleKind.CLEARING:
-        await ledger.exercise(
-          OperatorService.OfferClearingRole,
-          operatorServiceContract.contractId,
-          provider
-        );
-        if (isHubDeployment) {
-          handleDeployment(token, MarketplaceTrigger.ClearingTrigger);
-        }
+        doCreate(OperatorService.OfferClearingRole, provider);
+        handleDeployment(token, MarketplaceTrigger.ClearingTrigger);
         return;
-
       case RoleKind.TRADING:
-        await ledger.exercise(
-          OperatorService.OfferExchangeRole,
-          operatorServiceContract.contractId,
-          provider
-        );
+        doCreate(OperatorService.OfferExchangeRole, provider);
         return;
-
       case RoleKind.SETTLEMENT:
-        await ledger.exercise(
-          OperatorService.OfferSettlementService,
-          operatorServiceContract.contractId,
-          provider
-        );
-
-        if (isHubDeployment) {
-          handleDeployment(token, MarketplaceTrigger.SettlementInstructionTrigger);
-        }
+        doCreate(OperatorService.OfferSettlementService, provider);
+        handleDeployment(token, MarketplaceTrigger.SettlementInstructionTrigger);
         return;
-
       case RoleKind.DISTRIBUTION:
-        await ledger.exercise(
-          OperatorService.OfferDistributorRole,
-          operatorServiceContract.contractId,
-          provider
-        );
+        doCreate(OperatorService.OfferDistributorRole, provider);
         return;
-
       default:
         throw new Error(`Unsupported role: ${role}`);
     }
   }
 
+  async function doCreate(
+    choice: Choice<OperatorService, any, ContractId<any>, string>,
+    provider: { provider: string }
+  ) {
+    const operatorServiceContract = operatorService[0];
+    return await ledger.exercise(choice, operatorServiceContract.contractId, provider);
+  }
+
   async function handleDeployment(token: string, autoName: string) {
+    if (!isHubDeployment) {
+      return;
+    }
     const trigger = allTriggers.find(auto => auto.startsWith(autoName));
 
     if (trigger) {
@@ -219,7 +199,9 @@ const PartyRowDropZone = (props: {
   const [deployedAutomations, setDeployedAutomations] = useState<PublishedInstance[]>([]);
   const [dragCount, setDragCount] = useState(0);
 
-  const token = parties.find(p => p.party === party.payload.customer)?.token;
+  const token =
+    parties.find(p => p.party === party.payload.customer)?.token ||
+    computeToken(party.payload.customer);
 
   const roles = allRoles
     .filter(r => r.contract.payload.provider === party.payload.customer)

--- a/ui/src/pages/QuickSetup/SelectRolesPage.tsx
+++ b/ui/src/pages/QuickSetup/SelectRolesPage.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import DamlLedger, { useLedger } from '@daml/react';
 import { CreateEvent } from '@daml/ledger';
+import { Choice, ContractId } from '@daml/types';
 
 import { Role as OperatorService } from '@daml.js/da-marketplace/lib/Marketplace/Operator/Role';
 import { VerifiedIdentity } from '@daml.js/da-marketplace/lib/Marketplace/Regulator/Model';

--- a/ui/src/pages/QuickSetup/SelectRolesPage.tsx
+++ b/ui/src/pages/QuickSetup/SelectRolesPage.tsx
@@ -130,6 +130,7 @@ const DragAndDropRoles = () => {
     ) {
       return;
     }
+    console.log('ereeerereeeeeeeeee');
 
     const provider = { provider: partyId };
 
@@ -200,10 +201,9 @@ const PartyRowDropZone = (props: {
 
   const [deployedAutomations, setDeployedAutomations] = useState<PublishedInstance[]>([]);
   const [dragCount, setDragCount] = useState(0);
-
-  const token =
-    parties.find(p => p.party === party.payload.customer)?.token ||
-    computeToken(party.payload.customer);
+  const token = isHubDeployment
+    ? parties.find(p => p.party === party.payload.customer)?.token
+    : computeToken(party.payload.customer);
 
   const roles = allRoles
     .filter(r => r.contract.payload.provider === party.payload.customer)

--- a/ui/src/pages/QuickSetup/SelectRolesPage.tsx
+++ b/ui/src/pages/QuickSetup/SelectRolesPage.tsx
@@ -130,7 +130,6 @@ const DragAndDropRoles = () => {
     ) {
       return;
     }
-    console.log('ereeerereeeeeeeeee');
 
     const provider = { provider: partyId };
 

--- a/ui/src/pages/network/Trading.tsx
+++ b/ui/src/pages/network/Trading.tsx
@@ -19,7 +19,7 @@ export const TradingServiceTable: React.FC<Props> = ({ services }) => {
     await ledger.exercise(Service.Terminate, c.contractId, { ctrl: party });
   };
 
-return (
+  return (
     <StripedTable
       title="Trading"
       headings={[

--- a/ui/src/pages/network/Trading.tsx
+++ b/ui/src/pages/network/Trading.tsx
@@ -19,7 +19,7 @@ export const TradingServiceTable: React.FC<Props> = ({ services }) => {
     await ledger.exercise(Service.Terminate, c.contractId, { ctrl: party });
   };
 
-  return (
+return (
     <StripedTable
       title="Trading"
       headings={[


### PR DESCRIPTION
Self-referential services:
- customer accepts clearing role and automatically offers itself clearing service with ccp account
- customer accepts custody role and automatically offers itself custody and issuance services
- customer accepts exchange role and automatically offers itself matching (was already there), settlement (was already there) and listing (new) services

also adjusts numbering in the user guide to make it easier to modify parts of various sections without hving to re-number the whole thing

also fixes non-readable name in service request page of quick setup