### PR TITLE
Flatten wallet information 

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Route, RouteProps, Switch, useLocation, withRouter } from 'react-router-dom';
 import { SidebarEntry } from './components/Sidebar/SidebarEntry';
 import { Requests as CustodyRequests } from './pages/custody/Requests';
-import { Account } from './pages/custody/Account';
 import { useParty } from '@daml/react';
 import { Service as CustodyService } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service/';
 import { Service as ClearingService } from '@daml.js/da-marketplace/lib/Marketplace/Clearing/Service/';
@@ -16,7 +15,7 @@ import { Role as ClearingRole } from '@daml.js/da-marketplace/lib/Marketplace/Cl
 
 import { Auctions } from './pages/distribution/auction/Auctions';
 import { Requests as AuctionRequests } from './pages/distribution/auction/Requests';
-import { Assets } from './pages/custody/Assets';
+import Assets from './pages/custody/Assets';
 import { New as NewAuction } from './pages/distribution/auction/New';
 import { BiddingAuction } from './pages/distribution/bidding/Auction';
 import { InstrumentsTable } from './pages/origination/Instruments';

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -104,16 +104,9 @@ const AppComponent = () => {
       {
         label: 'Wallet',
         path: paths.app.wallet.root,
-        activeSubroutes: true,
         render: () => <Assets services={custodyService} />,
         icon: <WalletIcon />,
         children: [],
-      },
-    ],
-    additionalRoutes: [
-      {
-        path: paths.app.wallet.account + '/:contractId',
-        render: () => <Account services={custodyService} />,
       },
     ],
   });

