### PR TITLE
Add exchange fees

### DIFF
--- a/daml/Marketplace/Distribution/Bidding/Service.daml
+++ b/daml/Marketplace/Distribution/Bidding/Service.daml
@@ -108,7 +108,7 @@ template Service
         payment : Settlement.SettlementDetails
       controller provider, issuer
       do
-        create SettlementInstruction with buyer = customer; seller = issuer; ..
+        create SettlementInstruction with details = [delivery, payment]; ..
 
 template Offer
   with

--- a/daml/Marketplace/Rule/AllocationAccount.daml
+++ b/daml/Marketplace/Rule/AllocationAccount.daml
@@ -36,7 +36,7 @@ template AllocationAccountRule
         deposit <- fetch depositCid
         exerciseByKey @AssetSettlementRule deposit.account.id AssetSettlement_Debit with ..
       credit : Asset -> Update (ContractId AssetDeposit)
-      credit = \asset -> create AssetDeposit with ..
+      credit = \asset -> create AssetDeposit with observers = insert nominee observers; ..
       creditAccount : Account -> Asset -> Update (ContractId AssetDeposit)
       creditAccount = \account asset -> do
         depositCid <- exerciseByKey @AssetSettlementRule account.id AssetSettlement_Credit with ctrl = nominee, ..

--- a/daml/Marketplace/Settlement/Model.daml
+++ b/daml/Marketplace/Settlement/Model.daml
@@ -5,7 +5,7 @@ import DA.Finance.Asset (AssetDeposit)
 import DA.Finance.Asset.Settlement (AssetSettlementRule, AssetSettlement_AddController(..), AssetSettlement_RemoveController(..))
 import Marketplace.Rule.AllocationAccount (AllocationAccountRule, Transfer(..))
 import DA.Action (void, unless)
-import DA.Set (member)
+import DA.Set (member, fromList)
 
 type T = SettlementInstruction
 
@@ -20,17 +20,16 @@ template SettlementInstruction
   with
     operator : Party
     provider : Party
-    buyer : Party
-    seller : Party
-    payment : SettlementDetails
-    delivery : SettlementDetails
+    details : [SettlementDetails]
   where
-    signatory operator, provider, buyer, seller
+    let senders   = map (.senderAccount.owner) details
+        receivers = map (.receiverAccount.owner) details
+    signatory fromList $ [operator, provider] <> senders <> receivers
 
     controller provider can
       Settle : [ContractId AssetDeposit]
         do
