### PR TITLE
Add asset signatories to newly created asset deposits

### DIFF
--- a/daml/Marketplace/Custody/Service.daml
+++ b/daml/Marketplace/Custody/Service.daml
@@ -11,7 +11,6 @@ import DA.Set
 import Marketplace.Issuance.AssetDescription (Claims)
 import Marketplace.Rule.AllocationAccount (AllocationAccountRule(..))
 import Marketplace.Custody.Model qualified as Custody
-
 import Marketplace.Utils
 
 template Service

--- a/daml/Marketplace/Custody/Service.daml
+++ b/daml/Marketplace/Custody/Service.daml
@@ -1,6 +1,7 @@
 module Marketplace.Custody.Service where
 
 import DA.Finance.Asset
+import qualified DA.Finance.Asset as AssetDeposit
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 import DA.Finance.Utils (fetchAndArchive)
@@ -10,6 +11,7 @@ import DA.Set
 import Marketplace.Issuance.AssetDescription (Claims)
 import Marketplace.Rule.AllocationAccount (AllocationAccountRule(..))
 import Marketplace.Custody.Model qualified as Custody
+
 import Marketplace.Utils
 
 template Service
@@ -115,7 +117,9 @@ template Service
           creditAccountRequestCid : ContractId Custody.CreditAccountRequest
         do
           Custody.CreditAccountRequest{accountId; asset} <- fetchAndArchive creditAccountRequestCid
-          exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
+          depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
+          deposit <- fetch depositCid
+          exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
 
       nonconsuming DebitAccount : Asset
         with

--- a/daml/Marketplace/Issuance/Service.daml
+++ b/daml/Marketplace/Issuance/Service.daml
@@ -1,10 +1,11 @@
 module Marketplace.Issuance.Service where
 
 import DA.Finance.Asset
+import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
 import DA.Map qualified as Map
-import DA.Set (Set, fromList)
+import DA.Set (Set, fromList, union)
 import Marketplace.Issuance.Model (Issuance(..))
 import Marketplace.Issuance.AssetDescription (AssetDescription(..), Claims)
 import Marketplace.Issuance.AssetDescription qualified as AssetDescription
@@ -89,6 +90,8 @@ template Service
 
           let asset = Asset with id = assetId; quantity
           depositCid <- exerciseByKey @AssetSettlementRule accountId AssetSettlement_Credit with ctrl = provider; ..
+          deposit    <- fetch depositCid
+          depositCid <- exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
           pure (issuanceCid, depositCid)
 
       nonconsuming ReduceIssuance : ContractId Issuance

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -1,11 +1,10 @@
 module Marketplace.Rule.AllocationAccount where
 
 import DA.Record
-import DA.Set (Set, insert, member, union)
+import DA.Set (Set, insert, member)
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
-import DA.Finance.Asset (AssetDeposit (..))
-import DA.Finance.Asset qualified as AssetDeposit
+import DA.Finance.Asset (AssetDeposit(..))
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_Credit(..), AssetSettlement_Debit(..), AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 import DA.Action (void, unless)
 
@@ -39,10 +38,7 @@ template AllocationAccountRule
       credit : Asset -> Update (ContractId AssetDeposit)
       credit = \asset -> create AssetDeposit with ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
-      creditAccount = \account asset -> do
-       depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
-       deposit <- fetch depositCid
-       exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
+      creditAccount = \account asset -> exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
 
     controller nominee, account.owner can
       nonconsuming Transfer : ContractId AssetDeposit

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -1,10 +1,11 @@
 module Marketplace.Rule.AllocationAccount where
 
 import DA.Record
-import DA.Set (Set, insert, member)
+import DA.Set (Set, insert, member, union)
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
 import DA.Finance.Asset (AssetDeposit(..))
+import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_Credit(..), AssetSettlement_Debit(..), AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 import DA.Action (void, unless)
 
@@ -38,7 +39,14 @@ template AllocationAccountRule
       credit : Asset -> Update (ContractId AssetDeposit)
       credit = \asset -> create AssetDeposit with ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
-      creditAccount = \account asset -> exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+      creditAccount = \account asset -> do
+        depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+        deposit <- fetch depositCid
+        let
+          addProvider    = exerciseByKey @AssetSettlementRule account.id AssetSettlement_AddController with ctrl = deposit.account.owner
+          removeProvider = exerciseByKey @AssetSettlementRule account.id AssetSettlement_RemoveController with ctrl = deposit.account.owner
+          addObservers   = exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
+        addProvider *> addObservers <* removeProvider
 
     controller nominee, account.owner can
       nonconsuming Transfer : ContractId AssetDeposit

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -1,11 +1,10 @@
 module Marketplace.Rule.AllocationAccount where
 
 import DA.Record
-import DA.Set (Set, insert, member, union)
+import DA.Set (Set, insert, member)
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
 import DA.Finance.Asset (AssetDeposit(..))
