### PR TITLE
Syndication 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,32 +81,6 @@ jobs:
       - store_artifacts:
           path: da-marketplace-test-report
 
-  ui_test:
-    parameters:
-      daml_sdk_version:
-        type: string
-    executor: daml-executor
-    steps:
-      - checkout
-      - init_submodules
-      - restore_cache:
-          keys:
-            - daml-{{ checksum "daml.yaml" }}
-      - install_sdk:
-          version: << parameters.daml_sdk_version >>
-      - install_python
-      - install_yq
-      - run:
-          name: UI test
-          command: |
-            echo 'export PATH=$HOME/yq:$PATH' >> $BASH_ENV
-            source $BASH_ENV
-            make test-ui
-      - save_cache:
-          paths:
-            - ~/.daml
-          key: daml-{{ checksum "daml.yaml" }}
-
   publish:
     parameters:
       daml_sdk_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,12 +113,6 @@ workflows:
             branches:
               ignore:
                 - main
-      - ui_test:
-          daml_sdk_version: "1.12.0"
-          filters:
-            branches:
-              ignore:
-                - main
   publish:
     jobs:
       - publish:

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -1,8 +1,15 @@
 module Marketplace.Distribution.Syndication.Structuring.Model where
 
 import DA.Finance.Types (Id, Asset(..))
+import DA.Optional (fromSomeNote)
+import DA.Set (fromList)
 import Marketplace.Distribution.Syndication.Bidding.Model qualified as Bidding
-import Marketplace.Settlement.Hierarchical (createInstructions, Trade(..), Status(..))
+import Marketplace.Settlement.Hierarchical (AccountInfo, createInstructions, Trade(..), Status(..))
+import Marketplace.Issuance.Instrument.Model(Bond(..))
+import SwiftMessage.Model.MT545
+import SwiftMessage.Model.MT547
+import SwiftMessage.Util
+import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessageType(..), SwiftOutboundMessage(..))
 
 template CreateDealRequest
   with
@@ -80,59 +87,94 @@ template Tranche
     key (operator, issuer, dealId, trancheId) : (Party, Party, Text, Text)
     maintainer key._1
 
+    -- helper fuction to send swift message 
+    let 
+      sendSwiftMessage : Party -> Party -> Decimal -> Decimal -> Id -> Text -> Date -> Date -> Date -> Update (ContractId SwiftOutboundMessage) 
+      sendSwiftMessage seller buyer settledQty settledAmount settledCurrency settlementId dateOfTrade dateOfSettlement effDateOfSettlement = do
+        (_, sellerAccountInfo) <- fetchByKey @AccountInfo (operator, seller)
+        (_, receiverAccountInfo) <- fetchByKey @AccountInfo (operator, buyer)
+        (_, bond) <- fetchByKey @Bond (fromList [bondRegistrar, issuer], deliveryId.label)
+        let 
+          getSecurityAcc accInfo = fromSomeNote "current party has not security account" accInfo.securitiesAccount
+          instrumentId = bond.isin <> "-" <> deliveryId.label 
+          buyerSafekeepingAcc = getSecurityAcc receiverAccountInfo
+          sellerSafkeepingAcc = getSecurityAcc sellerAccountInfo
+          mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider seller settledAmount settledCurrency 
+                    dateOfTrade dateOfSettlement effDateOfSettlement
+                    settlementId settlementId buyerSafekeepingAcc (getSecurityAcc sellerAccountInfo) "safekeepingPlace" "placeOfSettlement"
+          
+          mt547 = createMT547Details instrumentId settledQty sellerSafkeepingAcc.provider seller settledAmount settledCurrency 
+                    dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
+                    settlementId settlementId buyerSafekeepingAcc (getSecurityAcc sellerAccountInfo) "safekeepingPlace" "placeOfSettlement"
+        create SwiftOutboundMessage with referenceId = settlementId; provider = operator ; consumer = operator; swiftMessage=MT545 (mt545); swiftMessageType=MT545_t; status=Pending; observers= fromList [bondRegistrar]    
+        create SwiftOutboundMessage with referenceId = settlementId; provider = operator ; consumer = operator; swiftMessage=MT547 (mt547); swiftMessageType=MT547_t; status=Pending; observers=fromList [bondRegistrar]    
+    
     controller operator can
       nonconsuming InstructIssuerSettlement : ContractId Trade
         with
           confirmationCids : [ContractId Bidding.Confirmation]
           price : Decimal
