### PR TITLE
FL-219, FL-220: add issuer into Bond and assetId into MT564 MT566

### DIFF
--- a/daml/Marketplace/Issuance/Instrument/Model.daml
+++ b/daml/Marketplace/Issuance/Instrument/Model.daml
@@ -40,6 +40,7 @@ template Bond
     id : Id
     isin : Text
     currencyId : Id
+    issuer : Party
     issueDate : Date
     maturityDate : Date
     stream : Optional InterestStream
@@ -58,6 +59,7 @@ template Swap
   with
     id : Id
     issueDate : Date
+    issuer : Party
     maturityDate : Date
     pay : InterestStream
     payCurrencyId : Id

--- a/daml/Marketplace/Lifecycle/Model.daml
+++ b/daml/Marketplace/Lifecycle/Model.daml
@@ -76,13 +76,13 @@ template Effect
               (_, bond) <- fetchByKey @Instrument.Bond (fromList [issuer, bondRegistrar], assetId.label)
             
               let
-                instrumentId = bond.isin <> assetId.label
+                instrumentId = bond.isin <> "-" <> assetId.label
                 faceAmount = asset.quantity
                 currency = asset.id
                 maturityDate = bond.maturityDate
                 payoutDate = date
                 redemptionDate = getRedemptionDate maturityDate payoutDate
-                mt566 = createMT566Details instrumentId buyerSafekeepingAcc CR faceAmount currency maturityDate payoutDate redemptionDate
+                mt566 = createMT566Details instrumentId assetId buyerSafekeepingAcc CR faceAmount currency maturityDate payoutDate redemptionDate
               create SwiftOutboundMessage with referenceId = settlementId; provider = operator ; consumer = operator; swiftMessage=MT566 (mt566); swiftMessageType=MT566_t; status=Pending; observers=fromList [payingAgent]
               pure ()
             else pure ()

--- a/daml/Marketplace/Lifecycle/Service.daml
+++ b/daml/Marketplace/Lifecycle/Service.daml
@@ -100,8 +100,8 @@ template Service
                     redemptionDate = getRedemptionDate maturityDate payoutDate
                     faceAmount = asset.quantity * (getPayoutRate claims)
                     buyerSafekeepingAcc = getAccount True settlementInfo buyer
-                    mt564 = createMT564Details instrumentId buyerSafekeepingAcc CR faceAmount currency maturityDate payoutDate redemptionDate exDivDate
-                    mt564_redempt = (\_ -> createMT564Details instrumentId buyerSafekeepingAcc CR asset.quantity currency maturityDate payoutDate redemptionDate exDivDate) <$> redemptionDate          
+                    mt564 = createMT564Details instrumentId asset.id buyerSafekeepingAcc CR faceAmount currency maturityDate payoutDate redemptionDate exDivDate
+                    mt564_redempt = (\_ -> createMT564Details instrumentId asset.id buyerSafekeepingAcc CR asset.quantity currency maturityDate payoutDate redemptionDate exDivDate) <$> redemptionDate          
                     notificationId = "Prenotification-" <> show exDivDate <> "-" <> assetId.label <> "(v" <> show assetId.version <> ")" <> "-" <> partyToText buyer
                   mapA_ (\mt564_r -> create SwiftOutboundMessage with referenceId = notificationId <> "-" <> "redempt"; provider = operator ; consumer = operator; swiftMessage=MT564 (mt564_r); swiftMessageType=MT564_t; status=Finalized; observers=empty) mt564_redempt
                   create SwiftOutboundMessage with referenceId = notificationId; provider = operator ; consumer = operator; swiftMessage=MT564 (mt564); swiftMessageType=MT564_t; status=Finalized; observers=empty

--- a/daml/SwiftMessage/Model/MT564.daml
+++ b/daml/SwiftMessage/Model/MT564.daml
@@ -9,8 +9,8 @@ data MT564Details = MT564Details with
     exDivDate : Date
   deriving (Eq, Show)
 
-createMT564Details : Text -> Account -> CRDB -> Decimal -> Id -> Date -> Date -> Optional Date -> Date -> MT564Details
-createMT564Details instrumentId buyerSafekeepingAcc crdb faceAmount 
+createMT564Details : Text -> Id -> Account -> CRDB -> Decimal -> Id -> Date -> Date -> Optional Date -> Date -> MT564Details
+createMT564Details instrumentId assetId buyerSafekeepingAcc crdb faceAmount 
   currency maturityDate payoutDate redemptionDate exDivDate = 
     let payoutType = if isSome redemptionDate then REDM else INTR in
     let payoutDetails = PayoutDetails with payoutCurrency = currency; settledCurrency = currency; .. in

