### PR TITLE
enhanced type safety for input fields

### DIFF
--- a/ui/src/components/InputDialog/Fields.tsx
+++ b/ui/src/components/InputDialog/Fields.tsx
@@ -16,7 +16,7 @@ interface SelectionField {
 }
 
 function isStringArray(sa: any[]): sa is string[] {
-  return sa.reduce((s, bool) => bool && typeof s === 'string', true);
+  return sa.reduce((bool, s) => bool && typeof s === 'string', true);
 }
 
 interface CheckBoxField {
@@ -25,7 +25,7 @@ interface CheckBoxField {
 }
 
 export type Field = RegularField | SelectionField | CheckBoxField;
-export type Fields = Record<string, Field>;
+export type Fields<T> = Record<keyof T, Field>;
 
 type FieldComponentsProps<T> = {
   defaultValue: T;
@@ -41,7 +41,7 @@ export function FieldComponents<T extends Record<string, string>>(props: FieldCo
   useEffect(() => onChange && onChange(state), [state, onChange]);
 
   function fieldsToInput([fieldName, field]: [string, Field]): JSX.Element {
-    const key = field.label + field.type;
+    const key = `${field.label} ${field.type}`;
 
     if (field.type === 'selection') {
       const options = isStringArray(field.items)

--- a/ui/src/components/InputDialog/RoleDialog.tsx
+++ b/ui/src/components/InputDialog/RoleDialog.tsx
@@ -6,9 +6,10 @@ import { InputDialog } from './InputDialog';
 
 import { Template } from '@daml/types';
 import { RoleRequestTemplates, RoleKind } from '../../context/RolesContext';
+import { Fields } from './Fields';
 
 interface RequestProps<T extends RoleRequestTemplates> {
-  fields: any;
+  fields: Fields<{ operator: string }>;
   open?: boolean;
   params: T;
   request: Template<T, undefined, string>;

--- a/ui/src/components/InputDialog/ServiceDialog.tsx
+++ b/ui/src/components/InputDialog/ServiceDialog.tsx
@@ -15,10 +15,11 @@ import { Role as TradingRole } from '@daml.js/da-marketplace/lib/Marketplace/Tra
 import { Role as CustodyRole } from '@daml.js/da-marketplace/lib/Marketplace/Custody/Role';
 import { Role as ClearingRole } from '@daml.js/da-marketplace/lib/Marketplace/Clearing/Role';
 import { useDisplayErrorMessage } from '../../context/MessagesContext';
+import { Fields } from './Fields';
 
 interface OfferProps<T extends ServiceOfferTemplates> {
   choice?: any;
-  fields: any;
+  fields: Fields<{ customer: string }>;
   open?: boolean;
   params: T;
   offer: Template<T, undefined, string>;
@@ -124,7 +125,7 @@ export const ServiceOfferDialog = <T extends ServiceOfferTemplates>({
       open={!!open}
       title={`Offer ${service} Service`}
       defaultValue={{
-        provider: '',
+        customer: '',
       }}
       fields={fields}
       onChange={onChange}
@@ -134,7 +135,7 @@ export const ServiceOfferDialog = <T extends ServiceOfferTemplates>({
 };
 
 interface RequestProps<T extends ServiceRequestTemplates> {
-  fields: any;
+  fields: Fields<{ provider: string }>;
   open?: boolean;
   params: T;
   request: Template<T, undefined, string>;

--- a/ui/src/pages/error/ServiceRequired.tsx
+++ b/ui/src/pages/error/ServiceRequired.tsx
@@ -25,6 +25,7 @@ import { useServiceRequestKinds } from '../../context/RequestsContext';
 import MissingServiceModal from '../../components/Common/MissingServiceModal';
 
 import { useStreamQueries } from '../../Main';
+import { Fields } from '../../components/InputDialog/Fields';
 
 type ServiceRequiredProps = {
   service: ServiceKind;
@@ -72,7 +73,13 @@ export const ServiceRequired: React.FC<ServiceRequiredProps> = ({ service, actio
   const [newRequest, setNewRequest] = useState(false);
   const [request, setRequest] = useState<ServiceRequest>(CustodyRequest);
   const [openDialog, setOpenDialog] = useState(true);
-  const [fields, setFields] = useState<object>({});
+  const [fields, setFields] = useState<Fields<{ provider: string }>>({
+    provider: {
+      label: 'Provider',
+      type: 'selection',
+      items: [],
+    },
+  });
   const [dialogState, setDialogState] = useState<any>({});
   const [requestParams, setRequestParams] = useState<RequestInterface>({
     provider: '',

--- a/ui/src/pages/landing/RoleRequestMenu.tsx
+++ b/ui/src/pages/landing/RoleRequestMenu.tsx
@@ -56,7 +56,13 @@ const RoleRequestMenu: React.FC = () => {
   const [request, setRequest] = useState<RoleRequest>();
   const [roleKind, setRoleKind] = useState<RoleKind>();
   const [openDialog, setOpenDialog] = useState(false);
-  const [fields, setFields] = useState<Fields>({});
+  const [fields, setFields] = useState<Fields<{ operator: string }>>({
+    operator: {
+      label: 'Operator',
+      type: 'selection',
+      items: [],
+    },
+  });
   const [dialogState, setDialogState] = useState<any>({});
   const [requestParams, setRequestParams] = useState<RequestInterface>({
     operator: '',
@@ -96,7 +102,7 @@ const RoleRequestMenu: React.FC = () => {
   const requestRole = <T extends RoleRequestTemplates>(
     role: Template<T, undefined, string>,
     kind: RoleKind,
-    extraFields?: Fields
+    extraFields?: Fields<{ ccpAccount?: string }>
   ) => {
     setFields({
       operator: {

--- a/ui/src/pages/landing/ServiceRequestMenu.tsx
+++ b/ui/src/pages/landing/ServiceRequestMenu.tsx
@@ -49,7 +49,13 @@ const ServiceRequestMenu: React.FC = () => {
   const [request, setRequest] = useState<ServiceRequest>();
   const [serviceKind, setServiceKind] = useState<ServiceKind>();
   const [openDialog, setOpenDialog] = useState(false);
-  const [fields, setFields] = useState<object>({});
+  const [fields, setFields] = useState<Fields<{ provider: string }>>({
+    provider: {
+      label: 'Provider',
+      type: 'selection',
+      items: [],
+    },
+  });
   const [fieldsFromProvider, setFieldsFromProvider] = useState<FieldCallbacks<Party>>({});
   const [dialogState, setDialogState] = useState<any>({});
   const [requestParams, setRequestParams] = useState<RequestInterface>({
@@ -133,7 +139,7 @@ const ServiceRequestMenu: React.FC = () => {
     const provider =
       identities.find(i => i.payload.legalName === dialogState?.provider)?.payload.customer || '';
 
-    const filteredFields: Fields = _.mapValues(fieldsFromProvider, createFieldFn =>
+    const filteredFields = _.mapValues(fieldsFromProvider, createFieldFn =>
       createFieldFn(provider)
     );
 
@@ -147,7 +153,6 @@ const ServiceRequestMenu: React.FC = () => {
     service: Template<T, undefined, string>,
     kind: ServiceKind,
     role: RoleKind,
-    extraFields?: Fields,
     fieldsFromProvider?: FieldCallbacks<Party>
   ) => {
     const providerNames = providersByRole.get(role)?.map(p => getName(p.payload.provider)) || [];
@@ -158,7 +163,6 @@ const ServiceRequestMenu: React.FC = () => {
         type: 'selection',
         items: providerNames,
       },
-      ...extraFields,
     });
 
     setRequest(service as unknown as Template<ServiceRequestTemplates, undefined, string>);
@@ -178,7 +182,7 @@ const ServiceRequestMenu: React.FC = () => {
       <ServiceRequestDialog
         open={openDialog}
         service={serviceKind}
-        fields={fields}
+        fields={{ ...fields }}
         params={requestParams}
         request={request}
         onChange={state => setDialogState(state)}
@@ -236,80 +240,56 @@ const ServiceRequestMenu: React.FC = () => {
       <OverflowMenuEntry
         label="Request Clearing Service"
         onClick={() =>
-          requestService(
-            ClearingRequest,
-            ServiceKind.CLEARING,
-            RoleKind.CLEARING,
-            {},
-            {
-              clearingAccount: makeAccountFilterField(
-                'Clearing Account (requires provider to be observer on account'
-              ),
-              marginAccount: makeAllocationAccountFilterField(
-                'Margin Account (requires provider to be nominee of allocation account)'
-              ),
-            }
-          )
+          requestService(ClearingRequest, ServiceKind.CLEARING, RoleKind.CLEARING, {
+            clearingAccount: makeAccountFilterField(
+              'Clearing Account (requires provider to be observer on account'
+            ),
+            marginAccount: makeAllocationAccountFilterField(
+              'Margin Account (requires provider to be nominee of allocation account)'
+            ),
+          })
         }
       />
       <OverflowMenuEntry
         label="Request Trading Service"
         onClick={() =>
-          requestService(
-            TradingRequest,
-            ServiceKind.TRADING,
-            RoleKind.TRADING,
-            {},
-            {
-              tradingAccount: makeAccountFilterField(
-                'Trading Account (requires provider to be provider on account)'
-              ),
-              allocationAccount: makeAllocationAccountFilterField(
-                'Allocation Account (requires provider to be nominee on account)'
-              ),
-            }
-          )
+          requestService(TradingRequest, ServiceKind.TRADING, RoleKind.TRADING, {
+            tradingAccount: makeAccountFilterField(
+              'Trading Account (requires provider to be provider or observer on account)'
+            ),
+            allocationAccount: makeAllocationAccountFilterField(
+              'Allocation Account (requires provider to be nominee on account)'
+            ),
+          })
         }
       />
       <OverflowMenuEntry
         label="Request Auction Service"
         onClick={() =>
-          requestService(
-            AuctionRequest,
-            ServiceKind.AUCTION,
-            RoleKind.DISTRIBUTION,
-            {},
-            {
-              tradingAccount: makeAccountFilterField(
-                'Trading Account (requires provider to be provider or observer on account)'
-              ),
-              allocationAccount: makeAllocationAccountFilterField(
-                'Allocation Account (requires provider to be nominee on account)'
-              ),
-              receivableAccount: makeAccountFilterField(
-                'Receivable Account (requires provider to be provider or observer on account)'
-              ),
-            }
-          )
+          requestService(AuctionRequest, ServiceKind.AUCTION, RoleKind.DISTRIBUTION, {
+            tradingAccount: makeAccountFilterField(
+              'Trading Account (requires provider to be provider or observer on account)'
+            ),
+            allocationAccount: makeAllocationAccountFilterField(
+              'Allocation Account (requires provider to be nominee on account)'
+            ),
+            receivableAccount: makeAccountFilterField(
+              'Receivable Account (requires provider to be provider or observer on account)'
+            ),
+          })
         }
       />
       <OverflowMenuEntry
         label="Request Bidding Service"
         onClick={() =>
-          requestService(
-            BiddingRequest,
-            ServiceKind.BIDDING,
-            RoleKind.DISTRIBUTION,
-            {},
-            {
-              tradingAccount: makeAccountFilterField(
-                'Trading Account (requires provider to be provider on account)'
-              ),
-              allocationAccount: makeAllocationAccountFilterField(
-                'Allocation Account (requires provider to be nominee on account)'
-              ),
-            }
-          )
+          requestService(BiddingRequest, ServiceKind.BIDDING, RoleKind.DISTRIBUTION, {
+            tradingAccount: makeAccountFilterField(
+              'Trading Account (requires provider to be provider on account)'
+            ),
+            allocationAccount: makeAllocationAccountFilterField(
+              'Allocation Account (requires provider to be nominee on account)'
+            ),
+          })
         }
       />
     </OverflowMenu>

--- a/ui/src/pages/landing/ServiceRequestMenu.tsx
+++ b/ui/src/pages/landing/ServiceRequestMenu.tsx
@@ -182,7 +182,7 @@ const ServiceRequestMenu: React.FC = () => {
       <ServiceRequestDialog
         open={openDialog}
         service={serviceKind}
-        fields={{ ...fields }}
+        fields={fields}
         params={requestParams}
         request={request}
         onChange={state => setDialogState(state)}

--- a/ui/src/pages/notifications/NotificationComponents.tsx
+++ b/ui/src/pages/notifications/NotificationComponents.tsx
@@ -34,7 +34,7 @@ const Notification: React.FC = ({ children }) => {
   return <div className="notification">{children}</div>;
 };
 
-type OfferProps<F extends Fields, T = OfferTemplates> = {
+type OfferProps<F extends Fields<{ provider: string }>, T = OfferTemplates> = {
   contractId: ContractId<T>;
   contract: T;
   serviceText: string;
@@ -44,7 +44,7 @@ type OfferProps<F extends Fields, T = OfferTemplates> = {
   declineChoice: OfferDeclineChoice;
 } & OfferAcceptFields<F, T>;
 
-export function OfferNotification<T extends Fields>({
+export function OfferNotification<T extends Fields<{ provider: string }>>({
   acceptChoice,
   declineChoice,
   contract,
@@ -125,7 +125,7 @@ export function OfferNotification<T extends Fields>({
   );
 }
 
-type RequestProps<F extends Fields> = {
+type RequestProps<F extends Fields<{ operator: string }>> = {
   serviceText: string;
   requester: string;
 
@@ -134,7 +134,7 @@ type RequestProps<F extends Fields> = {
   rejectChoice: RequestRejectChoice;
 } & RequestApproveFields<F>;
 
-export function RequestNotification<T extends Fields>({
+export function RequestNotification<T extends Fields<{ operator: string }>>({
   approveChoice,
   rejectChoice,
   contract,

--- a/ui/src/pages/setup/Offer.tsx
+++ b/ui/src/pages/setup/Offer.tsx
@@ -17,6 +17,7 @@ import { ServiceKind, ServiceOffer, ServiceRoleOfferChoice } from '../../context
 import { useHistory } from 'react-router';
 import { useWellKnownParties } from '@daml/hub-react/lib';
 import { useVerifiedParties } from '../../config';
+import { Account } from '@daml.js/da-marketplace/lib/DA/Finance/Types';
 
 interface RequestInterface {
   operator: string;
@@ -85,7 +86,13 @@ const Offer: React.FC<{ service: ServiceKind }> = ({ service }) => {
       identities.find(i => i.payload.legalName === dialogState?.customer)?.payload.customer || '';
 
     if (dialogState?.tradingAccount && dialogState?.allocationAccount) {
-      const params = { provider, customer, operator };
+      const params = {
+        provider,
+        customer,
+        operator,
+        tradingAccount: dialogState.tradingAccount,
+        allocationAccount: dialogState.allocationAccount,
+      };
       setParams(params);
     } else {
       setParams({


### PR DESCRIPTION
Fixes the problem reported by @brian-weir about blank dropdowns. The main problem was a simple type error, which wasn't caught by the compiler because some of the `fields` props were typed as `any` or `object`, introducing a blind-spot in the checker