+          dateOfTrade : Date
+          dateOfSettlement : Date 
         do
           confirmations <- mapA fetch confirmationCids
           let
             filtered = filter (\c -> c.asset.id == deliveryId) confirmations
             quantities = map (.asset.quantity) filtered
             aggregate = sum quantities
+            settledAmount = aggregate * price
             aggregateAsset = Asset with id = deliveryId; quantity = aggregate
-            aggregatePrice = Asset with id = paymentId; quantity = aggregate * price
+            aggregatePrice = Asset with id = paymentId; quantity = settledAmount
             settlementId = deliveryId.label <> "-" <> partyToText issuer <> "-" <> partyToText settlementBank
           assertMsg "Total confirmed amount is larger than available quantity" $ aggregate <= size
           bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuer settlementBank settlementId 0 aggregateAsset
           cashSis <- createInstructions True operator bondRegistrar cashProvider settlementBank issuer settlementId (length bondSis) aggregatePrice
           instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+          sendSwiftMessage issuer settlementBank aggregate settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
           create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = aggregateAsset; payment = aggregatePrice; status = Instructed
 
       nonconsuming InstructBndSettlement : ContractId Trade
         with
           confirmationCids : [ContractId Bidding.Confirmation]
           price : Decimal
+          dateOfTrade : Date
+          dateOfSettlement : Date
         do
           confirmations <- mapA fetch confirmationCids
           let
             filtered = filter (\c -> c.asset.id == deliveryId) confirmations
             quantities = map (.asset.quantity) filtered
             aggregate = sum quantities
+            settledAmount = aggregate * price
             aggregateAsset = Asset with id = deliveryId; quantity = aggregate
-            aggregatePrice = Asset with id = paymentId; quantity = aggregate * price
+            aggregatePrice = Asset with id = paymentId; quantity = settledAmount
             settlementId = deliveryId.label <> "-" <> partyToText settlementBank <> "-" <> partyToText bndBank
           assertMsg "Total confirmed amount is larger than available quantity" $ aggregate <= size
           bondSis <- createInstructions False operator bondRegistrar bondRegistrar settlementBank bndBank settlementId 0 aggregateAsset
           cashSis <- createInstructions True operator bondRegistrar cashProvider bndBank settlementBank settlementId (length bondSis) aggregatePrice
           instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+          sendSwiftMessage settlementBank bndBank aggregate settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement 
           create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = aggregateAsset; payment = aggregatePrice; status = Instructed
 
       nonconsuming InstructInvestorSettlement : [ContractId Trade]
         with
           confirmationCids : [ContractId Bidding.Confirmation]
           price : Decimal
+          dateOfTrade : Date
+          dateOfSettlement : Date
         do
           confirmations <- mapA fetch confirmationCids
           let
             filtered = filter (\c -> c.asset.id == deliveryId) confirmations
             settleConfirmation conf = do
               let
-                aggregatePrice = conf.price with quantity = conf.price.quantity * conf.asset.quantity
+                aggregate = conf.asset.quantity
+                settledAmount = conf.price.quantity * conf.asset.quantity
+                aggregatePrice = conf.price with quantity = settledAmount
                 settlementId = deliveryId.label <> "-" <> partyToText bndBank <> "-" <> partyToText conf.investor
               bondSis <- createInstructions False operator bondRegistrar bondRegistrar bndBank conf.investor settlementId 0 conf.asset
               cashSis <- createInstructions True operator bondRegistrar cashProvider conf.investor bndBank settlementId (length bondSis) aggregatePrice
               instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+              sendSwiftMessage settlementBank bndBank aggregate settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement 
               create Trade with operator; agent = bondRegistrar; deliverer = bndBank; payer = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = aggregatePrice; status = Instructed
           mapA settleConfirmation filtered

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -9,10 +9,6 @@ template CreateDealRequest
     operator : Party
     provider : Party
     customer : Party
-    settlementBank : Party
-    bndBank : Party
-    cashProvider : Party
-    bondRegistrar : Party
     dealId : Text
   where
     signatory operator, provider, customer