--- a/ui/src/components/Common/TitleWithActions.scss
+++ b/ui/src/components/Common/TitleWithActions.scss
@@ -1,4 +1,4 @@
- @use '../../themes/variables.scss' as *;
+@use '../../themes/variables.scss' as *;
 
 @mixin title-with-actions {
   .title-with-actions {

--- a/ui/src/components/Common/TitleWithActions.scss
+++ b/ui/src/components/Common/TitleWithActions.scss
@@ -1,4 +1,4 @@
-@use '../../themes/variables.scss' as *;
+ @use '../../themes/variables.scss' as *;
 
 @mixin title-with-actions {
   .title-with-actions {
@@ -16,9 +16,9 @@
       flex-direction: row;
       align-items: baseline;
       flex-wrap: wrap;
-
+      margin-left: $spacing-m;
       button {
-        margin-left: $spacing-m;
+        margin-right: $spacing-m;
       }
     }
 

--- a/ui/src/components/Form/ModalFormErrorHandled.tsx
+++ b/ui/src/components/Form/ModalFormErrorHandled.tsx
@@ -1,7 +1,9 @@
+import classNames from 'classnames';
 import React, { useState } from 'react';
 import { Button, Form, Message, Modal } from 'semantic-ui-react';
 
 import { ErrorMessage, parseError } from '../../pages/error/errorTypes';
+import { AddPlusIcon } from '../../icons/icons';
 
 type Renderable = number | string | React.ReactElement | React.ReactNode | Renderable[];
 type Callable = (callback: (fn: () => Promise<void>) => void) => Renderable;
@@ -18,6 +20,7 @@ type Props = {
   onSubmit: () => Promise<void>;
   disabled?: boolean;
   trigger?: JSX.Element;
+  addButton?: boolean;
 };
 
 const ModalFormErrorHandled: (props: Props) => React.ReactElement = ({
@@ -26,6 +29,7 @@ const ModalFormErrorHandled: (props: Props) => React.ReactElement = ({
   onSubmit,
   disabled,
   trigger,
+  addButton,
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<ErrorMessage>();
@@ -57,7 +61,14 @@ const ModalFormErrorHandled: (props: Props) => React.ReactElement = ({
       onClose={() => setOpen(false)}
       onOpen={() => setOpen(true)}
       open={open}
-      trigger={trigger || <Button className="ghost">{title}</Button>}
+      trigger={
+        trigger || (
+          <Button className={classNames('ghost', { 'add-button a a2 with-icon': addButton })}>
+            {addButton && <AddPlusIcon />}
+            {title}
+          </Button>
+        )
+      }
     >
       <Modal.Header as="h2">{title}</Modal.Header>
       <Modal.Content>

--- a/ui/src/components/Tile/Tile.scss
+++ b/ui/src/components/Tile/Tile.scss
@@ -22,6 +22,10 @@
       }
     }
 
+    &.inline {
+      width: 40%;
+    }
+
     &.thin-gap {
       margin-bottom: 2px;
     }

--- a/ui/src/icons/icons.tsx
+++ b/ui/src/icons/icons.tsx
@@ -383,3 +383,15 @@ export const IconMailLetter = () => {
     </svg>
   );
 };
+
+export const IconChevronDown = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M4 6.66663L8 10.6666L12 6.66663" stroke="#577FF1" stroke-linecap="round" />
+  </svg>
+);
+
+export const IconChevronUp = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 9.33337L8 5.33337L4 9.33337" stroke="#577FF1" stroke-linecap="round" />
+  </svg>
+);

--- a/ui/src/pages/custody/Account.scss
+++ b/ui/src/pages/custody/Account.scss
@@ -6,48 +6,48 @@
     margin-bottom: $spacing-l;
 
     .account-holding {
-        width: 100%;
-        border: 1px solid var(--cool-grey-90);
-        background-color: white;
-        color: var(--textcolor);
-        padding: $spacing-s;
-        border-radius: 4px;
-        margin-bottom: $spacing-s ;
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
+      width: 100%;
+      border: 1px solid var(--cool-grey-90);
+      background-color: white;
+      color: var(--textcolor);
+      padding: $spacing-s;
+      border-radius: 4px;
+      margin-bottom: $spacing-s;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
     }
 
     h4 {
-        margin: 0 $spacing-s 0 0 ;
+      margin: 0 $spacing-s 0 0;
     }
 
     .actions {
-        display: flex;
+      display: flex;
 
-        .ghost {
-            margin-left: $spacing-s;
-        }
+      .ghost {
+        margin-left: $spacing-s;
+      }
     }
 
     .empty {
-        margin:$spacing-s;
+      margin: $spacing-s;
     }
 
     .account-details {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        margin-bottom: $spacing-s;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      margin-bottom: $spacing-s;
 
-        .account-data {
-            display: inline;
-        }
+      .account-data {
+        display: inline;
+      }
 
-        p {
-            margin-right: $spacing-s
-        }
+      p {
+        margin-right: $spacing-s;
+      }
     }
   }
 }

--- a/ui/src/pages/custody/Account.scss
+++ b/ui/src/pages/custody/Account.scss
@@ -6,17 +6,17 @@
     margin-bottom: $spacing-l;
 
     .account-holding {
-      width: 100%;
-      border: 1px solid var(--cool-grey-90);
-      background-color: white;
-      color: var(--textcolor);
       padding: $spacing-s;
-      border-radius: 4px;
       margin-bottom: $spacing-s;
       display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
+
+      .tile-content {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+      }
     }
 
     h4 {

--- a/ui/src/pages/custody/Account.scss
+++ b/ui/src/pages/custody/Account.scss
@@ -4,6 +4,7 @@
   .account {
     animation: fadeIn 0.5s;
     margin-bottom: $spacing-l;
+    width: 100%;
 
     .account-holding {
       padding: $spacing-s;

--- a/ui/src/pages/custody/Account.scss
+++ b/ui/src/pages/custody/Account.scss
@@ -3,19 +3,51 @@
 @mixin account {
   .account {
     animation: fadeIn 0.5s;
+    margin-bottom: $spacing-l;
 
-    h2 {
-      margin-bottom: $spacing-m;
+    .account-holding {
+        width: 100%;
+        border: 1px solid var(--cool-grey-90);
+        background-color: white;
+        color: var(--textcolor);
+        padding: $spacing-s;
+        border-radius: 4px;
+        margin-bottom: $spacing-s ;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
     }
 
-    .button.ghost {
-      margin-right: $spacing-s;
+    h4 {
+        margin: 0 $spacing-s 0 0 ;
     }
 
-    .action-row {
-      display: flex;
-      flex-direction: row;
-      justify-content: normal;
+    .actions {
+        display: flex;
+
+        .ghost {
+            margin-left: $spacing-s;
+        }
+    }
+
+    .empty {
+        margin:$spacing-s;
+    }
+
+    .account-details {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        margin-bottom: $spacing-s;
+
+        .account-data {
+            display: inline;
+        }
+
+        p {
+            margin-right: $spacing-s
+        }
     }
   }
 }

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -12,7 +12,6 @@ import { Button, Form } from 'semantic-ui-react';
 import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
 import { usePartyName } from '../../config';
 import StripedTable from '../../components/Table/StripedTable';
-import BackButton from '../../components/Common/BackButton';
 import InfoCard from '../../components/Common/InfoCard';
 import Tile from '../../components/Tile/Tile';
 import { ServicePageProps, damlSetValues, createDropdownProp } from '../common';
@@ -20,266 +19,290 @@ import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/R
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
 import paths from '../../paths';
 import FormErrorHandled from '../../components/Form/FormErrorHandled';
+import OverflowMenu, { OverflowMenuEntry } from '../../pages/page/OverflowMenu';
 
-const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = ({
-  history,
-  services,
-}: RouteComponentProps & ServicePageProps<Service>) => {
-  const party = useParty();
-  const { getName } = usePartyName(party);
-  const ledger = useLedger();
-  const displayErrorMessage = useDisplayErrorMessage();
-  const { contractId } = useParams<any>();
+interface AccountProps {
+  contractId: string;
+}
+const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service> & AccountProps> =
+  ({
+    history,
+    services,
+    contractId,
+  }: RouteComponentProps & ServicePageProps<Service> & AccountProps) => {
+    const party = useParty();
+    const { getName } = usePartyName(party);
+    const ledger = useLedger();
+    const displayErrorMessage = useDisplayErrorMessage();
 
-  const cid = contractId.replace('_', '#');
+    const cid = contractId.replace('_', '#');
 
-  const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
-  const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
-    useStreamQueries(AllocationAccountRule);
-  const { contracts: assets, loading: assetsLoading } = useStreamQueries(AssetDescription);
-  const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
+    const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
+    const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
+      useStreamQueries(AllocationAccountRule);
+    const { contracts: assets, loading: assetsLoading } = useStreamQueries(AssetDescription);
+    const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
 
-  const [creditAsset, setCreditAsset] = useState<string>('');
-  const [creditQuantity, setCreditQuantity] = useState<string>('');
+    const [creditAsset, setCreditAsset] = useState<string>('');
+    const [creditQuantity, setCreditQuantity] = useState<string>('');
 
-  const allAccounts = useMemo(
-    () =>
-      accounts
-        .map(a => {
-          return { account: a.payload.account, contractId: a.contractId.replace('#', '_') };
-        })
-        .concat(
-          allocatedAccounts.map(a => {
+    const allAccounts = useMemo(
+      () =>
+        accounts
+          .map(a => {
             return { account: a.payload.account, contractId: a.contractId.replace('#', '_') };
           })
-        ),
-    [accounts, allocatedAccounts]
-  );
+          .concat(
+            allocatedAccounts.map(a => {
+              return { account: a.payload.account, contractId: a.contractId.replace('#', '_') };
+            })
+          ),
+      [accounts, allocatedAccounts]
+    );
 
-  const defaultTransferRequestDialogProps: InputDialogProps<any> = {
-    open: false,
-    title: 'Transfer Account Request',
-    defaultValue: { account: '' },
-    fields: {
-      account: { label: 'Account', type: 'selection', items: [] },
-    },
-    onClose: async function (state: any | null) {},
-  };
-  const [transferDialogProps, setTransferDialogProps] = useState<InputDialogProps<any>>(
-    defaultTransferRequestDialogProps
-  );
+    const defaultTransferRequestDialogProps: InputDialogProps<any> = {
+      open: false,
+      title: 'Transfer Account Request',
+      defaultValue: { account: '' },
+      fields: {
+        account: { label: 'Account', type: 'selection', items: [] },
+      },
+      onClose: async function (state: any | null) {},
+    };
+    const assetNames = assets.map(a => a.payload.description);
 
-  const clientServices = services.filter(s => s.payload.customer === party);
-  const targetAccount = allAccounts.find(a => a.contractId === cid);
+    const defaultCreditRequestDialogProps: InputDialogProps<any> = {
+      open: false,
+      title: 'Credit Account Request',
+      defaultValue: { account: '', asset: '', quantity: 0 },
+      fields: {
+        account: { label: 'Account', type: 'selection', items: [] },
+        asset: { label: 'Asset', type: 'selection', items: assetNames },
+        quantity: { label: 'Quantity', type: 'number' },
+      },
+      onClose: async function (state: any | null) {},
+    };
+    const [transferDialogProps, setTransferDialogProps] = useState<InputDialogProps<any>>(
+      defaultTransferRequestDialogProps
+    );
+    const [creditDialogProps, setCreditDialogProps] = useState<InputDialogProps<any>>(
+      defaultCreditRequestDialogProps
+    );
+    const clientServices = services.filter(s => s.payload.customer === party);
+    const targetAccount = allAccounts.find(a => a.contractId === cid);
 
-  if (accountsLoading || assetsLoading || depositsLoading || allocatedAccountsLoading) {
-    return <h4>Loading account...</h4>;
-  }
+    if (accountsLoading || assetsLoading || depositsLoading || allocatedAccountsLoading) {
+      return <h4>Loading account...</h4>;
+    }
 
-  if (!targetAccount) {
-    return <h4>Could not find account.</h4>;
-  }
+    if (!targetAccount) {
+      return <h4>Could not find account.</h4>;
+    }
 
-  const normalAccount = accounts.find(a => a.contractId === targetAccount.contractId);
-  const allocationAccount = allocatedAccounts.find(a => a.contractId === targetAccount.contractId);
-  const service = clientServices.find(s => s.payload.provider === targetAccount.account.provider);
+    const normalAccount = accounts.find(a => a.contractId === targetAccount.contractId);
+    const allocationAccount = allocatedAccounts.find(
+      a => a.contractId === targetAccount.contractId
+    );
+    const service = clientServices.find(s => s.payload.provider === targetAccount.account.provider);
 
-  const accountDeposits = deposits.filter(
-    d =>
-      d.payload.account.id.label === targetAccount.account.id.label &&
-      d.payload.account.provider === targetAccount.account.provider &&
-      d.payload.account.owner === targetAccount.account.owner
-  );
+    const accountDeposits = deposits.filter(
+      d =>
+        d.payload.account.id.label === targetAccount.account.id.label &&
+        d.payload.account.provider === targetAccount.account.provider &&
+        d.payload.account.owner === targetAccount.account.owner
+    );
 
-  const requestWithdrawDeposit = async (c: CreateEvent<AssetDeposit>) => {
-    if (!service)
-      return displayErrorMessage({
-        message: 'The account provider does not offer issuance services.',
-      });
-    await ledger.exercise(Service.RequestDebitAccount, service.contractId, {
-      accountId: c.payload.account.id,
-      debit: { depositCid: c.contractId },
-    });
-    history.push(paths.app.wallet.requests);
-  };
-
-  const relatedAccounts = accounts
-    .filter(a => a.contractId !== cid)
-    .filter(a => a.payload.account.owner === targetAccount.account.owner)
-    .map(r => r.payload.account.id.label);
-
-  const requestTransfer = (deposit: CreateEvent<AssetDeposit>) => {
-    const onClose = async (state: any | null) => {
-      setTransferDialogProps({ ...defaultTransferRequestDialogProps, open: false });
-      if (!state) return;
-      const transferToAccount = accounts.find(a => a.payload.account.id.label === state.account);
-
-      if (!service || !transferToAccount) return;
-
-      await ledger.exercise(Service.RequestTransferDeposit, service.contractId, {
-        accountId: targetAccount.account.id,
-        transfer: {
-          receiverAccountId: transferToAccount.payload.account.id,
-          depositCid: deposit.contractId,
-        },
+    const requestWithdrawDeposit = async (c: CreateEvent<AssetDeposit>) => {
+      if (!service)
+        return displayErrorMessage({
+          message: 'The account provider does not offer issuance services.',
+        });
+      await ledger.exercise(Service.RequestDebitAccount, service.contractId, {
+        accountId: c.payload.account.id,
+        debit: { depositCid: c.contractId },
       });
     };
-    setTransferDialogProps({
-      ...defaultTransferRequestDialogProps,
-      defaultValue: {
-        ...defaultTransferRequestDialogProps.defaultValue,
-        deposit: deposit.contractId,
-      },
-      fields: {
-        ...defaultTransferRequestDialogProps.fields,
-        account: { label: 'Account', type: 'selection', items: relatedAccounts },
-      },
-      open: true,
-      onClose,
-    });
-  };
 
-  const onRequestCredit = async () => {
-    const asset = assets.find(i => i.payload.description === creditAsset);
-    if (!asset) return;
+    const relatedAccounts = accounts
+      .filter(a => a.contractId !== cid)
+      .filter(a => a.payload.account.owner === targetAccount.account.owner)
+      .map(r => r.payload.account.id.label);
 
-    if (!service)
-      return displayErrorMessage({
-        message: `${getName(
-          targetAccount.account.provider
-        )} does not offer issuance services to ${getName(party)}`,
+    const requestTransfer = (deposit: CreateEvent<AssetDeposit>) => {
+      const onClose = async (state: any | null) => {
+        setTransferDialogProps({ ...defaultTransferRequestDialogProps, open: false });
+        if (!state) return;
+        const transferToAccount = accounts.find(a => a.payload.account.id.label === state.account);
+
+        if (!service || !transferToAccount) return;
+
+        await ledger.exercise(Service.RequestTransferDeposit, service.contractId, {
+          accountId: targetAccount.account.id,
+          transfer: {
+            receiverAccountId: transferToAccount.payload.account.id,
+            depositCid: deposit.contractId,
+          },
+        });
+      };
+      setTransferDialogProps({
+        ...defaultTransferRequestDialogProps,
+        defaultValue: {
+          ...defaultTransferRequestDialogProps.defaultValue,
+          deposit: deposit.contractId,
+        },
+        fields: {
+          ...defaultTransferRequestDialogProps.fields,
+          account: { label: 'Account', type: 'selection', items: relatedAccounts },
+        },
+        open: true,
+        onClose,
       });
+    };
 
-    await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
-      accountId: targetAccount.account.id,
-      asset: { id: asset.payload.assetId, quantity: creditQuantity },
-    });
-    setCreditAsset('');
-    setCreditQuantity('');
-  };
+    const requestCredit = async () => {
+      const onClose = async (state: any | null) => {
+        setCreditDialogProps({ ...defaultCreditRequestDialogProps, open: false });
+        if (!state) return;
 
-  const requestCloseAccount = async (c: CreateEvent<AssetSettlementRule>) => {
-    if (!service)
-      return displayErrorMessage({
-        message: 'The account provider does not offer issuance services.',
+        const asset = assets.find(i => i.payload.description === creditAsset);
+        if (!asset) return;
+
+        if (!service)
+          return displayErrorMessage({
+            message: `${getName(
+              targetAccount.account.provider
+            )} does not offer issuance services to ${getName(party)}`,
+          });
+
+        await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
+          accountId: targetAccount.account.id,
+          asset: { id: asset.payload.assetId, quantity: creditQuantity },
+        });
+      };
+      setCreditDialogProps({
+        ...defaultCreditRequestDialogProps,
+        defaultValue: {
+          ...defaultCreditRequestDialogProps.fields,
+          account: targetAccount.account.id.label,
+        },
+        fields: {
+          ...defaultCreditRequestDialogProps.fields,
+          account: { label: 'Account', type: 'selection', items: [targetAccount.account.id.label] },
+        },
+        open: true,
+        onClose,
       });
-    await ledger.exercise(Service.RequestCloseAccount, service.contractId, {
-      accountId: c.payload.account.id,
-    });
-    history.push(paths.app.wallet.requests);
-  };
+      setCreditAsset('');
+      setCreditQuantity('');
+    };
 
-  let accountData = [
-    {
-      label: 'Name',
-      data: targetAccount.account.id.label,
-    },
-    { label: 'Type', data: normalAccount ? 'Normal' : 'Allocation' },
-    { label: 'Provider', data: getName(targetAccount.account.provider) },
-    { label: 'Owner', data: getName(targetAccount.account.owner) },
-    {
-      label: 'Role',
-      data: party === targetAccount.account.provider ? 'Provider' : 'Client',
-    },
-  ];
+    const requestCloseAccount = async (c: CreateEvent<AssetSettlementRule>) => {
+      if (!service)
+        return displayErrorMessage({
+          message: 'The account provider does not offer issuance services.',
+        });
+      await ledger.exercise(Service.RequestCloseAccount, service.contractId, {
+        accountId: c.payload.account.id,
+      });
+      history.push(paths.app.wallet.requests);
+    };
 
-  if (normalAccount) {
-    accountData = [
-      ...accountData,
+    let accountData = [
       {
-        label: 'Controllers',
-        data: damlSetValues(normalAccount.payload.ctrls)
-          .map(ctrl => getName(ctrl))
-          .sort()
-          .join(', '),
+        label: 'Name',
+        data: targetAccount.account.id.label,
+      },
+      { label: 'Type', data: normalAccount ? 'Normal' : 'Allocation' },
+      { label: 'Provider', data: getName(targetAccount.account.provider) },
+      { label: 'Owner', data: getName(targetAccount.account.owner) },
+      {
+        label: 'Role',
+        data: party === targetAccount.account.provider ? 'Provider' : 'Client',
       },
     ];
-  }
-  if (allocationAccount) {
-    accountData = [
-      ...accountData,
-      {
-        label: 'Nominee',
-        data: allocationAccount.payload.nominee,
-      },
-    ];
-  }
 
-  return (
-    <>
-      <BackButton prevPageLabel="Wallet" prevPagePath={paths.app.wallet.root} />
-      <InputDialog {...transferDialogProps} isModal />
-      <div className="account">
-        <div className="page-section-row">
-          <InfoCard
-            title="Account Details"
-            info={accountData}
-            actions={
-              normalAccount && [
-                <Button
-                  key="close-account"
-                  className="ghost warning"
+    if (normalAccount) {
+      accountData = [
+        ...accountData,
+        {
+          label: 'Controllers',
+          data: damlSetValues(normalAccount.payload.ctrls)
+            .map(ctrl => getName(ctrl))
+            .sort()
+            .join(', '),
+        },
+      ];
+    }
+    if (allocationAccount) {
+      accountData = [
+        ...accountData,
+        {
+          label: 'Nominee',
+          data: allocationAccount.payload.nominee,
+        },
+      ];
+    }
+
+    return (
+      <>
+        <InputDialog {...transferDialogProps} isModal />
+        <InputDialog {...creditDialogProps} isModal />
+
+        <div className="account">
+          <div className="account-details">
+            <h4> {targetAccount.account.id.label} </h4>
+
+            <p className="p2">Type: {normalAccount ? 'Normal' : 'Allocation'} </p>
+            <p className="p2">Provider: {getName(targetAccount.account.provider)}</p>
+            <p className="p2">Owner: {getName(targetAccount.account.owner)}</p>
+            <p className="p2">
+              Role: {party === targetAccount.account.provider ? 'Provider' : 'Client'}
+            </p>
+            {normalAccount && (
+              <OverflowMenu>
+                <OverflowMenuEntry
+                  label={'Close Account'}
                   onClick={() => requestCloseAccount(normalAccount)}
-                >
-                  Close Account
-                </Button>,
-              ]
-            }
-          />
-          <Tile header="Credit Account Request">
-            <br />
-            <FormErrorHandled onSubmit={() => onRequestCredit()}>
-              <Form.Select
-                label="Asset"
-                options={assets.map(a => createDropdownProp(a.payload.description))}
-                value={creditAsset}
-                onChange={(_, data) => setCreditAsset(data.value as string)}
-              />
-              <Form.Input
-                label="Quantity"
-                type="number"
-                value={creditQuantity}
-                onChange={(_, data) => setCreditQuantity(data.value as string)}
-              />
-              <Button
-                type="submit"
-                className="ghost"
-                disabled={creditAsset === '' || creditQuantity === '' || creditQuantity === '0'}
-                content="Submit"
-              />
-            </FormErrorHandled>
-          </Tile>
-        </div>
-        <StripedTable
-          title="Holdings"
-          headings={['Holding', 'Asset', '']}
-          loading={depositsLoading}
-          rows={accountDeposits.map(c => {
-            return {
-              elements: [
-                c.payload.asset.quantity,
-                c.payload.asset.id.label,
-                <>
+                />
+                <OverflowMenuEntry label="Deposit" onClick={() => requestCredit()} />
+              </OverflowMenu>
+            )}
+          </div>
+
+          <div>
+            {accountDeposits.length > 0 ? (
+              accountDeposits.map(c => (
+                <div className="account-holding">
+                  <p>
+                    <b>{c.payload.asset.id.label}</b> {c.payload.asset.quantity}{' '}
+                  </p>
                   {party === targetAccount.account.owner && normalAccount && (
-                    <div className="action-row">
-                      <Button className="ghost" onClick={() => requestWithdrawDeposit(c)}>
-                        Withdraw
-                      </Button>
+                    <div className="actions">
+                      <Button
+                        className="ghost"
+                        content="Withdraw"
+                        onClick={() => requestWithdrawDeposit(c)}
+                      />
                       {relatedAccounts.length > 0 && (
-                        <Button className="ghost" onClick={() => requestTransfer(c)}>
-                          Transfer
-                        </Button>
+                        <Button
+                          className="ghost"
+                          content="Transfer"
+                          onClick={() => requestTransfer(c)}
+                        />
                       )}
                     </div>
                   )}
-                </>,
-              ],
-            };
-          })}
-        />
-      </div>
-    </>
-  );
-};
+                </div>
+              ))
+            ) : (
+              <div className="none p2">
+                <i>There are no holdings in this account.</i>
+              </div>
+            )}
+          </div>
+        </div>
+      </>
+    );
+  };
 
 export const Account = withRouter(AccountComponent);

--- a/ui/src/pages/custody/Account.tsx
+++ b/ui/src/pages/custody/Account.tsx
@@ -1,308 +1,259 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 import { useLedger, useParty } from '@daml/react';
 import { useStreamQueries } from '../../Main';
 import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asset/Settlement';
 import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset';
-import { RouteComponentProps, useParams, withRouter } from 'react-router-dom';
+import { Account as AccountContract } from '@daml.js/da-marketplace/lib/DA/Finance/Types';
 import { CreateEvent } from '@daml/ledger';
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service';
 import { InputDialog, InputDialogProps } from '../../components/InputDialog/InputDialog';
-import { Button, Form } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
 import { usePartyName } from '../../config';
-import StripedTable from '../../components/Table/StripedTable';
-import InfoCard from '../../components/Common/InfoCard';
 import Tile from '../../components/Tile/Tile';
-import { ServicePageProps, damlSetValues, createDropdownProp } from '../common';
+import { ServicePageProps, damlSetValues } from '../common';
 import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/Rule/AllocationAccount';
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
-import paths from '../../paths';
-import FormErrorHandled from '../../components/Form/FormErrorHandled';
 import OverflowMenu, { OverflowMenuEntry } from '../../pages/page/OverflowMenu';
 
 interface AccountProps {
-  contractId: string;
+  targetAccount: {
+    account: AccountContract;
+    contractId: string;
+  };
 }
-const AccountComponent: React.FC<RouteComponentProps & ServicePageProps<Service> & AccountProps> =
-  ({
-    history,
-    services,
-    contractId,
-  }: RouteComponentProps & ServicePageProps<Service> & AccountProps) => {
-    const party = useParty();
-    const { getName } = usePartyName(party);
-    const ledger = useLedger();
-    const displayErrorMessage = useDisplayErrorMessage();
 
-    const cid = contractId.replace('_', '#');
+const Account: React.FC<ServicePageProps<Service> & AccountProps> = ({
+  services,
+  targetAccount,
+}: ServicePageProps<Service> & AccountProps) => {
+  const party = useParty();
+  const { getName } = usePartyName(party);
+  const ledger = useLedger();
+  const displayErrorMessage = useDisplayErrorMessage();
 
-    const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
-    const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
-      useStreamQueries(AllocationAccountRule);
-    const { contracts: assets, loading: assetsLoading } = useStreamQueries(AssetDescription);
-    const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
+  const cid = targetAccount.contractId.replace('_', '#');
 
-    const [creditAsset, setCreditAsset] = useState<string>('');
-    const [creditQuantity, setCreditQuantity] = useState<string>('');
+  const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
+  const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
+    useStreamQueries(AllocationAccountRule);
+  const { contracts: assets, loading: assetsLoading } = useStreamQueries(AssetDescription);
+  const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
 
-    const allAccounts = useMemo(
-      () =>
-        accounts
-          .map(a => {
-            return { account: a.payload.account, contractId: a.contractId.replace('#', '_') };
-          })
-          .concat(
-            allocatedAccounts.map(a => {
-              return { account: a.payload.account, contractId: a.contractId.replace('#', '_') };
-            })
-          ),
-      [accounts, allocatedAccounts]
-    );
+  const [creditAsset, setCreditAsset] = useState<string>('');
+  const [creditQuantity, setCreditQuantity] = useState<string>('');
 
-    const defaultTransferRequestDialogProps: InputDialogProps<any> = {
-      open: false,
-      title: 'Transfer Account Request',
-      defaultValue: { account: '' },
-      fields: {
-        account: { label: 'Account', type: 'selection', items: [] },
-      },
-      onClose: async function (state: any | null) {},
-    };
-    const assetNames = assets.map(a => a.payload.description);
+  const defaultTransferRequestDialogProps: InputDialogProps<any> = {
+    open: false,
+    title: 'Transfer Account Request',
+    defaultValue: { account: '' },
+    fields: {
+      account: { label: 'Account', type: 'selection', items: [] },
+    },
+    onClose: async function (state: any | null) {},
+  };
+  const assetNames = assets.map(a => a.payload.description);
 
-    const defaultCreditRequestDialogProps: InputDialogProps<any> = {
-      open: false,
-      title: 'Credit Account Request',
-      defaultValue: { account: '', asset: '', quantity: 0 },
-      fields: {
-        account: { label: 'Account', type: 'selection', items: [] },
-        asset: { label: 'Asset', type: 'selection', items: assetNames },
-        quantity: { label: 'Quantity', type: 'number' },
-      },
-      onClose: async function (state: any | null) {},
-    };
-    const [transferDialogProps, setTransferDialogProps] = useState<InputDialogProps<any>>(
-      defaultTransferRequestDialogProps
-    );
-    const [creditDialogProps, setCreditDialogProps] = useState<InputDialogProps<any>>(
-      defaultCreditRequestDialogProps
-    );
-    const clientServices = services.filter(s => s.payload.customer === party);
-    const targetAccount = allAccounts.find(a => a.contractId === cid);
+  const defaultCreditRequestDialogProps: InputDialogProps<any> = {
+    open: false,
+    title: 'Credit Account Request',
+    defaultValue: { account: '', asset: '', quantity: 0 },
+    fields: {
+      account: { label: 'Account', type: 'selection', items: [] },
+      asset: { label: 'Asset', type: 'selection', items: assetNames },
+      quantity: { label: 'Quantity', type: 'number' },
+    },
+    onClose: async function (state: any | null) {},
+  };
+  const [transferDialogProps, setTransferDialogProps] = useState<InputDialogProps<any>>(
+    defaultTransferRequestDialogProps
+  );
+  const [creditDialogProps, setCreditDialogProps] = useState<InputDialogProps<any>>(
+    defaultCreditRequestDialogProps
+  );
+  const clientServices = services.filter(s => s.payload.customer === party);
 
-    if (accountsLoading || assetsLoading || depositsLoading || allocatedAccountsLoading) {
-      return <h4>Loading account...</h4>;
-    }
+  if (accountsLoading || assetsLoading || depositsLoading || allocatedAccountsLoading) {
+    return <h4>Loading account...</h4>;
+  }
 
-    if (!targetAccount) {
-      return <h4>Could not find account.</h4>;
-    }
+  if (!targetAccount) {
+    return <h4>Could not find account.</h4>;
+  }
 
-    const normalAccount = accounts.find(a => a.contractId === targetAccount.contractId);
-    const allocationAccount = allocatedAccounts.find(
-      a => a.contractId === targetAccount.contractId
-    );
-    const service = clientServices.find(s => s.payload.provider === targetAccount.account.provider);
+  const normalAccount = accounts.find(a => a.contractId === targetAccount.contractId);
+  const allocationAccount = allocatedAccounts.find(a => a.contractId === targetAccount.contractId);
+  const service = clientServices.find(s => s.payload.provider === targetAccount.account.provider);
 
-    const accountDeposits = deposits.filter(
-      d =>
-        d.payload.account.id.label === targetAccount.account.id.label &&
-        d.payload.account.provider === targetAccount.account.provider &&
-        d.payload.account.owner === targetAccount.account.owner
-    );
+  const accountDeposits = deposits.filter(
+    d =>
+      d.payload.account.id.label === targetAccount.account.id.label &&
+      d.payload.account.provider === targetAccount.account.provider &&
+      d.payload.account.owner === targetAccount.account.owner
+  );
 
-    const requestWithdrawDeposit = async (c: CreateEvent<AssetDeposit>) => {
-      if (!service)
-        return displayErrorMessage({
-          message: 'The account provider does not offer issuance services.',
-        });
-      await ledger.exercise(Service.RequestDebitAccount, service.contractId, {
-        accountId: c.payload.account.id,
-        debit: { depositCid: c.contractId },
+  const requestWithdrawDeposit = async (c: CreateEvent<AssetDeposit>) => {
+    if (!service)
+      return displayErrorMessage({
+        message: 'The account provider does not offer issuance services.',
       });
-    };
-
-    const relatedAccounts = accounts
-      .filter(a => a.contractId !== cid)
-      .filter(a => a.payload.account.owner === targetAccount.account.owner)
-      .map(r => r.payload.account.id.label);
-
-    const requestTransfer = (deposit: CreateEvent<AssetDeposit>) => {
-      const onClose = async (state: any | null) => {
-        setTransferDialogProps({ ...defaultTransferRequestDialogProps, open: false });
-        if (!state) return;
-        const transferToAccount = accounts.find(a => a.payload.account.id.label === state.account);
-
-        if (!service || !transferToAccount) return;
-
-        await ledger.exercise(Service.RequestTransferDeposit, service.contractId, {
-          accountId: targetAccount.account.id,
-          transfer: {
-            receiverAccountId: transferToAccount.payload.account.id,
-            depositCid: deposit.contractId,
-          },
-        });
-      };
-      setTransferDialogProps({
-        ...defaultTransferRequestDialogProps,
-        defaultValue: {
-          ...defaultTransferRequestDialogProps.defaultValue,
-          deposit: deposit.contractId,
-        },
-        fields: {
-          ...defaultTransferRequestDialogProps.fields,
-          account: { label: 'Account', type: 'selection', items: relatedAccounts },
-        },
-        open: true,
-        onClose,
-      });
-    };
-
-    const requestCredit = async () => {
-      const onClose = async (state: any | null) => {
-        setCreditDialogProps({ ...defaultCreditRequestDialogProps, open: false });
-        if (!state) return;
-
-        const asset = assets.find(i => i.payload.description === creditAsset);
-        if (!asset) return;
-
-        if (!service)
-          return displayErrorMessage({
-            message: `${getName(
-              targetAccount.account.provider
-            )} does not offer issuance services to ${getName(party)}`,
-          });
-
-        await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
-          accountId: targetAccount.account.id,
-          asset: { id: asset.payload.assetId, quantity: creditQuantity },
-        });
-      };
-      setCreditDialogProps({
-        ...defaultCreditRequestDialogProps,
-        defaultValue: {
-          ...defaultCreditRequestDialogProps.fields,
-          account: targetAccount.account.id.label,
-        },
-        fields: {
-          ...defaultCreditRequestDialogProps.fields,
-          account: { label: 'Account', type: 'selection', items: [targetAccount.account.id.label] },
-        },
-        open: true,
-        onClose,
-      });
-      setCreditAsset('');
-      setCreditQuantity('');
-    };
-
-    const requestCloseAccount = async (c: CreateEvent<AssetSettlementRule>) => {
-      if (!service)
-        return displayErrorMessage({
-          message: 'The account provider does not offer issuance services.',
-        });
-      await ledger.exercise(Service.RequestCloseAccount, service.contractId, {
-        accountId: c.payload.account.id,
-      });
-      history.push(paths.app.wallet.requests);
-    };
-
-    let accountData = [
-      {
-        label: 'Name',
-        data: targetAccount.account.id.label,
-      },
-      { label: 'Type', data: normalAccount ? 'Normal' : 'Allocation' },
-      { label: 'Provider', data: getName(targetAccount.account.provider) },
-      { label: 'Owner', data: getName(targetAccount.account.owner) },
-      {
-        label: 'Role',
-        data: party === targetAccount.account.provider ? 'Provider' : 'Client',
-      },
-    ];
-
-    if (normalAccount) {
-      accountData = [
-        ...accountData,
-        {
-          label: 'Controllers',
-          data: damlSetValues(normalAccount.payload.ctrls)
-            .map(ctrl => getName(ctrl))
-            .sort()
-            .join(', '),
-        },
-      ];
-    }
-    if (allocationAccount) {
-      accountData = [
-        ...accountData,
-        {
-          label: 'Nominee',
-          data: allocationAccount.payload.nominee,
-        },
-      ];
-    }
-
-    return (
-      <>
-        <InputDialog {...transferDialogProps} isModal />
-        <InputDialog {...creditDialogProps} isModal />
-
-        <div className="account">
-          <div className="account-details">
-            <h4> {targetAccount.account.id.label} </h4>
-
-            <p className="p2">Type: {normalAccount ? 'Normal' : 'Allocation'} </p>
-            <p className="p2">Provider: {getName(targetAccount.account.provider)}</p>
-            <p className="p2">Owner: {getName(targetAccount.account.owner)}</p>
-            <p className="p2">
-              Role: {party === targetAccount.account.provider ? 'Provider' : 'Client'}
-            </p>
-            {normalAccount && (
-              <OverflowMenu>
-                <OverflowMenuEntry
-                  label={'Close Account'}
-                  onClick={() => requestCloseAccount(normalAccount)}
-                />
-                <OverflowMenuEntry label="Deposit" onClick={() => requestCredit()} />
-              </OverflowMenu>
-            )}
-          </div>
-
-          <div>
-            {accountDeposits.length > 0 ? (
-              accountDeposits.map(c => (
-                <div className="account-holding">
-                  <p>
-                    <b>{c.payload.asset.id.label}</b> {c.payload.asset.quantity}{' '}
-                  </p>
-                  {party === targetAccount.account.owner && normalAccount && (
-                    <div className="actions">
-                      <Button
-                        className="ghost"
-                        content="Withdraw"
-                        onClick={() => requestWithdrawDeposit(c)}
-                      />
-                      {relatedAccounts.length > 0 && (
-                        <Button
-                          className="ghost"
-                          content="Transfer"
-                          onClick={() => requestTransfer(c)}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
-              ))
-            ) : (
-              <div className="none p2">
-                <i>There are no holdings in this account.</i>
-              </div>
-            )}
-          </div>
-        </div>
-      </>
-    );
+    await ledger.exercise(Service.RequestDebitAccount, service.contractId, {
+      accountId: c.payload.account.id,
+      debit: { depositCid: c.contractId },
+    });
   };
 
-export const Account = withRouter(AccountComponent);
+  const relatedAccounts = accounts
+    .filter(a => a.contractId !== cid)
+    .filter(a => a.payload.account.owner === targetAccount.account.owner)
+    .map(r => r.payload.account.id.label);
+
+  const requestTransfer = (deposit: CreateEvent<AssetDeposit>) => {
+    const onClose = async (state: any | null) => {
+      setTransferDialogProps({ ...defaultTransferRequestDialogProps, open: false });
+      if (!state) return;
+      const transferToAccount = accounts.find(a => a.payload.account.id.label === state.account);
+
+      if (!service || !transferToAccount) return;
+
+      await ledger.exercise(Service.RequestTransferDeposit, service.contractId, {
+        accountId: targetAccount.account.id,
+        transfer: {
+          receiverAccountId: transferToAccount.payload.account.id,
+          depositCid: deposit.contractId,
+        },
+      });
+    };
+    setTransferDialogProps({
+      ...defaultTransferRequestDialogProps,
+      defaultValue: {
+        ...defaultTransferRequestDialogProps.defaultValue,
+        deposit: deposit.contractId,
+      },
+      fields: {
+        ...defaultTransferRequestDialogProps.fields,
+        account: { label: 'Account', type: 'selection', items: relatedAccounts },
+      },
+      open: true,
+      onClose,
+    });
+  };
+
+  const requestCredit = async () => {
+    const onClose = async (state: any | null) => {
+      setCreditDialogProps({ ...defaultCreditRequestDialogProps, open: false });
+      if (!state) return;
+
+      const asset = assets.find(i => i.payload.description === creditAsset);
+      if (!asset) return;
+
+      if (!service)
+        return displayErrorMessage({
+          message: `${getName(
+            targetAccount.account.provider
+          )} does not offer issuance services to ${getName(party)}`,
+        });
+
+      await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
+        accountId: targetAccount.account.id,
+        asset: { id: asset.payload.assetId, quantity: creditQuantity },
+      });
+    };
+    setCreditDialogProps({
+      ...defaultCreditRequestDialogProps,
+      defaultValue: {
+        ...defaultCreditRequestDialogProps.fields,
+        account: targetAccount.account.id.label,
+      },
+      fields: {
+        ...defaultCreditRequestDialogProps.fields,
+        account: { label: 'Account', type: 'selection', items: [targetAccount.account.id.label] },
+      },
+      open: true,
+      onClose,
+    });
+    setCreditAsset('');
+    setCreditQuantity('');
+  };
+
+  const requestCloseAccount = async (c: CreateEvent<AssetSettlementRule>) => {
+    if (!service)
+      return displayErrorMessage({
+        message: 'The account provider does not offer issuance services.',
+      });
+    await ledger.exercise(Service.RequestCloseAccount, service.contractId, {
+      accountId: c.payload.account.id,
+    });
+  };
+
+  return (
+    <>
+      <InputDialog {...transferDialogProps} isModal />
+      <InputDialog {...creditDialogProps} isModal />
+
+      <div className="account">
+        <div className="account-details">
+          <h4> {targetAccount.account.id.label} </h4>
+          <p className="p2">Type: {normalAccount ? 'Normal' : 'Allocation'} </p>
+          <p className="p2">Provider: {getName(targetAccount.account.provider)}</p>
+          <p className="p2">Owner: {getName(targetAccount.account.owner)}</p>
+          <p className="p2">
+            Role: {party === targetAccount.account.provider ? 'Provider' : 'Client'}
+          </p>
+          {allocationAccount && <p className="p2">Nominee: {allocationAccount.payload.nominee}</p>}
+          {normalAccount && (
+            <p className="p2">
+              Controllers:{' '}
+              {damlSetValues(normalAccount.payload.ctrls)
+                .map(ctrl => getName(ctrl))
+                .sort()
+                .join(', ')}
+            </p>
+          )}
+          {normalAccount && (
+            <OverflowMenu>
+              <OverflowMenuEntry
+                label={'Close Account'}
+                onClick={() => requestCloseAccount(normalAccount)}
+              />
+              <OverflowMenuEntry label="Deposit" onClick={() => requestCredit()} />
+            </OverflowMenu>
+          )}
+        </div>
+
+        {accountDeposits.length > 0 ? (
+          accountDeposits.map(c => (
+            <Tile className="account-holding">
+              <p>
+                <b>{c.payload.asset.id.label}</b> {c.payload.asset.quantity}{' '}
+              </p>
+              {party === targetAccount.account.owner && normalAccount && (
+                <div className="actions">
+                  <Button
+                    className="ghost"
+                    content="Withdraw"
+                    onClick={() => requestWithdrawDeposit(c)}
+                  />
+                  {relatedAccounts.length > 0 && (
+                    <Button
+                      className="ghost"
+                      content="Transfer"
+                      onClick={() => requestTransfer(c)}
+                    />
+                  )}
+                </div>
+              )}
+            </Tile>
+          ))
+        ) : (
+          <div className="none p2">
+            <i>There are no holdings in this account.</i>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default Account;

--- a/ui/src/pages/custody/Assets.tsx
+++ b/ui/src/pages/custody/Assets.tsx
@@ -1,16 +1,33 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useStreamQueries } from '../../Main';
 import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asset/Settlement';
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service';
-import { ServicePageProps } from '../common';
 import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/Rule/AllocationAccount';
+import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
 import Account from './Account';
-import { Header } from 'semantic-ui-react';
+import Tile from '../../components/Tile/Tile';
+import FormErrorHandled from '../../components/Form/FormErrorHandled';
+import { Button, Form, Header } from 'semantic-ui-react';
+import { ServicePageProps, createDropdownProp } from '../common';
+import { usePartyName } from '../../config';
+import { useLedger, useParty } from '@daml/react';
+import { useDisplayErrorMessage } from '../../context/MessagesContext';
 
 const Assets: React.FC<ServicePageProps<Service>> = ({ services }: ServicePageProps<Service>) => {
   const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
   const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
     useStreamQueries(AllocationAccountRule);
+  const { contracts: assets } = useStreamQueries(AssetDescription);
+  const displayErrorMessage = useDisplayErrorMessage();
+
+  const [creditAsset, setCreditAsset] = useState<string>('');
+  const [creditQuantity, setCreditQuantity] = useState<string>('');
+  const [selectedAccount, setSelectedAccount] = useState<string>('');
+
+  const party = useParty();
+  const ledger = useLedger();
+
+  const { getName } = usePartyName(party);
 
   const allAccounts = useMemo(
     () =>
@@ -30,12 +47,73 @@ const Assets: React.FC<ServicePageProps<Service>> = ({ services }: ServicePagePr
     return <div>Loading...</div>;
   }
 
+  const clientServices = services.filter(s => s.payload.customer === party);
+
+  const onRequestCredit = async () => {
+    const asset = assets.find(i => i.payload.description === creditAsset);
+    const targetAccount = allAccounts.find(a => a.contractId === selectedAccount);
+    if (!asset || !targetAccount) return;
+    const service = clientServices.find(
+      s => s.payload.provider === targetAccount?.account.provider
+    );
+
+    if (!service)
+      return displayErrorMessage({
+        message: `${getName(
+          targetAccount.account.provider
+        )} does not offer issuance services to ${getName(party)}`,
+      });
+
+    await ledger.exercise(Service.RequestCreditAccount, service.contractId, {
+      accountId: targetAccount.account.id,
+      asset: { id: asset.payload.assetId, quantity: creditQuantity },
+    });
+    setCreditAsset('');
+    setCreditQuantity('');
+  };
+
   return (
     <div className="assets">
       <Header as="h2">Accounts</Header>
-      {allAccounts.map(a => (
-        <Account targetAccount={a} services={services} />
-      ))}
+      <div className="page-section-row">
+        <div>
+          {allAccounts.map(a => (
+            <Account targetAccount={a} services={services} />
+          ))}
+        </div>
+
+        <Tile className="inline" header="Quick Deposit">
+          <br />
+          <FormErrorHandled onSubmit={() => onRequestCredit()}>
+            <Form.Select
+              label="Account"
+              options={allAccounts.map(a => {
+                return { text: a.account.id.label, value: a.contractId };
+              })}
+              value={selectedAccount}
+              onChange={(_, data) => setSelectedAccount(data.value as string)}
+            />
+            <Form.Select
+              label="Asset"
+              options={assets.map(a => createDropdownProp(a.payload.description))}
+              value={creditAsset}
+              onChange={(_, data) => setCreditAsset(data.value as string)}
+            />
+            <Form.Input
+              label="Quantity"
+              type="number"
+              value={creditQuantity}
+              onChange={(_, data) => setCreditQuantity(data.value as string)}
+            />
+            <Button
+              type="submit"
+              className="ghost"
+              disabled={creditAsset === '' || creditQuantity === '' || creditQuantity === '0'}
+              content="Submit"
+            />
+          </FormErrorHandled>
+        </Tile>
+      </div>
     </div>
   );
 };

--- a/ui/src/pages/custody/Assets.tsx
+++ b/ui/src/pages/custody/Assets.tsx
@@ -1,21 +1,13 @@
 import React, { useMemo } from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { useParty } from '@daml/react';
 import { useStreamQueries } from '../../Main';
 import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asset/Settlement';
-import { usePartyName } from '../../config';
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service';
 import { ServicePageProps } from '../common';
 import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/Rule/AllocationAccount';
-import { Account } from './Account';
+import Account from './Account';
 import { Header } from 'semantic-ui-react';
 
-const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = ({
-  history,
-  services,
-}: RouteComponentProps & ServicePageProps<Service>) => {
-  const party = useParty();
-
+const Assets: React.FC<ServicePageProps<Service>> = ({ services }: ServicePageProps<Service>) => {
   const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
   const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
     useStreamQueries(AllocationAccountRule);
@@ -42,10 +34,10 @@ const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>>
     <div className="assets">
       <Header as="h2">Accounts</Header>
       {allAccounts.map(a => (
-        <Account contractId={a.contractId} services={services} />
+        <Account targetAccount={a} services={services} />
       ))}
     </div>
   );
 };
 
-export const Assets = withRouter(AssetsComponent);
+export default Assets;

--- a/ui/src/pages/custody/Assets.tsx
+++ b/ui/src/pages/custody/Assets.tsx
@@ -12,6 +12,8 @@ import { ServicePageProps, createDropdownProp } from '../common';
 import { usePartyName } from '../../config';
 import { useLedger, useParty } from '@daml/react';
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
+import TitleWithActions from '../../components/Common/TitleWithActions';
+import { NewAccount } from './New';
 
 const Assets: React.FC<ServicePageProps<Service>> = ({ services }: ServicePageProps<Service>) => {
   const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
@@ -74,7 +76,9 @@ const Assets: React.FC<ServicePageProps<Service>> = ({ services }: ServicePagePr
 
   return (
     <div className="assets">
-      <Header as="h2">Accounts</Header>
+      <TitleWithActions title="Accounts">
+        <NewAccount party={party} modal addButton/>
+      </TitleWithActions>
       <div className="page-section-row">
         <div>
           {allAccounts.map(a => (

--- a/ui/src/pages/custody/Assets.tsx
+++ b/ui/src/pages/custody/Assets.tsx
@@ -2,28 +2,23 @@ import React, { useMemo } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { useParty } from '@daml/react';
 import { useStreamQueries } from '../../Main';
-import { AssetDeposit } from '@daml.js/da-marketplace/lib/DA/Finance/Asset';
 import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asset/Settlement';
 import { usePartyName } from '../../config';
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service';
 import { ServicePageProps } from '../common';
-import StripedTable from '../../components/Table/StripedTable';
 import { AllocationAccountRule } from '@daml.js/da-marketplace/lib/Marketplace/Rule/AllocationAccount';
-import TitleWithActions from '../../components/Common/TitleWithActions';
-import paths from '../../paths';
-import { NewAccount } from './New';
+import { Account } from './Account';
+import { Header } from 'semantic-ui-react';
 
 const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = ({
   history,
   services,
 }: RouteComponentProps & ServicePageProps<Service>) => {
   const party = useParty();
-  const { getName } = usePartyName(party);
 
   const { contracts: accounts, loading: accountsLoading } = useStreamQueries(AssetSettlementRule);
   const { contracts: allocatedAccounts, loading: allocatedAccountsLoading } =
     useStreamQueries(AllocationAccountRule);
-  const { contracts: deposits, loading: depositsLoading } = useStreamQueries(AssetDeposit);
 
   const allAccounts = useMemo(
     () =>
@@ -39,53 +34,16 @@ const AssetsComponent: React.FC<RouteComponentProps & ServicePageProps<Service>>
     [accounts, allocatedAccounts]
   );
 
+  if (accountsLoading || allocatedAccountsLoading) {
+    return <div>Loading...</div>;
+  }
+
   return (
-    <div>
-      <StripedTable
-        title="Holdings"
-        rowsClickable
-        headings={['Asset', 'Account', 'Owner']}
-        loading={depositsLoading}
-        rows={deposits.map(c => {
-          return {
-            elements: [
-              <>
-                <b>{c.payload.asset.id.label}</b> {c.payload.asset.quantity}
-              </>,
-              c.payload.account.id.label,
-              getName(c.payload.account.owner),
-            ],
-            onClick: () =>
-              history.push(
-                paths.app.wallet.account +
-                  '/' +
-                  allAccounts
-                    .find(a => a.account.id.label === c.payload.account.id.label)
-                    ?.contractId.replace('#', '_')
-              ),
-          };
-        })}
-      />
-      <TitleWithActions title="Accounts">
-        <NewAccount custodyServices={services} party={party} modal />
-      </TitleWithActions>
-      <StripedTable
-        rowsClickable
-        headings={['Account', 'Type', 'Provider', 'Owner', 'Role']}
-        loading={accountsLoading || allocatedAccountsLoading}
-        rows={allAccounts.map(a => {
-          return {
-            elements: [
-              a.account.id.label,
-              accounts.find(b => b.contractId === a.contractId) ? 'Normal' : 'Allocation',
-              getName(a.account.provider),
-              getName(a.account.owner),
-              party === a.account.provider ? 'Provider' : 'Client',
-            ],
-            onClick: () => history.push(`${paths.app.wallet.account}/${a.contractId}`),
-          };
-        })}
-      />
+    <div className="assets">
+      <Header as="h2">Accounts</Header>
+      {allAccounts.map(a => (
+        <Account contractId={a.contractId} services={services} />
+      ))}
     </div>
   );
 };

--- a/ui/src/pages/custody/Assets.tsx
+++ b/ui/src/pages/custody/Assets.tsx
@@ -7,7 +7,7 @@ import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuan
 import Account from './Account';
 import Tile from '../../components/Tile/Tile';
 import FormErrorHandled from '../../components/Form/FormErrorHandled';
-import { Button, Form, Header } from 'semantic-ui-react';
+import { Button, Form } from 'semantic-ui-react';
 import { ServicePageProps, createDropdownProp } from '../common';
 import { usePartyName } from '../../config';
 import { useLedger, useParty } from '@daml/react';
@@ -77,7 +77,7 @@ const Assets: React.FC<ServicePageProps<Service>> = ({ services }: ServicePagePr
   return (
     <div className="assets">
       <TitleWithActions title="Accounts">
-        <NewAccount party={party} modal addButton/>
+        <NewAccount party={party} modal addButton />
       </TitleWithActions>
       <div className="page-section-row">
         <div>

--- a/ui/src/pages/custody/New.tsx
+++ b/ui/src/pages/custody/New.tsx
@@ -28,9 +28,10 @@ type Props = {
   party: Party;
   custodyServices?: Readonly<CreateEvent<CustodyService>[]> | undefined;
   modal?: boolean;
+  addButton?: boolean;
 };
 
-const NewComponent: React.FC<Props> = ({ party, custodyServices, modal }) => {
+const NewComponent: React.FC<Props> = ({ party, custodyServices, modal, addButton }) => {
   const { getName } = usePartyName(party);
   const ledger = useLedger();
 
@@ -199,6 +200,7 @@ const NewComponent: React.FC<Props> = ({ party, custodyServices, modal }) => {
       onSubmit={() => requestAccount()}
       title="New Account"
       disabled={!canRequest}
+      addButton={addButton}
     >
       {fields}
     </ModalFormErrorHandled>

--- a/ui/src/pages/page/PageSection.scss
+++ b/ui/src/pages/page/PageSection.scss
@@ -22,10 +22,15 @@
 
       > :first-child {
         margin-right: $spacing-l;
+        width: 100%;
       }
 
       @media screen and (max-width: 1000px) {
         flex-direction: column;
+
+        .tile .inline {
+          width: 100%;
+        }
       }
     }
   }

--- a/ui/src/themes/button.scss
+++ b/ui/src/themes/button.scss
@@ -32,6 +32,11 @@
         border: none;
       }
 
+      &.secondary-smaller {
+        padding: 6px;
+        font-size: 14px;
+      }
+
       &.back-button {
         padding: 6px;
         background-color: transparent;


### PR DESCRIPTION
Instead of a Holdings table followed by an Account table, we now have holdings listed under their designated accounts and a quick deposit tile like the previous marketplace had. This kind of refactor is also working toward flattening the UX where we can i.e. reducing nested pages 

<img width="1680" alt="Screen Shot 2021-06-15 at 2 31 04 PM" src="https://user-images.githubusercontent.com/40438835/122119369-181b7180-cdf7-11eb-84d3-52c094c2f3bc.png">