-          forA [payment, delivery] (\settlementDetails -> do
+          forA details (\settlementDetails -> do
             let
               transferTo = settlementDetails.receiverAccount
               depositCid = settlementDetails.depositCid

--- a/daml/Marketplace/Trading/Confirmation/Model.daml
+++ b/daml/Marketplace/Trading/Confirmation/Model.daml
@@ -7,10 +7,8 @@ import DA.Finance.Types (Account(..))
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Set (Set, insert)
 import Marketplace.Settlement.Model qualified as Settlement
-import qualified Marketplace.Rule.AllocationAccount as AllocationAccountRule (T, Transfer(..))
 import Marketplace.Trading.Model qualified as Order
-import DA.Optional.Total (whenSome)
-import DA.Functor (void)
+import DA.Optional.Total (optionalToList)
 
 -- TODO: Try to turn this into a service
 
@@ -82,7 +80,7 @@ template Confirmation
           -- TODO: Check that price matches limit order price, quantity is less than order qty, rounding, etc
           -- paymentCurrencyId <- (.quotedAssetId) . snd <$> fetchByKey @Listing (operator, provider, buyOrder.details.symbol)
 
-          [payment, delivery] <- forA [(buyOrder, buyer, seller), (sellOrder, seller, buyer)] (\(order, party, counterparty) -> do
+          details <- concat <$> forA [(buyOrder, buyer, seller), (sellOrder, seller, buyer)] (\(order, party, counterparty) -> do
             let
               isPartialFill = execution.quantity < order.remainingQuantity
               executions = execution :: order.executions
@@ -93,38 +91,40 @@ template Confirmation
               getAllocationAccount = getAccount accounts (.allocationAccount)
               getTradingAccount    = getAccount accounts (.tradingAccount)
 
-            let transferToFeeAccount : ContractId AssetDeposit -> Update (ContractId AssetDeposit)
-                transferToFeeAccount depositCid = do
+            let createFeeDetails : ContractId AssetDeposit -> Update Settlement.SettlementDetails
+                createFeeDetails depositCid = do
                   feeAccount <- (.feeAccount) . snd <$> fetchByKey @Order.FeeSchedule (operator, provider)
-                  exerciseByKey @AllocationAccountRule.T (getAllocationAccount party).id
-                      AllocationAccountRule.Transfer with transferTo = feeAccount; ..
+                  pure $ Settlement.SettlementDetails with depositCid; senderAccount = getAllocationAccount party; receiverAccount = feeAccount
 
             let (Order.Collateral depositCid) = order.collateral
-            depositCid <- if isPartialFill
+            (depositCid, optFeeDetails) <- if isPartialFill
               then do
-                newOptExchangeFee <- case order.details.optExchangeFee of
-                  None               -> return None
+                (newOptExchangeFee, feeDetails) <- case order.details.optExchangeFee of
+                  None               -> return (None, None)
                   Some feeDepositCid -> do
                     feeQuantity <- (.asset.quantity) <$> fetch feeDepositCid
                     let feeToTake = roundBankers 2 $ feeQuantity * (execution.quantity / order.remainingQuantity)
                     [feeDepositCid, remainingFeeDepositCid] <- exercise feeDepositCid AssetDeposit_Split with quantities = [feeToTake]
-                    transferToFeeAccount feeDepositCid
-                    return $ Some remainingFeeDepositCid
+                    feeDetails <- createFeeDetails feeDepositCid
+                    return $ (Some remainingFeeDepositCid, Some feeDetails)
 
                 (depositCid :: depositRemainingCid :: _) <- exercise depositCid AssetDeposit_Split with ..
                 create order with
                   executions, remainingQuantity
                   collateral = Order.Collateral depositRemainingCid, status = Order.PartiallyExecuted
                   details = order.details with optExchangeFee = newOptExchangeFee
-                pure depositCid
+                pure (depositCid, feeDetails)
               else do
-                whenSome order.details.optExchangeFee (void . transferToFeeAccount)
+                optFeeDetails <- case order.details.optExchangeFee of
+                  Some feeCid -> Some <$> createFeeDetails feeCid
+                  _           -> return None
                 create order with
                   executions, remainingQuantity
                   status = Order.FullyExecuted, details = order.details with optExchangeFee = None
-                pure depositCid
+                pure (depositCid, optFeeDetails)
 
-            pure Settlement.SettlementDetails with depositCid; senderAccount = getAllocationAccount party; receiverAccount = getTradingAccount counterparty
+            let tradeDetails = Settlement.SettlementDetails with depositCid; senderAccount = getAllocationAccount party; receiverAccount = getTradingAccount counterparty
+            pure $ optionalToList optFeeDetails <> [tradeDetails]
             )
 
           create Settlement.SettlementInstruction with ..

--- a/daml/Marketplace/Trading/Confirmation/Model.daml
+++ b/daml/Marketplace/Trading/Confirmation/Model.daml
@@ -2,13 +2,15 @@ module Marketplace.Trading.Confirmation.Model where
 
 import DA.List (head)
 import DA.Foldable (forA_)
-import DA.Finance.Asset (AssetDeposit_Split(..))
+import DA.Finance.Asset (AssetDeposit, AssetDeposit_Split(..))
 import DA.Finance.Types (Account(..))
 import DA.Finance.Utils (fetchAndArchive)
 import DA.Set (Set, insert)
 import Marketplace.Settlement.Model qualified as Settlement
--- import Marketplace.Trading.Listing (Listing)
+import qualified Marketplace.Rule.AllocationAccount as AllocationAccountRule (T, Transfer(..))
 import Marketplace.Trading.Model qualified as Order
+import DA.Optional.Total (whenSome)
+import DA.Functor (void)
 
 -- TODO: Try to turn this into a service
 
@@ -91,14 +93,30 @@ template Confirmation
               getAllocationAccount = getAccount accounts (.allocationAccount)
               getTradingAccount    = getAccount accounts (.tradingAccount)
 
+            -- whenSome order.details.optExchangeFee $ \depositCid -> do
+            let transferToFeeAccount : ContractId AssetDeposit -> Update (ContractId AssetDeposit)
+                transferToFeeAccount depositCid = do
+                  feeAccount <- (.feeAccount) . snd <$> fetchByKey @Order.FeeSchedule (operator, provider)
+                  exerciseByKey @AllocationAccountRule.T (getAllocationAccount party).id AllocationAccountRule.Transfer with transferTo = feeAccount; ..
+
             let (Order.Collateral depositCid) = order.collateral
             depositCid <- if isPartialFill
               then do
+                newOptExchangeFee <- case order.details.optExchangeFee of
+                    None               -> return None
+                    Some feeDepositCid -> do
+                        feeQuantity <- (.asset.quantity) <$> fetch feeDepositCid
+                        let feeToTake = feeQuantity * (execution.quantity / order.remainingQuantity)
+                        [feeDepositCid, remainingFeeDepositCid] <- exercise feeDepositCid AssetDeposit_Split with quantities = [feeToTake]
+                        transferToFeeAccount feeDepositCid
+                        return $ Some remainingFeeDepositCid
+
                 (depositCid :: depositRemainingCid :: _) <- exercise depositCid AssetDeposit_Split with ..
                 create order with executions, remainingQuantity, collateral = Order.Collateral depositRemainingCid, status = Order.PartiallyExecuted
                 pure depositCid
               else do
-                create order with executions, remainingQuantity, status = Order.FullyExecuted
+                whenSome order.details.optExchangeFee (void . transferToFeeAccount)
+                create order with executions, remainingQuantity, status = Order.FullyExecuted, details = order.details with optExchangeFee = None
                 pure depositCid
 
             pure Settlement.SettlementDetails with depositCid; senderAccount = getAllocationAccount party; receiverAccount = getTradingAccount counterparty

--- a/daml/Marketplace/Trading/Confirmation/Model.daml
+++ b/daml/Marketplace/Trading/Confirmation/Model.daml
@@ -93,30 +93,35 @@ template Confirmation
               getAllocationAccount = getAccount accounts (.allocationAccount)
               getTradingAccount    = getAccount accounts (.tradingAccount)
 
-            -- whenSome order.details.optExchangeFee $ \depositCid -> do
             let transferToFeeAccount : ContractId AssetDeposit -> Update (ContractId AssetDeposit)
                 transferToFeeAccount depositCid = do
                   feeAccount <- (.feeAccount) . snd <$> fetchByKey @Order.FeeSchedule (operator, provider)
-                  exerciseByKey @AllocationAccountRule.T (getAllocationAccount party).id AllocationAccountRule.Transfer with transferTo = feeAccount; ..
+                  exerciseByKey @AllocationAccountRule.T (getAllocationAccount party).id
+                      AllocationAccountRule.Transfer with transferTo = feeAccount; ..
 
             let (Order.Collateral depositCid) = order.collateral
             depositCid <- if isPartialFill
               then do
                 newOptExchangeFee <- case order.details.optExchangeFee of
-                    None               -> return None
-                    Some feeDepositCid -> do
-                        feeQuantity <- (.asset.quantity) <$> fetch feeDepositCid
-                        let feeToTake = feeQuantity * (execution.quantity / order.remainingQuantity)
-                        [feeDepositCid, remainingFeeDepositCid] <- exercise feeDepositCid AssetDeposit_Split with quantities = [feeToTake]
-                        transferToFeeAccount feeDepositCid
-                        return $ Some remainingFeeDepositCid
+                  None               -> return None
+                  Some feeDepositCid -> do
+                    feeQuantity <- (.asset.quantity) <$> fetch feeDepositCid
+                    let feeToTake = roundBankers 2 $ feeQuantity * (execution.quantity / order.remainingQuantity)
+                    [feeDepositCid, remainingFeeDepositCid] <- exercise feeDepositCid AssetDeposit_Split with quantities = [feeToTake]
+                    transferToFeeAccount feeDepositCid
+                    return $ Some remainingFeeDepositCid
 
                 (depositCid :: depositRemainingCid :: _) <- exercise depositCid AssetDeposit_Split with ..
-                create order with executions, remainingQuantity, collateral = Order.Collateral depositRemainingCid, status = Order.PartiallyExecuted
+                create order with
+                  executions, remainingQuantity
+                  collateral = Order.Collateral depositRemainingCid, status = Order.PartiallyExecuted
+                  details = order.details with optExchangeFee = newOptExchangeFee
                 pure depositCid
               else do
                 whenSome order.details.optExchangeFee (void . transferToFeeAccount)
-                create order with executions, remainingQuantity, status = Order.FullyExecuted, details = order.details with optExchangeFee = None
+                create order with
+                  executions, remainingQuantity
+                  status = Order.FullyExecuted, details = order.details with optExchangeFee = None
                 pure depositCid
 
             pure Settlement.SettlementDetails with depositCid; senderAccount = getAllocationAccount party; receiverAccount = getTradingAccount counterparty

--- a/daml/Marketplace/Trading/Model.daml
+++ b/daml/Marketplace/Trading/Model.daml
@@ -1,7 +1,8 @@
 module Marketplace.Trading.Model where
 
+import DA.Set (Set)
 import DA.Finance.Asset (AssetDeposit)
-import DA.Finance.Types (Id(..), Asset(..))
+import DA.Finance.Types (Account, Id(..), Asset(..))
 import Marketplace.Trading.Error qualified as Error
 
 data Side
@@ -37,6 +38,7 @@ data Details = Details with
     side : Side
     orderType : OrderType
     timeInForce : TimeInForce
+    optExchangeFee : Optional (ContractId AssetDeposit)
   deriving (Eq, Show)
 
 data Status
@@ -93,3 +95,32 @@ template Order
     key (provider, details.id.label) : (Party, Text)
     maintainer key._1
 
+data Fee = Fee with
+    amount : Decimal
+    currency : Id
+    timeInEffect : Time
+  deriving (Show, Eq)
+
+template FeeSchedule
+  with
+    operator : Party
+    provider : Party
+    currentFee : Fee
+    pastFees : [Fee]
+    feeAccount : Account
+    observers : Set Party
+  where
+    signatory provider
+    key (operator, provider) : (Party, Party)
+    maintainer key._2
+    observer observers
+
+    controller provider can
+      UpdateFeeSchedule : ContractId FeeSchedule
+        with
+          amount : Decimal
+          currency : Id
+        do
+          timeInEffect <- getTime
+          let newFee = Fee with ..
+          create this with currentFee = newFee; pastFees = currentFee :: pastFees

--- a/daml/Marketplace/Trading/Role.daml
+++ b/daml/Marketplace/Trading/Role.daml
@@ -85,8 +85,6 @@ template Offer
     controller provider can
       Accept : (ContractId Role, ContractId Matching.Service, ContractId Listing.Service, ContractId Settlement.Service)
         do
-          time <- getTime
-
           matchingCid   <- createOrLookup Matching.Service with ..
           settlementCid <- createOrLookup Settlement.Service with ..
           listingCid    <- createOrLookup Listing.Service with customer = provider, ..
@@ -110,8 +108,6 @@ template Request
         with
           observers : Set Party
         do
-          time <- getTime
-
           matchingCid   <- createOrLookup Matching.Service with ..
           settlementCid <- createOrLookup Settlement.Service with ..
           listingCid    <- createOrLookup Listing.Service with customer = provider, ..

--- a/daml/Marketplace/Trading/Role.daml
+++ b/daml/Marketplace/Trading/Role.daml
@@ -1,9 +1,12 @@
 module Marketplace.Trading.Role where
 
+import DA.Finance.Types
+
 import Marketplace.Settlement.Service qualified as Settlement
 import Marketplace.Trading.Matching.Service qualified as Matching
 import Marketplace.Listing.Service qualified as Listing
 import Marketplace.Trading.Service qualified as Trading
+import Marketplace.Trading.Model qualified as Model
 import Marketplace.Utils
 import DA.Set (Set)
 
@@ -57,6 +60,15 @@ template Role
         do
           archive listingServiceCid
 
+      nonconsuming CreateFeeSchedule : ContractId Model.FeeSchedule
+        with
+          currency : Id
+          feeAccount : Account
+          quantity : Decimal
+        do
+          time <- getTime
+          create Model.FeeSchedule with currentFee = Model.Fee quantity currency time; pastFees = []; ..
+
     controller operator can
       TerminateRole : ()
         do
@@ -73,10 +85,13 @@ template Offer
     controller provider can
       Accept : (ContractId Role, ContractId Matching.Service, ContractId Listing.Service, ContractId Settlement.Service)
         do
+          time <- getTime
+
           matchingCid   <- createOrLookup Matching.Service with ..
           settlementCid <- createOrLookup Settlement.Service with ..
           listingCid    <- createOrLookup Listing.Service with customer = provider, ..
           roleCid       <- createOrLookup Role with ..
+
           return (roleCid, matchingCid, listingCid, settlementCid)
 
       Decline : ()
@@ -95,6 +110,8 @@ template Request
         with
           observers : Set Party
         do
+          time <- getTime
+
           matchingCid   <- createOrLookup Matching.Service with ..
           settlementCid <- createOrLookup Settlement.Service with ..
           listingCid    <- createOrLookup Listing.Service with customer = provider, ..

--- a/daml/Marketplace/Trading/Service.daml
+++ b/daml/Marketplace/Trading/Service.daml
@@ -39,6 +39,12 @@ template Service
         (Order.Cleared party)         -> return $ Order.Cleared party
         (Order.Collateral depositCid) -> Order.Collateral <$> exerciseByKey @AllocationAccountRule.T allocationAccount.id AllocationAccountRule.Withdraw with transferTo = tradingAccount, ..
 
+      withdrawFeesFromAllocationAccount : Optional (ContractId AssetDeposit) -> Update (Optional (ContractId AssetDeposit))
+      withdrawFeesFromAllocationAccount = \case
+        Some depositCid -> Some <$> exerciseByKey @AllocationAccountRule.T allocationAccount.id AllocationAccountRule.Withdraw with transferTo = tradingAccount, ..
+        None            -> return None
+
+
     controller customer can
       nonconsuming RequestCreateOrder : Either (ContractId Order.T)
                                                (ContractId Order.T, ContractId CreateOrderRequest, Order.TradeCollateral)
@@ -52,8 +58,16 @@ template Service
             executions = []
             remainingQuantity = details.asset.quantity
 
+          let detailsWithDepositedFees : Update Order.Details
+              detailsWithDepositedFees = case details.optExchangeFee of
+                  Some feeDepositCid -> do
+                    newDepositCid <- exerciseByKey @AllocationAccountRule.T allocationAccount.id AllocationAccountRule.Deposit with depositCid = feeDepositCid; ..
+                    return details with optExchangeFee = Some newDepositCid
+                  None -> return details
+
           case collateral of
             (Order.Collateral depositCid) -> do
+                details <- detailsWithDepositedFees
                 collateral <- Order.Collateral <$> exerciseByKey @AllocationAccountRule.T allocationAccount.id AllocationAccountRule.Deposit with ..
                 createOrderRequestCid <- create CreateOrderRequest with ..
                 orderCid <- create Order.Order with ..
@@ -69,6 +83,7 @@ template Service
 
                 (Some serviceCid) -> exercise serviceCid Clearing.ApproveTrade >>= \case
                     True -> do
+                        details <- detailsWithDepositedFees
                         createOrderRequestCid <- create CreateOrderRequest with ..
                         orderCid <- create Order.Order with ..
                         return $ Right (orderCid, createOrderRequestCid, collateral)
@@ -117,6 +132,7 @@ template Service
           let reason = Error with code = show errorCode; message = errorMessage
           orderCid <- create order with status = Order.Rejected with reason
           collateral <- withdrawFromAllocationAccount collateral
+          optExchangeFee <- withdrawFeesFromAllocationAccount details.optExchangeFee
 
           return (orderCid, collateral)
 
@@ -152,6 +168,7 @@ template Service
 
           orderCid <- create order with status = Order.Cancelled
           collateral <- withdrawFromAllocationAccount order.collateral
+          optExchangeFee <- withdrawFeesFromAllocationAccount details.optExchangeFee
 
           return (orderCid, collateral)
 

--- a/daml/Marketplace/Trading/Service.daml
+++ b/daml/Marketplace/Trading/Service.daml
@@ -41,8 +41,9 @@ template Service
 
       withdrawFeesFromAllocationAccount : Optional (ContractId AssetDeposit) -> Update (Optional (ContractId AssetDeposit))
       withdrawFeesFromAllocationAccount = \case
-        Some depositCid -> Some <$> exerciseByKey @AllocationAccountRule.T allocationAccount.id AllocationAccountRule.Withdraw with transferTo = tradingAccount, ..
         None            -> return None
+        Some depositCid -> Some <$> exerciseByKey @AllocationAccountRule.T allocationAccount.id
+                                      AllocationAccountRule.Withdraw with transferTo = tradingAccount, ..
 
 
     controller customer can
@@ -61,7 +62,8 @@ template Service
           let detailsWithDepositedFees : Update Order.Details
               detailsWithDepositedFees = case details.optExchangeFee of
                   Some feeDepositCid -> do
-                    newDepositCid <- exerciseByKey @AllocationAccountRule.T allocationAccount.id AllocationAccountRule.Deposit with depositCid = feeDepositCid; ..
+                    newDepositCid <- exerciseByKey @AllocationAccountRule.T allocationAccount.id
+                                        AllocationAccountRule.Deposit with depositCid = feeDepositCid; ..
                     return details with optExchangeFee = Some newDepositCid
                   None -> return details
 

--- a/daml/Tests/Clearing.daml
+++ b/daml/Tests/Clearing.daml
@@ -1,13 +1,12 @@
 module Tests.Clearing where
 
 import Daml.Script
-import DA.Finance.Asset
-import DA.Finance.Types
 import Marketplace.Clearing.Model
 import Marketplace.Clearing.Service (DepositWithRemaining(..),CalculationResult(..))
 import Marketplace.Clearing.Service qualified as Clearing
 
 import Common
+import Tests.Utils
 import DA.Action (void)
 
 testClearingTransfers : Script ()
@@ -131,19 +130,4 @@ testMarkToMarket = do
   assert =<< depositsQuantityEquals bob.customer bob.clearingAccount 25_000.0
 
   return ()
-
--- |Check if the given account has deposits equaling the given amount
-depositsQuantityEquals : Party -> Account -> Decimal -> Script Bool
-depositsQuantityEquals party account amount = do
-  accountQuantity <- getDepositQuantities party =<< getDepositsForAccount party account
-  return $ amount == accountQuantity
-
-getDepositsForAccount : Party -> Account -> Script [ContractId AssetDeposit]
-getDepositsForAccount party account = map fst . filter (\(_,d) -> d.account == account) <$> query @AssetDeposit party
-
-getDepositQuantities : Party -> [ContractId AssetDeposit] -> Script Decimal
-getDepositQuantities party depositCids = do
-  foldl (+) 0.0 <$> forA depositCids (\dcid -> do
-      Some d <- queryContractId party dcid
-      return d.asset.quantity)
 

--- a/daml/Tests/ExchangeTrade.daml
+++ b/daml/Tests/ExchangeTrade.daml
@@ -61,6 +61,7 @@ setup = do
           id = Id with signatories = fromList [ alice.customer ]; label = "123"; version = 0
           listingId
           asset = shareAsset
+          optExchangeFee = None
           orderType = Order.Limit with
             price = 100.0
           side = Order.Buy
@@ -75,6 +76,7 @@ setup = do
           id = Id with signatories = fromList [ bob.customer ]; label = "456"; version = 0
           listingId
           asset = shareAsset
+          optExchangeFee = None
           orderType = Order.Limit with
             price = 100.0
           side = Order.Sell
@@ -147,6 +149,7 @@ partialExecutionsTest = do
           orderType = Order.Limit with price = 100.0
           side = Order.Buy
           timeInForce = Order.GTC
+          optExchangeFee = None
         collateral = Order.Collateral aliceDepositCid
 
   -- > Bob places 4 offers for his shares
@@ -161,6 +164,7 @@ partialExecutionsTest = do
           orderType = Order.Limit with price = 100.0
           side = Order.Sell
           timeInForce = Order.GTC
+          optExchangeFee = None
         collateral = Order.Collateral bobDepositCid
 
   ( bobDepositCid :: bobRemainingDepositCid :: _ ) <- bob.customer `submit` do exerciseCmd bobRemainingDepositCid AssetDeposit_Split with quantities = [50.0]
@@ -174,6 +178,7 @@ partialExecutionsTest = do
           orderType = Order.Limit with price = 100.0
           side = Order.Sell
           timeInForce = Order.GTC
+          optExchangeFee = None
         collateral = Order.Collateral bobDepositCid
 
   ( bobDepositCid :: bobRemainingDepositCid :: _ ) <- bob.customer `submit` do exerciseCmd bobRemainingDepositCid AssetDeposit_Split with quantities = [50.0]
@@ -187,6 +192,7 @@ partialExecutionsTest = do
           orderType = Order.Limit with price = 100.0
           side = Order.Sell
           timeInForce = Order.GTC
+          optExchangeFee = None
         collateral = Order.Collateral bobDepositCid
 
   ( bobDepositCid :: _ ) <- bob.customer `submit` do exerciseCmd bobRemainingDepositCid AssetDeposit_Split with quantities = [50.0]
@@ -200,6 +206,7 @@ partialExecutionsTest = do
           orderType = Order.Limit with price = 100.0
           side = Order.Sell
           timeInForce = Order.GTC
+          optExchangeFee = None
         collateral = Order.Collateral bobDepositCid
 
   -- Exchange matches the the buy order to the 4 sell orders

--- a/daml/Tests/Locking.daml
+++ b/daml/Tests/Locking.daml
@@ -32,10 +32,10 @@ traderCannotMoveAllocatedAsset = do
 
   -- Create orders
   let aliceOrderId = Id with signatories = fromList [ alice.customer ], label = "1", version = 0
-  Right (aliceOrderCid, aliceCreateOrderRequestCid, aliceAssetDepositCid) <- submit alice.customer do exerciseCmd alice.tradingServiceCid Trading.RequestCreateOrder with collateral = Order.Collateral aliceDepositCid; details = Order.Details with id = aliceOrderId, listingId, asset = shareAsset, side = Order.Sell, timeInForce = Order.GTC, orderType = Order.Limit with price = 100.0
+  Right (aliceOrderCid, aliceCreateOrderRequestCid, aliceAssetDepositCid) <- submit alice.customer do exerciseCmd alice.tradingServiceCid Trading.RequestCreateOrder with collateral = Order.Collateral aliceDepositCid; details = Order.Details with optExchangeFee = None, id = aliceOrderId, listingId, asset = shareAsset, side = Order.Sell, timeInForce = Order.GTC, orderType = Order.Limit with price = 100.0
 
   let bobOrderId = Id with signatories = fromList [ bob.customer ], label = "2", version = 0
-  Right (bobOrderCid, bobCreateOrderRequestCid, bobAssetDepositCid) <- submit bob.customer do exerciseCmd bob.tradingServiceCid Trading.RequestCreateOrder with collateral = Order.Collateral bobDepositCid; details = Order.Details with id = bobOrderId, listingId, asset = shareAsset, side = Order.Buy, timeInForce = Order.GTC, orderType = Order.Limit with price = 100.0
+  Right (bobOrderCid, bobCreateOrderRequestCid, bobAssetDepositCid) <- submit bob.customer do exerciseCmd bob.tradingServiceCid Trading.RequestCreateOrder with collateral = Order.Collateral bobDepositCid; details = Order.Details with optExchangeFee = None, id = bobOrderId, listingId, asset = shareAsset, side = Order.Buy, timeInForce = Order.GTC, orderType = Order.Limit with price = 100.0
 
   -- Account owners can't move asset pledged as order collateral
   submitMustFail alice.customer do exerciseByKeyCmd @AllocationAccountRule alice.exchangeLockedAccount.id Transfer with depositCid = aliceDepositCid; transferTo = alice.mainAccount

--- a/daml/Tests/Trading/Cleared.daml
+++ b/daml/Tests/Trading/Cleared.daml
@@ -76,6 +76,7 @@ clearedTradingTest = do
         collateral = Order.Cleared clearinghouse
         details = Order.Details with
             id = aliceOrderId
+            optExchangeFee = None
             listingId
             asset = tsla with quantity = 200.0
             side = Order.Sell
@@ -91,6 +92,7 @@ clearedTradingTest = do
             id = bobOrderId
             listingId
             asset = shareAsset
+            optExchangeFee = None
             side = Order.Buy
             timeInForce = Order.GTC
             orderType = Order.Limit with price = 100.0
@@ -147,6 +149,7 @@ clearedTradingTest = do
             id = bobOrderId2
             listingId
             asset = shareAsset
+            optExchangeFee = None
             side = Order.Buy
             timeInForce = Order.GTC
             orderType = Order.Limit with price = 100.0
@@ -164,6 +167,7 @@ clearedTradingTest = do
             id = charlieOrderId
             listingId
             asset = shareAsset
+            optExchangeFee = None
             side = Order.Buy
             timeInForce = Order.GTC
             orderType = Order.Limit with price = 100.0

--- a/daml/Tests/Trading/E2E.daml
+++ b/daml/Tests/Trading/E2E.daml
@@ -67,6 +67,7 @@ tradingEndToEndTest = do
             asset = tsla with quantity = 200.0
             side = Order.Sell
             timeInForce = Order.GTC
+            optExchangeFee = None
             orderType = Order.Limit with price = 100.0
   checkOrderStatusMatches aliceOrderCid alice.customer Order.New
 
@@ -79,6 +80,7 @@ tradingEndToEndTest = do
             listingId
             asset = shareAsset
             side = Order.Buy
+            optExchangeFee = None
             timeInForce = Order.GTC
             orderType = Order.Limit with price = 100.0
   checkOrderStatusMatches bobOrderCid bob.customer Order.New

--- a/daml/Tests/Trading/Fees.daml
+++ b/daml/Tests/Trading/Fees.daml
@@ -1,4 +1,3 @@
-
 module Tests.Trading.Fees where
 
 import Common
@@ -42,8 +41,6 @@ setup = do
 
   exchange `submit` createCmd Trading.FeeSchedule with currentFee = Trading.Fee 0.0 currency time; provider = exchange; pastFees = []; observers = Set.fromList [public]; ..
   exchange `submit` exerciseByKeyCmd @Trading.FeeSchedule (operator,exchange) Trading.UpdateFeeSchedule with amount = 2.0; currency = usd.id
-
-
 
   -- Assets
   let

--- a/daml/Tests/Trading/Fees.daml
+++ b/daml/Tests/Trading/Fees.daml
@@ -1,6 +1,7 @@
 module Tests.Trading.Fees where
 
 import Common
+import Tests.Utils
 import Daml.Script
 import DA.Set
 import DA.Set qualified as Set
@@ -117,5 +118,7 @@ setup = do
 
   -- Exchange settles the instructed trade
   submit exchange do exerciseCmd settlementInstructionCid Settlement.Settle
+
+  assert =<< depositsQuantityEquals exchange feeAccount 4.0
 
   pure ()

--- a/daml/Tests/Trading/Fees.daml
+++ b/daml/Tests/Trading/Fees.daml
@@ -1,0 +1,124 @@
+
+module Tests.Trading.Fees where
+
+import Common
+import Daml.Script
+import DA.Set
+import DA.Set qualified as Set
+import DA.Finance.Types
+import Marketplace.Custody.Role qualified as Custodian
+import Marketplace.Trading.Model qualified as Trading
+import Marketplace.Custody.Service qualified as Custody
+import qualified Marketplace.Settlement.Model as Settlement
+import qualified Marketplace.Trading.Matching.Service as Matching
+import qualified Marketplace.Trading.Model as Order
+import qualified Marketplace.Trading.Service as TradingService
+import qualified Marketplace.Listing.Service as Listing
+import qualified Marketplace.Listing.Model as Listing
+
+import DA.List
+
+setup : Script ()
+setup = do
+  providers@Providers{public; operator; bank; exchange; matchingServiceCid, custodianRoleCid} <- onboardProviders
+
+  alice <- onboardCustomer providers "Alice"
+  bob <- onboardCustomer providers "Bob"
+  issuer <- onboardCustomer providers "Issuer"
+
+  Assets{usd; tsla} <- onboardAssets providers issuer
+
+  -- set up exchange fee schedule
+  time <- getTime
+  let feeAccountId = Id with signatories = Set.fromList [ bank, exchange]; label = "FeeAccount-" <> show exchange; version = 0
+      feeAccount   = Account with provider = bank; owner = exchange; id = feeAccountId
+      currency     = usd.id
+
+  custodyServiceOfferCid <- submit bank do exerciseCmd custodianRoleCid Custodian.OfferCustodyService with customer = exchange, ..
+  custodyServiceCid <- submit exchange do exerciseCmd custodyServiceOfferCid Custody.Accept
+
+  openAccountRequestCid <- submit exchange do exerciseCmd custodyServiceCid Custody.RequestOpenAccount with accountId = feeAccountId; observers = [bank]; ctrls = [bank, exchange]
+  submit bank do exerciseCmd custodyServiceCid Custody.OpenAccount with openAccountRequestCid = openAccountRequestCid
+
+  exchange `submit` createCmd Trading.FeeSchedule with currentFee = Trading.Fee 0.0 currency time; provider = exchange; pastFees = []; observers = Set.fromList [public]; ..
+  exchange `submit` exerciseByKeyCmd @Trading.FeeSchedule (operator,exchange) Trading.UpdateFeeSchedule with amount = 2.0; currency = usd.id
+
+
+
+  -- Assets
+  let
+    shareAsset = tsla with quantity = 200.0
+    cashAsset = usd with quantity = 20000.0
+    priceAsset = usd with quantity = 100.0
+    feeAsset = usd with quantity = 2.0
+
+  aliceDepositCid <- depositAsset providers alice shareAsset alice.mainAccount.id
+  aliceFeeDepositCid <- depositAsset providers alice feeAsset alice.mainAccount.id
+  bobDepositCid <- depositAsset providers bob cashAsset bob.mainAccount.id
+  bobFeeDepositCid <- depositAsset providers bob feeAsset bob.mainAccount.id
+
+  -- List a Security to trade
+  (listingServiceCid, _) <- head <$> query @Listing.Service alice.customer
+  let
+    symbol = "TSLAUSD"
+    listingType = Listing.CollateralizedRequest
+    calendarId = "1"
+    description = "Tesla Inc."
+    tradedAssetId = shareAsset.id
+    quotedAssetId = cashAsset.id
+    tradedAssetPrecision = 2
+    quotedAssetPrecision = 2
+    minimumTradableQuantity = 1.0
+    maximumTradableQuantity = 1000000.0
+    providerId = "12345"
+    observers = []
+  createListingRequestCid <- alice.customer `submit` do exerciseCmd listingServiceCid Listing.RequestCreateListing with ..
+  listingCid <- exchange `submit` do exerciseCmd listingServiceCid Listing.CreateListing with ..
+  (Some Listing.Listing{listingId}) <- queryContractId @Listing.Listing exchange listingCid
+
+  -- > Alice places a bid for shares
+  Right (aliceOrderCid, aliceCreateOrderRequestCid, _) <- submit alice.customer do
+    exerciseByKeyCmd @TradingService.T (operator, exchange, alice.customer) TradingService.RequestCreateOrder
+      with
+        details = Order.Details with
+          id = Id with signatories = fromList [ alice.customer ]; label = "123"; version = 0
+          listingId
+          asset = shareAsset
+          optExchangeFee = Some aliceFeeDepositCid
+          orderType = Order.Limit with
+            price = 100.0
+          side = Order.Buy
+          timeInForce = Order.GTC
+        collateral = Order.Collateral aliceDepositCid
+
+  -- > Bob places a new offer for shares
+  Right (bobOrderCid, bobCreateOrderRequestCid, _) <- submit bob.customer do
+    exerciseByKeyCmd @TradingService.T (operator, exchange, bob.customer) TradingService.RequestCreateOrder
+      with
+        details = Order.Details with
+          id = Id with signatories = fromList [ bob.customer ]; label = "456"; version = 0
+          listingId
+          asset = shareAsset
+          optExchangeFee = Some bobFeeDepositCid
+          orderType = Order.Limit with
+            price = 100.0
+          side = Order.Sell
+          timeInForce = Order.GTC
+        collateral = Order.Collateral bobDepositCid
+
+  -- Exchange matches the two orders
+  Matching.Collateralized settlementInstructionCid <- submit exchange do
+    exerciseCmd matchingServiceCid Matching.MatchOrders
+      with
+        execution = Order.Execution with
+          matchId = "789"
+          makerOrderId = "123"
+          takerOrderId = "456"
+          quantity = 200.0
+          price = 100.0
+          timestamp = ""
+
+  -- Exchange settles the instructed trade
+  submit exchange do exerciseCmd settlementInstructionCid Settlement.Settle
+
+  pure ()

--- a/daml/Tests/Utils.daml
+++ b/daml/Tests/Utils.daml
@@ -1,10 +1,13 @@
 module Tests.Utils where
 
+import Daml.Script
+
 import ContingentClaims.Claim (Claim, Claim(Zero), when, scale, cond, give, one, and, or)
 import ContingentClaims.Observable qualified as O
 import ContingentClaims.Observation qualified as O
 import ContingentClaims.FinancialClaim (at, fixed, floating, swap, european, bermudan)
-import DA.Finance.Types (Id(..))
+import DA.Finance.Asset
+import DA.Finance.Types (Account, Id(..))
 import Prelude hiding (and, or)
 
 type C = Claim O.Observation Date Id
@@ -65,3 +68,19 @@ convertibleNote underlying ccy principal discount maturity interest cap =
     conversionPayout = scale (O.pure (principal * (1.0 + interest)) O./ (O.observe underlying.label O.* O.pure (1.0 - discount))) (one underlying)
     principalPayout = scale (O.pure (principal * (1.0 + interest))) (one ccy)
   in when (at maturity) $ cond conversionCondition conversionPayout principalPayout
+
+-- |Check if the given account has deposits equaling the given amount
+depositsQuantityEquals : Party -> Account -> Decimal -> Script Bool
+depositsQuantityEquals party account amount = do
+  accountQuantity <- getDepositQuantities party =<< getDepositsForAccount party account
+  return $ amount == accountQuantity
+
+getDepositsForAccount : Party -> Account -> Script [ContractId AssetDeposit]
+getDepositsForAccount party account = map fst . filter (\(_,d) -> d.account == account) <$> query @AssetDeposit party
+
+getDepositQuantities : Party -> [ContractId AssetDeposit] -> Script Decimal
+getDepositQuantities party depositCids = do
+  foldl (+) 0.0 <$> forA depositCids (\dcid -> do
+      Some d <- queryContractId party dcid
+      return d.asset.quantity)
+

--- a/exberry_adapter/bot/exberry_adapter_bot.py
+++ b/exberry_adapter/bot/exberry_adapter_bot.py
@@ -25,6 +25,7 @@ class EXBERRY:
 
 class MARKETPLACE:
     CreateOrderRequest = 'Marketplace.Trading.Service:CreateOrderRequest'
+    FeeSchedule = 'Marketplace.Trading.Model:FeeSchedule'
     CancelOrderRequest = 'Marketplace.Trading.Service:CancelOrderRequest'
     Order = 'Marketplace.Trading.Model:Order'
     CreateListingRequest = 'Marketplace.Listing.Service:CreateListingRequest'
@@ -95,9 +96,24 @@ def main():
 
     # Marketplace --> Exberry
     @client.ledger_created(MARKETPLACE.CreateOrderRequest)
-    def handle_order_request(event):
+    async def handle_order_request(event):
         logging.info(f'Received Create Order Request - {event}')
         order = event.cdata['details']
+
+        opt_fee_contract_id = order['optExchangeFee']
+        fee_amount = 0.0
+        if opt_fee_contract_id != None:
+            fee_deposit = client.find_by_id(opt_fee_contract_id)
+            fee_amount = fee_deposit['asset']['quantity']
+
+
+        _, fee_schedule = await client.find_one(MARKETPLACE.FeeSchedule, {'provider': exchange_party})
+        if fee_schedule['currentFee']['amount'] > fee_amount:
+            return [exercise(event.cid,
+                        'RejectRequest', {
+                            'errorCode': '790',
+                            'errorMessage': 'Fee does not match exchange fee'}
+                    )]
 
         return create(EXBERRY.NewOrderRequest, {
             'order': {

--- a/triggers/daml/MatchingEngine.daml
+++ b/triggers/daml/MatchingEngine.daml
@@ -49,11 +49,9 @@ handleMatchingRule party = do
   -- Acknowledge all 'Order.Request' and update current ID                                                                        │
   orderRequests <- query @Service.CreateOrderRequest
   deposits <- query @AssetDeposit
-  debug $ show deposits
   forA_ orderRequests \(cid,or) -> do
     exchangeFeeAmount <- case or.details.optExchangeFee of
-        Some depositCid -> do
-          (.asset.quantity) . fromSomeNote "querying exchange fee" <$> queryContractId depositCid
+        Some depositCid -> (.asset.quantity) . fromSomeNote "querying exchange fee" <$> queryContractId depositCid
         None            -> return 0.0
     if exchangeFeeAmount < currentFee
     then void $ emitExerciseCmd cid Service.RejectRequest with errorCode = 790; errorMessage = "Fee requirement not met"

--- a/triggers/daml/MatchingEngine.daml
+++ b/triggers/daml/MatchingEngine.daml
@@ -4,6 +4,7 @@
 module MatchingEngine where
 
 import DA.Action
+import DA.Optional
 import DA.Foldable hiding (elem, null, length)
 import DA.List
 import Daml.Trigger
@@ -15,6 +16,7 @@ import qualified Marketplace.Clearing.Market.Service as MarketClearingService
 import qualified Marketplace.Trading.Matching.Service as Matching
 
 import Utils
+import DA.Finance.Asset (AssetDeposit)
 
 type CurrentOrderId = Int
 
@@ -24,10 +26,12 @@ handleMatching = Trigger
   , updateState = \_ -> pure ()
   , rule = handleMatchingRule
   , registeredTemplates = RegisteredTemplates [ registeredTemplate @ListingService.Service
+                                              , registeredTemplate @AssetDeposit
                                               , registeredTemplate @ListingService.CreateListingRequest
                                               , registeredTemplate @MarketClearingService.Service
                                               , registeredTemplate @Service.CreateOrderRequest
                                               , registeredTemplate @Service.CancelOrderRequest
+                                              , registeredTemplate @Order.FeeSchedule
                                               , registeredTemplate @Order.T ]
   , heartbeat = None
   }
@@ -36,13 +40,28 @@ handleMatchingRule : Party -> TriggerA CurrentOrderId ()
 handleMatchingRule party = do
   debug "Running matching rule..."
 
-  -- Acknowledge all 'Order.Request' and update current ID
+  fees <- query @Order.FeeSchedule
+
+  let currentFee = case fees of
+        [(_, feeSchedule):xs] -> feeSchedule.currentFee.amount
+        _                     -> 0.0
+
+  -- Acknowledge all 'Order.Request' and update current ID                                                                        │
   orderRequests <- query @Service.CreateOrderRequest
-  forA_ orderRequests \(cid,_) -> do
-    currentOrderId <- get
-    emitExerciseCmd cid Service.AcknowledgeRequest with providerOrderId = show currentOrderId
-    debug "Acknowledging order"
-    modify (+1)
+  deposits <- query @AssetDeposit
+  debug $ show deposits
+  forA_ orderRequests \(cid,or) -> do
+    exchangeFeeAmount <- case or.details.optExchangeFee of
+        Some depositCid -> do
+          (.asset.quantity) . fromSomeNote "querying exchange fee" <$> queryContractId depositCid
+        None            -> return 0.0
+    if exchangeFeeAmount < currentFee
+    then void $ emitExerciseCmd cid Service.RejectRequest with errorCode = 790; errorMessage = "Fee requirement not met"
+    else do
+      currentOrderId <- get
+      emitExerciseCmd cid Service.AcknowledgeRequest with providerOrderId = show currentOrderId
+      debug "Acknowledging order"
+      modify (+1)
 
   time <- getTime
   -- Acknowledge all 'Order.CancelRequest'

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -60,6 +60,7 @@ import { TradingOrder } from './pages/trading/Order';
 import Notifications, { useAllNotifications } from './pages/notifications/Notifications';
 import { ServiceRequired } from './pages/error/ServiceRequired';
 import paths from './paths';
+import {FeeSchedule} from '@daml.js/da-marketplace/lib/Marketplace/Trading/Model';
 
 type Entry = {
   displayEntry: () => boolean;
@@ -305,16 +306,16 @@ const AppComponent = () => {
     ],
     additionalRoutes: [
       {
-        path: paths.app.listings.root + '/:contractId?',
-        render: () => <ListingsTable services={listingService} listings={listings} />,
-      },
-      {
         path: paths.app.listings.new,
         render: () => (
           <ServiceRequired service={ServiceKind.LISTING} action="New Listing">
             <ListingNew services={listingService} />
           </ServiceRequired>
         ),
+      },
+      {
+        path: paths.app.listings.root + '/:contractId?',
+        render: () => <ListingsTable services={listingService} listings={listings} />,
       },
     ],
   });
@@ -333,6 +334,7 @@ const AppComponent = () => {
     ],
   });
 
+  const { contracts: feeSchedules } = useStreamQueries(FeeSchedule);
   entries.push({
     displayEntry: () => tradingService.length > 0,
     sidebar: [
@@ -346,7 +348,7 @@ const AppComponent = () => {
         children: listings.map(c => ({
           label: c.payload.listingId.label,
           path: paths.app.markets.root + '/' + c.contractId.replace('#', '_'),
-          render: () => <Market services={tradingService} cid={c.contractId} listings={listings} />,
+          render: () => <Market services={tradingService} cid={c.contractId} listings={listings} feeSchedules={feeSchedules}/>,
           icon: <ExchangeIcon />,
           children: [],
         })),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -60,7 +60,7 @@ import { TradingOrder } from './pages/trading/Order';
 import Notifications, { useAllNotifications } from './pages/notifications/Notifications';
 import { ServiceRequired } from './pages/error/ServiceRequired';
 import paths from './paths';
-import {FeeSchedule} from '@daml.js/da-marketplace/lib/Marketplace/Trading/Model';
+import { FeeSchedule } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Model';
 
 type Entry = {
   displayEntry: () => boolean;
@@ -348,7 +348,14 @@ const AppComponent = () => {
         children: listings.map(c => ({
           label: c.payload.listingId.label,
           path: paths.app.markets.root + '/' + c.contractId.replace('#', '_'),
-          render: () => <Market services={tradingService} cid={c.contractId} listings={listings} feeSchedules={feeSchedules}/>,
+          render: () => (
+            <Market
+              services={tradingService}
+              cid={c.contractId}
+              listings={listings}
+              feeSchedules={feeSchedules}
+            />
+          ),
           icon: <ExchangeIcon />,
           children: [],
         })),

--- a/ui/src/components/Tile/Tile.tsx
+++ b/ui/src/components/Tile/Tile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Header } from 'semantic-ui-react';
+import { Header, Loader } from 'semantic-ui-react';
 import { OpenMarketplaceLogo } from '../../icons/icons';
 
 const logoHeader = (
@@ -17,6 +17,7 @@ type TileProps = {
   thinGap?: boolean;
   subtitle?: string;
   showLogoHeader?: boolean;
+  loading?: boolean;
 };
 
 const Tile: React.FC<TileProps> = ({
@@ -27,6 +28,7 @@ const Tile: React.FC<TileProps> = ({
   subtitle,
   header,
   showLogoHeader,
+  loading,
 }) => {
   return (
     <>
@@ -34,7 +36,13 @@ const Tile: React.FC<TileProps> = ({
         {!!showLogoHeader && <div className="tile-header">{logoHeader}</div>}
         {!!header && <Header as="h3">{header}</Header>}
         {!!subtitle && <p className="subtitle">{subtitle}</p>}
-        <div className="tile-content">{children}</div>
+        {loading ? (
+          <Loader active size="large">
+            <p>Loading...</p>
+          </Loader>
+        ) : (
+          <div className="tile-content">{children}</div>
+        )}
       </div>
     </>
   );

--- a/ui/src/pages/listing/New.tsx
+++ b/ui/src/pages/listing/New.tsx
@@ -81,7 +81,6 @@ const NewComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = 
   }, [el2, quotedAsset, showQuotedAsset]);
 
   const service = customerServices[0];
-  console.log('on this page');
   if (!service) return <></>;
 
   const requestListing = async () => {

--- a/ui/src/pages/listing/New.tsx
+++ b/ui/src/pages/listing/New.tsx
@@ -81,6 +81,7 @@ const NewComponent: React.FC<RouteComponentProps & ServicePageProps<Service>> = 
   }, [el2, quotedAsset, showQuotedAsset]);
 
   const service = customerServices[0];
+  console.log('on this page');
   if (!service) return <></>;
 
   const requestListing = async () => {

--- a/ui/src/pages/network/Fees.tsx
+++ b/ui/src/pages/network/Fees.tsx
@@ -16,7 +16,7 @@ type Props = {
   role: CreateEvent<ExchangeRole, any, any>;
 };
 
-const NewComponent: React.FC<Props> = ({ role }: Props) => {
+const ManageFees: React.FC<Props> = ({ role }: Props) => {
   const ledger = useLedger();
   const party = useParty();
   const custodyServices = useStreamQueries(CustodyService).contracts;
@@ -137,4 +137,4 @@ const NewComponent: React.FC<Props> = ({ role }: Props) => {
   );
 };
 
-export const NewFee = NewComponent;
+export default ManageFees;

--- a/ui/src/pages/network/Fees.tsx
+++ b/ui/src/pages/network/Fees.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+import AccountComponent from '../custody/Account';
+import { Service as CustodyService } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Service';
+import { useLedger, useParty } from '@daml/react';
+import { useStreamQueries } from '../../Main';
+import { AssetSettlementRule } from '@daml.js/da-marketplace/lib/DA/Finance/Asset/Settlement';
+import { AssetDescription } from '@daml.js/da-marketplace/lib/Marketplace/Issuance/AssetDescription';
+import { Role as ExchangeRole } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Role';
+import { CreateEvent } from '@daml/ledger';
+import FormErrorHandled from '../../components/Form/FormErrorHandled';
+import { Button, Form } from 'semantic-ui-react';
+import Tile from '../../components/Tile/Tile';
+import { FeeSchedule } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Model';
+
+type Props = {
+  role: CreateEvent<ExchangeRole, any, any>;
+};
+
+const NewComponent: React.FC<Props> = ({ role }: Props) => {
+  const ledger = useLedger();
+  const party = useParty();
+  const custodyServices = useStreamQueries(CustodyService).contracts;
+  const { contracts: feeSchedules, loading: schedulesLoading } = useStreamQueries(FeeSchedule);
+  const feeSchedule = feeSchedules.find(fs => fs.payload.provider === party);
+
+  const [assetLabel, setAssetLabel] = useState(feeSchedule?.payload.currentFee.currency.label);
+  const [accountLabel, setAccountLabel] = useState('');
+  const [quantity, setQuantity] = useState(
+    !!feeSchedule ? feeSchedule.payload.currentFee.amount : ''
+  );
+
+  useEffect(() => {
+    if (!feeSchedule) return;
+    setAssetLabel(feeSchedule.payload.currentFee.currency.label);
+    setQuantity(feeSchedule.payload.currentFee.amount);
+    setAccountLabel(feeSchedule.payload.feeAccount.id.label);
+  }, [feeSchedule]);
+
+  const assets = useStreamQueries(AssetDescription).contracts;
+
+  const asset = assets.find(c => c.payload.assetId.label === assetLabel);
+  const assetSettlementRules = useStreamQueries(AssetSettlementRule).contracts;
+  const accounts = assetSettlementRules
+    .map(c => c.payload.account)
+    .filter(acc => acc.owner === party);
+  const account = accounts.find(a => a.id.label === accountLabel);
+  const accountRule = assetSettlementRules.find(ar => ar.payload.account.id.label === accountLabel);
+
+  const canRequest = !feeSchedule
+    ? !!assetLabel && !!asset && !!accountLabel && !!account && !!quantity
+    : !!quantity;
+
+  if (!role)
+    return (
+      <div>
+        <h2>Party "{party}" can not setup a Fee Schedule.</h2>
+      </div>
+    );
+
+  const createFeeSchedule = async () => {
+    if (!feeSchedule) {
+      if (!asset || !account) return;
+      await ledger.exercise(ExchangeRole.CreateFeeSchedule, role.contractId, {
+        currency: asset.payload.assetId,
+        feeAccount: account,
+        quantity,
+      });
+    } else {
+      if (!asset) return;
+      await ledger.exercise(FeeSchedule.UpdateFeeSchedule, feeSchedule.contractId, {
+        amount: quantity,
+        currency: asset.payload.assetId,
+      });
+    }
+  };
+
+  return (
+    <div className="page-section-row">
+      <Tile className="inline" header="Setup Fees">
+        <br />
+        {!schedulesLoading && (
+          <FormErrorHandled onSubmit={createFeeSchedule}>
+            {!feeSchedule && (
+              <>
+                <Form.Select
+                  selection
+                  label="Fee Account"
+                  options={accounts.map(c => ({
+                    text: c.id.label,
+                    value: c.id.label,
+                  }))}
+                  value={accountLabel}
+                  onChange={(_, d) => setAccountLabel((d.value && (d.value as string)) || '')}
+                />
+              </>
+            )}
+            <Form.Select
+              selection
+              label="Currency"
+              options={assets.map(c => ({
+                text: c.payload.assetId.label,
+                value: c.payload.assetId.label,
+              }))}
+              value={!!feeSchedule ? assetLabel : assetLabel}
+              onChange={(_, d) => setAssetLabel((d.value && (d.value as string)) || '')}
+            />
+
+            <Form.Input
+              placeholder={!!feeSchedule ? feeSchedule.payload.currentFee.amount : quantity}
+              required
+              fluid
+              number
+              label="Fee Amount"
+              value={quantity}
+              onChange={e => setQuantity(e.currentTarget.value)}
+            />
+
+            <Button type="submit" disabled={!canRequest} className="ghost">
+              {!!feeSchedule ? 'Update Fee Schedule' : 'Create Fee Schedule'}
+            </Button>
+          </FormErrorHandled>
+        )}
+      </Tile>
+      <Tile className="inline">
+        <br />
+        {!!accountRule && (
+          <AccountComponent
+            targetAccount={{
+              account: accountRule.payload.account,
+              contractId: accountRule.contractId,
+            }}
+            services={custodyServices}
+          />
+        )}
+      </Tile>
+    </div>
+  );
+};
+
+export const NewFee = NewComponent;

--- a/ui/src/pages/network/Trading.tsx
+++ b/ui/src/pages/network/Trading.tsx
@@ -7,7 +7,7 @@ import { Role as ExchangeRole } from '@daml.js/da-marketplace/lib/Marketplace/Tr
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Service/module';
 import { getTemplateId, usePartyName } from '../../config';
 import StripedTable from '../../components/Table/StripedTable';
-import { NewFee } from './Fees';
+import ManageFees from './Fees';
 
 type Props = {
   services: Readonly<CreateEvent<Service, any, any>[]>;
@@ -26,7 +26,7 @@ export const TradingServiceTable: React.FC<Props> = ({ services }) => {
 
   return (
     <div>
-      {!!role && <NewFee role={role} />}
+      {!!role && <ManageFees role={role} />}
       <StripedTable
         title="Trading"
         headings={[

--- a/ui/src/pages/network/Trading.tsx
+++ b/ui/src/pages/network/Trading.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { Button } from 'semantic-ui-react';
 import { CreateEvent } from '@daml/ledger';
 import { useLedger, useParty } from '@daml/react';
+import { useStreamQueries } from '../../Main';
+import { Role as ExchangeRole } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Role';
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Service/module';
 import { getTemplateId, usePartyName } from '../../config';
 import StripedTable from '../../components/Table/StripedTable';
+import {NewFee} from './Fees';
 
 type Props = {
   services: Readonly<CreateEvent<Service, any, any>[]>;
@@ -15,39 +18,46 @@ export const TradingServiceTable: React.FC<Props> = ({ services }) => {
   const { getName } = usePartyName(party);
   const ledger = useLedger();
 
+  const role = useStreamQueries(ExchangeRole).contracts.find(rl => rl.payload.provider === party);
+
   const terminateService = async (c: CreateEvent<Service>) => {
     await ledger.exercise(Service.Terminate, c.contractId, { ctrl: party });
   };
 
   return (
-    <StripedTable
-      title="Trading"
-      headings={[
-        'Service',
-        'Operator',
-        'Provider',
-        'Consumer',
-        'Role',
-        'Trading Account',
-        'Allocation Account',
-        'Action',
-      ]}
-      rows={services.map((c, i) => {
-        return {
-          elements: [
-            getTemplateId(c.templateId),
-            getName(c.payload.operator),
-            getName(c.payload.provider),
-            getName(c.payload.customer),
-            party === c.payload.provider ? 'Provider' : 'Consumer',
-            c.payload.tradingAccount.id.label,
-            c.payload.allocationAccount.id.label,
-            <Button className="ghost warning" onClick={() => terminateService(c)}>
-              Terminate
-            </Button>,
-          ],
-        };
-      })}
-    />
+    <div>
+      {!!role && (
+        <NewFee role={role}/>
+      )}
+      <StripedTable
+        title="Trading"
+        headings={[
+          'Service',
+          'Operator',
+          'Provider',
+          'Consumer',
+          'Role',
+          'Trading Account',
+          'Allocation Account',
+          'Action',
+        ]}
+        rows={services.map((c, i) => {
+          return {
+            elements: [
+              getTemplateId(c.templateId),
+              getName(c.payload.operator),
+              getName(c.payload.provider),
+              getName(c.payload.customer),
+              party === c.payload.provider ? 'Provider' : 'Consumer',
+              c.payload.tradingAccount.id.label,
+              c.payload.allocationAccount.id.label,
+              <Button className="ghost warning" onClick={() => terminateService(c)}>
+                Terminate
+              </Button>,
+            ],
+          };
+        })}
+      />
+    </div>
   );
 };

--- a/ui/src/pages/network/Trading.tsx
+++ b/ui/src/pages/network/Trading.tsx
@@ -7,7 +7,7 @@ import { Role as ExchangeRole } from '@daml.js/da-marketplace/lib/Marketplace/Tr
 import { Service } from '@daml.js/da-marketplace/lib/Marketplace/Trading/Service/module';
 import { getTemplateId, usePartyName } from '../../config';
 import StripedTable from '../../components/Table/StripedTable';
-import {NewFee} from './Fees';
+import { NewFee } from './Fees';
 
 type Props = {
   services: Readonly<CreateEvent<Service, any, any>[]>;
@@ -26,9 +26,7 @@ export const TradingServiceTable: React.FC<Props> = ({ services }) => {
 
   return (
     <div>
-      {!!role && (
-        <NewFee role={role}/>
-      )}
+      {!!role && <NewFee role={role} />}
       <StripedTable
         title="Trading"
         headings={[


### PR DESCRIPTION
Adds Exchange Fees via an `Optional` `ContractId AssetDeposit` field in the order details and a customizable `FeeSchedule` contract that the Exchange can set. Orders that do not include the correct fee will be rejected by the MatchingEngine or Exchange Adapter (this is also enforced in the UI). When the order is matched and confirmed, the fees are moved into an account held by the Exchange. Fees are prorated when an order is partially filled.

![Screen Shot 2021-06-22 at 8 34 32 PM](https://user-images.githubusercontent.com/71082197/123016741-43730300-d399-11eb-923a-528ea0b7d364.png)