@@ -22,6 +18,10 @@ template AddTrancheRequest
     operator : Party
     provider : Party
     customer : Party
+    settlementBank : Party
+    bndBank : Party
+    cashProvider : Party
+    bondRegistrar : Party
     dealId : Text
     trancheId : Text
     deliveryId : Id
@@ -35,10 +35,6 @@ template Deal
     operator : Party
     structurer : Party
     issuer : Party
-    settlementBank : Party
-    bndBank : Party
-    cashProvider : Party
-    bondRegistrar : Party
     dealId : Text
     trancheIds : [Text]
   where
@@ -54,6 +50,10 @@ template Deal
           deliveryId : Id
           paymentId : Id
           size : Decimal
+          settlementBank : Party
+          bndBank : Party
+          cashProvider : Party
+          bondRegistrar : Party
         do
           dealCid <- create this with trancheIds = trancheIds <> [trancheId]
           trancheCid <- create Tranche with ..

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -33,12 +33,12 @@ template AddTrancheRequest
 template Deal
   with
     operator : Party
-    structurer : Party
+    dealProvider : Party
     issuer : Party
     dealId : Text
     trancheIds : [Text]
   where
-    signatory operator, structurer, issuer
+    signatory operator, dealProvider, issuer
 
     key (operator, issuer, dealId) : (Party, Party, Text)
     maintainer key._1
@@ -56,13 +56,13 @@ template Deal
           bondRegistrar : Party
         do
           dealCid <- create this with trancheIds = trancheIds <> [trancheId]
-          trancheCid <- create Tranche with ..
+          trancheCid <- create Tranche with trancheProvider = dealProvider; ..
           pure (dealCid, trancheCid)
 
 template Tranche
   with
     operator : Party
-    structurer : Party
+    trancheProvider : Party
     issuer : Party
     settlementBank : Party
     bndBank : Party
@@ -74,7 +74,7 @@ template Tranche
     paymentId : Id
     size : Decimal
   where
-    signatory operator, structurer, issuer
+    signatory operator, trancheProvider, issuer
     observer settlementBank, bndBank
 
     key (operator, issuer, dealId, trancheId) : (Party, Party, Text, Text)

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -134,5 +134,5 @@ template Tranche
               bondSis <- createInstructions False operator bondRegistrar bondRegistrar bndBank conf.investor settlementId 0 conf.asset
               cashSis <- createInstructions True operator bondRegistrar cashProvider conf.investor bndBank settlementId (length bondSis) aggregatePrice
               instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
-              create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = conf.asset; payment = aggregatePrice; status = Instructed
+              create Trade with operator; agent = bondRegistrar; deliverer = bndBank; payer = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = aggregatePrice; status = Instructed
           mapA settleConfirmation filtered

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Service.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Service.daml
@@ -21,16 +21,16 @@ template Service
     controller customer can
       nonconsuming RequestCreateDeal : ContractId CreateDealRequest
         with
-          settlementBank : Party
-          bndBank : Party
-          cashProvider : Party
-          bondRegistrar : Party
           dealId : Text
         do
           create CreateDealRequest with ..
 
       nonconsuming RequestAddTranche : ContractId AddTrancheRequest
         with
+          settlementBank : Party
+          bndBank : Party
+          cashProvider : Party
+          bondRegistrar : Party
           dealId : Text
           trancheId : Text
           deliveryId : Id

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Service.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Service.daml
@@ -45,7 +45,7 @@ template Service
           createDealRequestCid : ContractId CreateDealRequest
         do
           CreateDealRequest{..} <- fetchAndArchive createDealRequestCid
-          create Deal with structurer = provider; issuer = customer; trancheIds = []; ..
+          create Deal with dealProvider = provider; issuer = customer; trancheIds = []; ..
 
       nonconsuming AddTranche : (ContractId Deal, ContractId Tranche)
         with

--- a/daml/Marketplace/Issuance/Instrument/Model.daml
+++ b/daml/Marketplace/Issuance/Instrument/Model.daml
@@ -38,6 +38,7 @@ data InterestStream = InterestStream
 template Bond
   with
     id : Id