-import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_Credit(..), AssetSettlement_Debit(..), AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 import DA.Action (void, unless)
 

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -1,10 +1,11 @@
 module Marketplace.Rule.AllocationAccount where
 
 import DA.Record
-import DA.Set (Set, insert, member)
+import DA.Set (Set, insert, member, union)
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
 import DA.Finance.Asset (AssetDeposit(..))
+import qualified DA.Finance.Asset as AssetDeposit
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_Credit(..), AssetSettlement_Debit(..), AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 import DA.Action (void, unless)
 
@@ -38,7 +39,10 @@ template AllocationAccountRule
       credit : Asset -> Update (ContractId AssetDeposit)
       credit = \asset -> create AssetDeposit with ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
-      creditAccount = \account asset -> exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+      creditAccount = \account asset -> do
+        depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+        deposit <- fetch depositCid
+        exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
 
     nonconsuming choice Transfer : ContractId AssetDeposit
         with

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -39,23 +39,17 @@ template AllocationAccountRule
       credit : Asset -> Update (ContractId AssetDeposit)
       credit = \asset -> create AssetDeposit with ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
-      creditAccount = \account asset -> do
-        depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
-        deposit <- fetch depositCid
-        let
-          addProvider    = exerciseByKey @AssetSettlementRule account.id AssetSettlement_AddController with ctrl = deposit.account.owner
-          removeProvider = exerciseByKey @AssetSettlementRule account.id AssetSettlement_RemoveController with ctrl = deposit.account.owner
-          addObservers   = exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
-        addProvider *> addObservers <* removeProvider
+      creditAccount = \account asset -> exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
 
-    controller nominee, account.owner can
-      nonconsuming Transfer : ContractId AssetDeposit
+    nonconsuming choice Transfer : ContractId AssetDeposit
         with
           transferTo : Account
           depositCid : ContractId AssetDeposit
+        controller nominee, account.owner, transferTo.owner
         do
           debit depositCid >>= creditAccount transferTo
 
+    controller nominee, account.owner can
       nonconsuming Deposit : ContractId AssetDeposit
         with
           depositCid : ContractId AssetDeposit

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -1,10 +1,11 @@
 module Marketplace.Rule.AllocationAccount where
 
 import DA.Record
-import DA.Set (Set, insert, member)
+import DA.Set (Set, insert, member, union)
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Finance.Types (Account, Id, Asset)
-import DA.Finance.Asset (AssetDeposit(..))
+import DA.Finance.Asset (AssetDeposit (..))
+import DA.Finance.Asset qualified as AssetDeposit
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_Credit(..), AssetSettlement_Debit(..), AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 import DA.Action (void, unless)
 
@@ -38,7 +39,10 @@ template AllocationAccountRule
       credit : Asset -> Update (ContractId AssetDeposit)
       credit = \asset -> create AssetDeposit with ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
-      creditAccount = \account asset -> exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+      creditAccount = \account asset -> do
+       depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..
+       deposit <- fetch depositCid
+       exercise depositCid AssetDeposit.AssetDeposit_SetObservers with newObservers = deposit.asset.id.signatories `union` deposit.observers
 
     controller nominee, account.owner can
       nonconsuming Transfer : ContractId AssetDeposit

--- a/ui/src/pages/QuickSetup/RequestServicesPage.tsx
+++ b/ui/src/pages/QuickSetup/RequestServicesPage.tsx
@@ -262,8 +262,8 @@ const RequestForm = (props: {
           {services.map((s, i) => (
             <div className="party-name" key={i}>
               <p>
-                {s.contract.payload.provider} provides {s.service} service to{' '}
-                {s.contract.payload.customer}{' '}
+                {getName(s.contract.payload.provider)} provides {s.service} service to{' '}
+                {getName(s.contract.payload.customer)}{' '}
               </p>
             </div>
           ))}

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -15,7 +15,7 @@ import StripedTable from '../../components/Table/StripedTable';
 import BackButton from '../../components/Common/BackButton';
 import InfoCard from '../../components/Common/InfoCard';
 import Tile from '../../components/Tile/Tile';
-import { ServicePageProps, damlSetValues, makeDamlSet } from '../common';
+import { ServicePageProps, damlSetValues } from '../common';
 import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/Rule/AllocationAccount';
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
 import paths from '../../paths';
@@ -33,8 +33,9 @@ const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>
   const cid = contractId.replace('_', '#');
 
   const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
-  const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
-    useStreamQueries(AllocationAccountRule);
+  const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } = useStreamQueries(
+    AllocationAccountRule
+  );
   const { contracts: assets, loading: assetsLoading } = useStreamQueries(AssetDescription);
   const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
 


### PR DESCRIPTION
When an asset deposit is created, the signatories of that asset are added as observers. That way any issuer can view allocations of their asset.