--- a/daml/SwiftMessage/Model/MT566.daml
+++ b/daml/SwiftMessage/Model/MT566.daml
@@ -8,8 +8,8 @@ data MT566Details = MT566Details with
     payoutDetails : PayoutDetails
   deriving (Eq, Show)
 
-createMT566Details : Text -> Account -> CRDB -> Decimal -> Id -> Date -> Date -> Optional Date -> MT566Details
-createMT566Details instrumentId buyerSafekeepingAcc crdb faceAmount 
+createMT566Details : Text -> Id -> Account -> CRDB -> Decimal -> Id -> Date -> Date -> Optional Date -> MT566Details
+createMT566Details instrumentId assetId buyerSafekeepingAcc crdb faceAmount 
   currency maturityDate payoutDate redemptionDate = 
     let payoutType = if isSome redemptionDate then REDM else INTR in
     let payoutDetails = PayoutDetails with payoutCurrency = currency; settledCurrency = currency; .. in

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -17,7 +17,8 @@ data MessageType =
 data CRDB = CR | DB deriving (Eq, Show)
 
 data PayoutDetails = PayoutDetails with
-    instrumentId : Text -- ISIN + bond id
+    instrumentId : Text -- ISIN + bond id label
+    assetId : Id -- bond id
     buyerSafekeepingAcc : Account -- buyer's/investor's cash account
 
     crdb : CRDB -- credit or debit indicator

--- a/daml/Tests/Distribution/Syndication/Origination.daml
+++ b/daml/Tests/Distribution/Syndication/Origination.daml
@@ -58,10 +58,10 @@ origination Parties{..} = do
     swapRecAmount = Instrument.Fixed with annualRate = 0.01
     swapPay = Instrument.InterestStream with schedule = swapPaySched; amount = swapPayAmount
     swapRec = Instrument.InterestStream with schedule = swapRecSched; amount = swapRecAmount
-    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator]
-    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator]
-    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator]
-    swap1 = createSwap              swap1Id usd.assetId usd.assetId swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
+    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator]
+    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator]
+    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator]
+    swap1 = createSwap              swap1Id usd.assetId usd.assetId issuer swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
 
   submitMulti [operator, bondRegistrar] [] do createCmd HolidayCalendar with operator; provider = bondRegistrar; calendar = fedCalendar; observers = fromList [issuer]
 

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -139,27 +139,27 @@ createSchedule : Date -> Date -> PeriodEnum -> Int -> [Text] -> BusinessDayConve
 createSchedule startDate endDate period periodMultiplier calendarIds businessDayConvention dayCountConvention rollConvention =
   Instrument.InterestSchedule with ..
 
-createFixedRateBond : Id -> Text -> Id -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFixedRateBond id isin currencyId issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable observers =
+createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
+createFixedRateBond id isin currencyId issuer issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable observers =
   let
     amount = Instrument.Fixed with annualRate
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createFloatingRateBond : Id -> Text -> Id -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFloatingRateBond id isin currencyId issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable observers =
+createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
+createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable observers =
   let
     amount = Instrument.Float with rateId; periodSpread
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createZeroCouponBond : Id -> Text -> Id -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createZeroCouponBond id isin currencyId issueDate maturityDate isTradeable isPricedDirty isCallable observers =
+createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
+createZeroCouponBond id isin currencyId issuer issueDate maturityDate isTradeable isPricedDirty isCallable observers =
   Instrument.Bond with stream = None; ..
 
-createSwap : Id -> Id -> Id -> Date -> Date -> Instrument.InterestStream -> Instrument.InterestStream -> Bool -> [Party] -> Instrument.Swap
-createSwap id payCurrencyId receiveCurrencyId issueDate maturityDate pay receive isTradeable observers =
-  Instrument.Swap with id; payCurrencyId; receiveCurrencyId; issueDate; maturityDate; pay; receive; isTradeable; observers
+createSwap : Id -> Id -> Id -> Party -> Date -> Date -> Instrument.InterestStream -> Instrument.InterestStream -> Bool -> [Party] -> Instrument.Swap
+createSwap id payCurrencyId receiveCurrencyId issuer issueDate maturityDate pay receive isTradeable observers =
+  Instrument.Swap with ..
 
 originateBond : Party -> Party -> Party -> [Party] -> Instrument.Bond -> Script (AssetDescription, ContractId Instrument.Bond)
 originateBond operator provider customer observers bond = do


### PR DESCRIPTION
After discussion with @dorrit-du-da we would like to make some minor changes below to better support query with filtering
Changes include in this PR:

1. add issuer into Bond so swift adaptor will be able to compose the key (operator, payingAgent, issuer) and fetch Lifecycle.Service  
2. add assetId field into MT564 and MT566 for swift adaptor to filter/group SwiftOutboundMessage