+    isin : Text
     currencyId : Id
     issueDate : Date
     maturityDate : Date

--- a/daml/Marketplace/Settlement/Hierarchical.daml
+++ b/daml/Marketplace/Settlement/Hierarchical.daml
@@ -45,6 +45,13 @@ template Trade
     key (operator, settlementId) : (Party, Text)
     maintainer key._1
 
+    let finalizeSwiftMessage k = do
+        cidOpt <- lookupByKey @SwiftOutboundMessage k
+        case cidOpt of
+              Some cid -> do 
+                exercise cid Finalize
+                pure ()
+              None -> pure ()  -- do nothing during the trade matching for now
     controller agent can
       Settle : (ContractId Trade, [ContractId AssetDeposit])
         do
@@ -55,10 +62,8 @@ template Trade
               exercise siCid SettleInstruction
           adCids <- mapA settle instructionIds
           tradeCid <- create this with status = Settled
-          (mt545Cid, _) <- fetchByKey @SwiftOutboundMessage (operator, settlementId, MT545_t)
-          (mt547Cid, _) <- fetchByKey @SwiftOutboundMessage (operator, settlementId, MT547_t)
-          exercise mt545Cid Finalize
-          exercise mt547Cid Finalize
+          finalizeSwiftMessage (operator, settlementId, MT545_t)
+          finalizeSwiftMessage (operator, settlementId, MT547_t)
           pure (tradeCid, adCids)
 
 template Delivery

--- a/daml/Marketplace/Settlement/Hierarchical.daml
+++ b/daml/Marketplace/Settlement/Hierarchical.daml
@@ -4,7 +4,7 @@ import DA.Assert ((===))
 import DA.Finance.Types (Account, Asset)
 import DA.Finance.Asset (AssetDeposit(..), AssetDeposit_Transfer(..), AssetDeposit_SetObservers(..))
 import DA.List (singleton)
-import DA.Optional (fromSome, fromSomeNote)
+import DA.Optional (whenSome, fromSome, fromSomeNote)
 import DA.Set (fromList)
 import Prelude hiding (lookup)
 import SwiftMessage.Message
@@ -47,11 +47,7 @@ template Trade
 
     let finalizeSwiftMessage k = do
         cidOpt <- lookupByKey @SwiftOutboundMessage k
-        case cidOpt of
-              Some cid -> do 
-                exercise cid Finalize
-                pure ()
-              None -> pure ()  -- do nothing during the trade matching for now
+        whenSome cidOpt (\cid -> do exercise cid Finalize; pure ())
     controller agent can
       Settle : (ContractId Trade, [ContractId AssetDeposit])
         do

--- a/daml/Marketplace/Settlement/Hierarchical.daml
+++ b/daml/Marketplace/Settlement/Hierarchical.daml
@@ -7,6 +7,7 @@ import DA.List (singleton)
 import DA.Optional (fromSome, fromSomeNote)
 import DA.Set (fromList)
 import Prelude hiding (lookup)
+import SwiftMessage.Message
 
 data Status =
   Instructed
@@ -54,6 +55,10 @@ template Trade
               exercise siCid SettleInstruction
           adCids <- mapA settle instructionIds
           tradeCid <- create this with status = Settled
+          (mt545Cid, _) <- fetchByKey @SwiftOutboundMessage (operator, settlementId, MT545_t)
+          (mt547Cid, _) <- fetchByKey @SwiftOutboundMessage (operator, settlementId, MT547_t)
+          exercise mt545Cid Finalize
+          exercise mt547Cid Finalize
           pure (tradeCid, adCids)
 
 template Delivery

--- a/daml/SwiftMessage/Message.daml
+++ b/daml/SwiftMessage/Message.daml
@@ -1,0 +1,63 @@
+module SwiftMessage.Message where
+
+import SwiftMessage.Util
+import SwiftMessage.Model.MT545
+import SwiftMessage.Model.MT547
+import DA.Set (Set)
+
+data SwiftMessage = 
+      MT545 (MT545Details)
+    | MT547 (MT547Details)
+  deriving (Eq, Show)
+
+data SwiftMessageType = MT545_t | MT547_t 
+  deriving (Eq, Show)
+
+
+-- This is the message that will be published from daml side onto ledger and consumed by swift adaptor
+template SwiftOutboundMessage
+  with 
+    referenceId : Text
+    provider : Party 
+    consumer : Party
+    observers : Set Party
+    swiftMessage : SwiftMessage
+    swiftMessageType : SwiftMessageType
+    status : MessageStatus
+  where 
+    signatory provider
+    observer observers
+
+    key (provider, referenceId, swiftMessageType) : (Party, Text, SwiftMessageType)
+    maintainer key._1
+
+    controller consumer can
+      Response : ContractId SwiftOutboundMessageResponse
+        with
+          response : ConsumerResponse
+          timeStamp : Time
+        do create SwiftOutboundMessageResponse with ..
+    
+    controller observers can
+      Finalize : ContractId SwiftOutboundMessage
+        do create this with status = Finalized
+
+    controller provider can
+      Cancel : ()
+        do pure ()
+    
+    controller provider can
+      AddObservers : ContractId SwiftOutboundMessage
+        with 
+          newObserver : Set Party 
+            do create this with observers = newObserver <> observers  
+template SwiftOutboundMessageResponse
+    with 
+      referenceId : Text
+      provider : Party 
+      consumer : Party
+      swiftMessage : SwiftMessage
+      response : ConsumerResponse
+      timeStamp : Time
+    where
+      signatory provider, consumer

--- a/daml/SwiftMessage/Model/MT545.daml
+++ b/daml/SwiftMessage/Model/MT545.daml
@@ -1,0 +1,37 @@
+module SwiftMessage.Model.MT545 where
+
+import DA.Finance.Types (Id(..), Account(..))
+import SwiftMessage.Util
+
+data MT545Details = MT545Details with
+    messageType: MessageType -- NEWM
+    
+    instrumentId: Text --ISIN IE00BYVQ9F29 ISHARES NASDAQ 100 UCITS ETF ISHARES NASDAQ 100 EUR-H ACC
+    qtyOfInstrument: Decimal -- security quantity
+
+    deliveringAgent: Party  -- placeholder as pending on GS side // deliverying or receiving agent??
+    seller: Party
+
+    settledAmount: Decimal -- notional
+    settledCurrency: Id
+    dateOfTrade: Date -- 20201029
+    dateOfSettlement: Date  -- 20201102
+    effDateOfSettlement: Date -- this should be SETT instead of ESET and should be same as dateOfSettlement
+    
+    senderMsgRef: Text -- settlement id
+    relatedMsgRef: Text -- same as senderMessageReference 
+    
+    buyerSafekeepingAcc: Account -- custodian bond registart account 
+    sellerSafekeepingAcc: Account -- Issuer bondregistar account 
+    safekeepingPlace: Text --  TOKENIZED INFRASTRUCTURE
+    placeOfSettlement: Text --  TOKENIZED INFRASTRUCTURE
+  deriving (Eq, Show)
+
+  
+createMT545Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
+  -> Date -> Date -> Date 
+  -> Text -> Text -> Account -> Account -> Text -> Text -> MT545Details
+createMT545Details instrumentId qtyOfInstrument deliveringAgent seller settledAmount settledCurrency 
+  dateOfTrade dateOfSettlement effDateOfSettlement 
+  senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
+    MT545Details with messageType = NEWM; ..

--- a/daml/SwiftMessage/Model/MT547.daml
+++ b/daml/SwiftMessage/Model/MT547.daml
@@ -1,0 +1,38 @@
+
+module SwiftMessage.Model.MT547 where
+
+import DA.Finance.Types (Id(..), Account(..))
+import SwiftMessage.Util
+
+data MT547Details = MT547Details with
+    messageType: MessageType -- NEWM
+    
+    instrumentId: Text --ISIN IE00BYVQ9F29 ISHARES NASDAQ 100 UCITS ETF ISHARES NASDAQ 100 EUR-H ACC
+    qtyOfInstrument: Decimal -- security quantity
+    
+    receivingAgent: Party  -- placeholder as pending on GS side // deliverying or receiving agent??
+    seller: Party
+    
+    settledAmount: Decimal -- notional
+    settledCurrency: Id
+    dateOfTrade: Date -- 20201029
+    dateOfSettlement: Date  -- 20201102
+    effDateOfSettlement: Date -- this should be SETT instead of ESET and should be same as dateOfSettlement
+    valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
+
+    senderMsgRef: Text -- settlementId
+    relatedMsgRef: Text -- same as senderMessageReference 
+    
+    buyerSafekeepingAcc: Account -- GS suggests putting AccountID as placeholder
+    sellerSafekeepingAcc: Account -- GS suggests putting Account ID as placeholder
+    safekeepingPlace: Text --  TOKENIZED INFRASTRUCTURE
+    placeOfSettlement: Text
+  deriving (Eq, Show)
+
+createMT547Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
+  -> Date -> Date -> Date -> Date
+  -> Text -> Text -> Account -> Account -> Text -> Text -> MT547Details
+createMT547Details instrumentId qtyOfInstrument receivingAgent seller settledAmount settledCurrency 
+  dateOfTrade dateOfSettlement effDateOfSettlement valueDate 
+  senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
+    MT547Details with messageType = NEWM; ..

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -1,0 +1,18 @@
+module SwiftMessage.Util where
+
+data MessageStatus = Pending | Finalized
+  deriving (Eq, Show)
+
+data MessageType = 
+    CANC -- Cancellation Request
+  | NEWM -- New
+  | RVSL -- Reversal
+  | REPE
+  | REPL
+  | RMDR
+  deriving (Eq, Show)
+
+data ConsumerResponse = 
+  COMPLETED
+  | FAILED with errorMessage: Text
+  deriving (Eq, Show)

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -17,9 +17,9 @@ issuance : Parties -> Origination -> Script ()
 issuance Parties{..} Origination{..} = do
 
   let dealId = "DEAL1"
-  dealCid     <- createDeal operator structurer issuer settlementBank bndBank bondRegistrar cashProvider dealId
-  (dealCid, tranche1Cid) <- addTranche operator structurer issuer dealId "TRANCHE1" bond1.id usd.assetId 100_000_000.0
-  (dealCid, tranche2Cid) <- addTranche operator structurer issuer dealId "TRANCHE2" bond2.id usd.assetId 100_000_000.0
+  dealCid     <- createDeal operator structurer issuer dealId
+  (dealCid, tranche1Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider dealId "TRANCHE1" bond1.id usd.assetId 100_000_000.0
+  (dealCid, tranche2Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider dealId "TRANCHE2" bond2.id usd.assetId 100_000_000.0
 
   deposit operator cashProvider  issuer     14_000_000.0 usd.assetId
   deposit operator cashProvider  lm1        20_000_000.0 usd.assetId

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -6,6 +6,7 @@ import Marketplace.Distribution.Syndication.Structuring.Model qualified as Struc
 import Tests.Distribution.Syndication.Origination (origination, Origination(..))
 import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 import Tests.Distribution.Syndication.Util
+import DA.Date (Month(Dec), date)
 
 test : Script ()
 test = do
@@ -73,24 +74,26 @@ issuance Parties{..} Origination{..} = do
   let
     confirmationCids = [ confirmation11Cid, confirmation12Cid, confirmation21Cid, confirmation22Cid, confirmation31Cid, confirmation32Cid, confirmation41Cid, confirmation42Cid ]
     price = offeredPrice
+    dateOfSettlement = date 2021 Dec 20
+    dateOfTrade = dateOfSettlement
 
   -- Step 1
-  dvpCid11 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructIssuerSettlement with confirmationCids; price
-  dvpCid12 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructIssuerSettlement with confirmationCids; price
+  dvpCid11 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructIssuerSettlement with confirmationCids; price; dateOfSettlement; dateOfTrade
+  dvpCid12 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructIssuerSettlement with confirmationCids; price; dateOfSettlement; dateOfTrade
   allocateInstructions [ issuer, custodian2, settlementBank ]
   signInstructions [ issuer, custodian2, settlementBank ]
   settleTrades bondRegistrar [ dvpCid11, dvpCid12 ]
 
-  -- Step 2
-  dvpCid21 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructBndSettlement with confirmationCids; price
-  dvpCid22 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructBndSettlement with confirmationCids; price
+  -- Step 2 
+  dvpCid21 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructBndSettlement with confirmationCids; price; dateOfSettlement; dateOfTrade 
+  dvpCid22 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructBndSettlement with confirmationCids; price; dateOfSettlement; dateOfTrade
   allocateInstructions [ settlementBank, custodian2, custodian3, bndBank ]
   signInstructions [ settlementBank, custodian2, custodian3, bndBank ]
   settleTrades bondRegistrar [ dvpCid21, dvpCid22 ]
 
-  -- Step 3
-  dvpCids31 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructInvestorSettlement with confirmationCids; price
-  dvpCids32 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructInvestorSettlement with confirmationCids; price
+  -- -- Step 3
+  dvpCids31 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructInvestorSettlement with confirmationCids; price; dateOfSettlement; dateOfTrade
+  dvpCids32 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructInvestorSettlement with confirmationCids; price; dateOfSettlement; dateOfTrade
   allocateInstructions [ bndBank, lm1, lm2, lm3, custodian1, custodian2, custodian3, custodian4, custodian5, investor1, investor2, investor3, investor4 ]
   signInstructions [ bndBank, lm1, lm2, lm3, custodian1, custodian2, custodian3, custodian4, custodian5, investor1, investor2, investor3, investor4 ]
   settleTrades bondRegistrar $ dvpCids31 <> dvpCids32

--- a/daml/Tests/Distribution/Syndication/Origination.daml
+++ b/daml/Tests/Distribution/Syndication/Origination.daml
@@ -58,9 +58,9 @@ origination Parties{..} = do
     swapRecAmount = Instrument.Fixed with annualRate = 0.01
     swapPay = Instrument.InterestStream with schedule = swapPaySched; amount = swapPayAmount
     swapRec = Instrument.InterestStream with schedule = swapRecSched; amount = swapRecAmount
-    bond1 = createFixedRateBond     bond1Id "ISIN" usd.assetId bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True [public]
-    bond2 = createFixedRateBond     bond2Id "ISIN" usd.assetId bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True [public]
-    bond3 = createFloatingRateBond  bond3Id "ISIN" usd.assetId bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True [public]
+    bond1 = createFixedRateBond     bond1Id "ISIN" usd.assetId bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True [public, operator]
+    bond2 = createFixedRateBond     bond2Id "ISIN" usd.assetId bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True [public, operator]
+    bond3 = createFloatingRateBond  bond3Id "ISIN" usd.assetId bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True [public, operator]
     swap1 = createSwap              swap1Id usd.assetId usd.assetId swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
 
   submitMulti [operator, bondRegistrar] [] do createCmd HolidayCalendar with operator; provider = bondRegistrar; calendar = fedCalendar; observers = fromList [issuer]

--- a/daml/Tests/Distribution/Syndication/Origination.daml
+++ b/daml/Tests/Distribution/Syndication/Origination.daml
@@ -58,9 +58,9 @@ origination Parties{..} = do
     swapRecAmount = Instrument.Fixed with annualRate = 0.01
     swapPay = Instrument.InterestStream with schedule = swapPaySched; amount = swapPayAmount
     swapRec = Instrument.InterestStream with schedule = swapRecSched; amount = swapRecAmount
-    bond1 = createFixedRateBond     bond1Id usd.assetId bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True [public]
-    bond2 = createFixedRateBond     bond2Id usd.assetId bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True [public]
-    bond3 = createFloatingRateBond  bond3Id usd.assetId bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True [public]
+    bond1 = createFixedRateBond     bond1Id "ISIN" usd.assetId bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True [public]
+    bond2 = createFixedRateBond     bond2Id "ISIN" usd.assetId bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True [public]
+    bond3 = createFloatingRateBond  bond3Id "ISIN" usd.assetId bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True [public]
     swap1 = createSwap              swap1Id usd.assetId usd.assetId swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
 
   submitMulti [operator, bondRegistrar] [] do createCmd HolidayCalendar with operator; provider = bondRegistrar; calendar = fedCalendar; observers = fromList [issuer]

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -114,23 +114,23 @@ createSchedule : Date -> Date -> PeriodEnum -> Int -> [Text] -> BusinessDayConve
 createSchedule startDate endDate period periodMultiplier calendarIds businessDayConvention dayCountConvention rollConvention =
   Instrument.InterestSchedule with ..
 
-createFixedRateBond : Id -> Id -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFixedRateBond id currencyId issueDate maturityDate schedule annualRate isTradeable isPricedDirty observers =
+createFixedRateBond : Id -> Text -> Id -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> [Party] -> Instrument.Bond
+createFixedRateBond id isin currencyId issueDate maturityDate schedule annualRate isTradeable isPricedDirty observers =
   let
     amount = Instrument.Fixed with annualRate
     stream = Some Instrument.InterestStream with schedule; amount
-  in Instrument.Bond with id; currencyId; issueDate; maturityDate; stream; isTradeable; isPricedDirty; observers
+  in Instrument.Bond with ..
 
-createFloatingRateBond : Id -> Id -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFloatingRateBond id currencyId issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty observers =
+createFloatingRateBond : Id -> Text -> Id -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> [Party] -> Instrument.Bond
+createFloatingRateBond id isin currencyId issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty observers =
   let
     amount = Instrument.Float with rateId; periodSpread
     stream = Some Instrument.InterestStream with schedule; amount
-  in Instrument.Bond with id; currencyId; issueDate; maturityDate; stream; isTradeable; isPricedDirty; observers
+  in Instrument.Bond with ..
 
-createZeroCouponBond : Id -> Id -> Date -> Date -> Bool -> Bool -> [Party] -> Instrument.Bond
-createZeroCouponBond id currencyId issueDate maturityDate isTradeable isPricedDirty observers =
-  Instrument.Bond with id; currencyId; issueDate; maturityDate; stream = None; isTradeable; isPricedDirty; observers
+createZeroCouponBond : Id -> Text -> Id -> Date -> Date -> Bool -> Bool -> [Party] -> Instrument.Bond
+createZeroCouponBond id isin currencyId issueDate maturityDate isTradeable isPricedDirty observers =
+  Instrument.Bond with stream = None; ..
 
 createSwap : Id -> Id -> Id -> Date -> Date -> Instrument.InterestStream -> Instrument.InterestStream -> Bool -> [Party] -> Instrument.Swap
 createSwap id payCurrencyId receiveCurrencyId issueDate maturityDate pay receive isTradeable observers =

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -160,13 +160,13 @@ deposit operator provider customer quantity assetId = do
   depositRequestCid <- submitMulti [customer] [] do exerciseByKeyCmd @Custody.Service (operator, provider, customer) Custody.RequestDeposit with asset
   submit provider do exerciseByKeyCmd @Custody.Service (operator, provider, customer) Custody.Deposit with depositRequestCid
 
-createDeal : Party -> Party -> Party -> Party -> Party -> Party -> Party -> Text -> Script (ContractId Structuring.Deal)
-createDeal operator provider customer settlementBank bndBank bondRegistrar cashProvider dealId = do
+createDeal : Party -> Party -> Party -> Text -> Script (ContractId Structuring.Deal)
+createDeal operator provider customer dealId = do
   createDealRequestCid <- submit customer do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.RequestCreateDeal with ..
   submit provider do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.CreateDeal with ..
 
-addTranche : Party -> Party -> Party -> Text -> Text -> Id -> Id -> Decimal -> Script (ContractId Structuring.Deal, ContractId Structuring.Tranche)
-addTranche operator provider customer dealId trancheId deliveryId paymentId size = do
+addTranche : Party -> Party -> Party -> Party -> Party -> Party -> Party -> Text -> Text -> Id -> Id -> Decimal -> Script (ContractId Structuring.Deal, ContractId Structuring.Tranche)
+addTranche operator provider customer settlementBank bndBank bondRegistrar cashProvider dealId trancheId deliveryId paymentId size = do
   addTrancheRequestCid <- submit customer do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.RequestAddTranche with ..
   submit provider do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.AddTranche with ..
 


### PR DESCRIPTION
Note that @dorrit-du-da and I have discussed and decide to leave out the change in 
FL-177 Split out calcuateEffect from lifecycle part

changes covered
FL-167 ISIN with Bond Name to be added to the tranche
FL-168 Move issuance parties to the Trance level from the Deal level
FL-176 Modify Trade to capture the asset movement
FL-182 MT545 message daml integration
FL-183 MT547 message daml integration