### PR TITLE
Add support for FoP settlement

### DIFF
--- a/daml/Marketplace/Distribution/Syndication/Bidding/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Bidding/Model.daml
@@ -1,6 +1,7 @@
 module Marketplace.Distribution.Syndication.Bidding.Model where
 
 import DA.Finance.Types (Asset, Id)
+import Marketplace.Settlement.Hierarchical (SettlementMode)
 
 template BidRequest
   with
@@ -62,6 +63,8 @@ template Allocation
 
     controller investor can
       Confirm : ContractId Confirmation
+        with
+          settlementMode : SettlementMode
         do
           create Confirmation with ..
 
@@ -74,6 +77,7 @@ template Confirmation
     dealId : Text
     asset : Asset
     price : Asset
+    settlementMode : SettlementMode
   where
     signatory operator, provider, investor
     observer issuer

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -35,6 +35,8 @@ template AddTrancheRequest
     deliveryId : Id
     paymentId : Id
     size : Decimal
+    issuerSettlementMode : SettlementMode
+    bndSettlementMode : SettlementMode
   where
     signatory operator, provider, customer
 
@@ -63,6 +65,8 @@ template Deal
           cashProvider : Party
           bondRegistrar : Party
           payingAgent : Party
+          issuerSettlementMode : SettlementMode
+          bndSettlementMode : SettlementMode
         do
           dealCid <- create this with trancheIds = trancheIds <> [trancheId]
           trancheCid <- create Tranche with trancheProvider = dealProvider; ..
@@ -83,6 +87,8 @@ template Tranche
     deliveryId : Id
     paymentId : Id
     size : Decimal
+    issuerSettlementMode : SettlementMode
+    bndSettlementMode : SettlementMode
   where
     signatory operator, trancheProvider, issuer
     observer settlementBank, bndBank
@@ -125,16 +131,25 @@ template Tranche
             settlementId = deliveryId.label <> "-" <> partyToText issuer <> "-" <> partyToText settlementBank
           (_, issuerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, issuer)
           (_, settlementBankSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, settlementBank)
-          let
-            issuerCashAccount = getAccount True issuerSettlementInfo issuer
-            settlementBankCashAccount = getAccount True settlementBankSettlementInfo settlementBank
-            issuerSecuritiesAccount = getAccount False issuerSettlementInfo issuer
-            settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
-          bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuerSecuritiesAccount settlementBankSecuritiesAccount settlementId 0 totalAsset
-          cashSis <- createInstructions True operator bondRegistrar cashProvider settlementBankCashAccount issuerCashAccount settlementId (length bondSis) totalPrice
-          instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+          instructionIds <-
+            if issuerSettlementMode == Dvp
+            then do
+              let
+                issuerCashAccount = getAccount True issuerSettlementInfo issuer
+                settlementBankCashAccount = getAccount True settlementBankSettlementInfo settlementBank
+                issuerSecuritiesAccount = getAccount False issuerSettlementInfo issuer
+                settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
+              bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuerSecuritiesAccount settlementBankSecuritiesAccount settlementId 0 totalAsset
+              cashSis <- createInstructions True operator bondRegistrar cashProvider settlementBankCashAccount issuerCashAccount settlementId (length bondSis) totalPrice
+              map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+            else do
+              let
+                issuerSecuritiesAccount = getAccount False issuerSettlementInfo issuer
+                settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
+              bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuerSecuritiesAccount settlementBankSecuritiesAccount settlementId 0 totalAsset
+              map (.instructionId) <$> mapA fetch bondSis
           sendSwiftMessage issuer settlementBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
-          create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = Dvp
+          create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = issuerSettlementMode
 
       nonconsuming InstructBndSettlement : ContractId Trade
         with
@@ -149,16 +164,25 @@ template Tranche
             settlementId = deliveryId.label <> "-" <> partyToText settlementBank <> "-" <> partyToText bndBank
           (_, bndBankSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, bndBank)
           (_, settlementBankSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, settlementBank)
-          let
-            bndBankCashAccount = getAccount True bndBankSettlementInfo bndBank
-            settlementBankCashAccount = getAccount True settlementBankSettlementInfo settlementBank
-            bndBankSecuritiesAccount = getAccount False bndBankSettlementInfo bndBank
-            settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
-          bondSis <- createInstructions False operator bondRegistrar bondRegistrar settlementBankSecuritiesAccount bndBankSecuritiesAccount settlementId 0 totalAsset
-          cashSis <- createInstructions True operator bondRegistrar cashProvider bndBankCashAccount settlementBankCashAccount settlementId (length bondSis) totalPrice
-          instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+          instructionIds <-
+            if bndSettlementMode == Dvp
+            then do
+              let
+                bndBankCashAccount = getAccount True bndBankSettlementInfo bndBank
+                settlementBankCashAccount = getAccount True settlementBankSettlementInfo settlementBank
+                bndBankSecuritiesAccount = getAccount False bndBankSettlementInfo bndBank
+                settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
+              bondSis <- createInstructions False operator bondRegistrar bondRegistrar settlementBankSecuritiesAccount bndBankSecuritiesAccount settlementId 0 totalAsset
+              cashSis <- createInstructions True operator bondRegistrar cashProvider bndBankCashAccount settlementBankCashAccount settlementId (length bondSis) totalPrice
+              map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+            else do
+              let
+                bndBankSecuritiesAccount = getAccount False bndBankSettlementInfo bndBank
+                settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
+              bondSis <- createInstructions False operator bondRegistrar bondRegistrar settlementBankSecuritiesAccount bndBankSecuritiesAccount settlementId 0 totalAsset
+              map (.instructionId) <$> mapA fetch bondSis
           sendSwiftMessage settlementBank bndBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
-          create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = Dvp
+          create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = bndSettlementMode
 
       nonconsuming InstructInvestorSettlement : [ContractId Trade]
         with

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -6,10 +6,10 @@ import Marketplace.Custody.Model qualified as Custody
 import Marketplace.Distribution.Syndication.Bidding.Model qualified as Bidding
 import Marketplace.Settlement.Hierarchical (createInstructions, getAccount, Trade(..), Status(..), SettlementMode(..))
 import Marketplace.Issuance.Instrument.Model(Bond(..))
+import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessageType(..), SwiftOutboundMessage(..))
 import SwiftMessage.Model.MT545
 import SwiftMessage.Model.MT547
 import SwiftMessage.Util
-import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessageType(..), SwiftOutboundMessage(..))
 
 template CreateDealRequest
   with
@@ -131,22 +131,21 @@ template Tranche
             settlementId = deliveryId.label <> "-" <> partyToText issuer <> "-" <> partyToText settlementBank
           (_, issuerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, issuer)
           (_, settlementBankSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, settlementBank)
+          
+          let 
+            issuerSecuritiesAccount = getAccount False issuerSettlementInfo issuer
+            settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
+          bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuerSecuritiesAccount settlementBankSecuritiesAccount settlementId 0 totalAsset
+          
           instructionIds <-
             if issuerSettlementMode == Dvp
             then do
               let
                 issuerCashAccount = getAccount True issuerSettlementInfo issuer
                 settlementBankCashAccount = getAccount True settlementBankSettlementInfo settlementBank
-                issuerSecuritiesAccount = getAccount False issuerSettlementInfo issuer
-                settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
-              bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuerSecuritiesAccount settlementBankSecuritiesAccount settlementId 0 totalAsset
               cashSis <- createInstructions True operator bondRegistrar cashProvider settlementBankCashAccount issuerCashAccount settlementId (length bondSis) totalPrice
               map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
             else do
-              let
-                issuerSecuritiesAccount = getAccount False issuerSettlementInfo issuer
-                settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
-              bondSis <- createInstructions False operator bondRegistrar bondRegistrar issuerSecuritiesAccount settlementBankSecuritiesAccount settlementId 0 totalAsset
               map (.instructionId) <$> mapA fetch bondSis
           sendSwiftMessage issuer settlementBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
           create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = issuerSettlementMode

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -4,7 +4,7 @@ import DA.Finance.Types (Id, Asset(..))
 import DA.Set (fromList)
 import Marketplace.Custody.Model qualified as Custody
 import Marketplace.Distribution.Syndication.Bidding.Model qualified as Bidding
-import Marketplace.Settlement.Hierarchical (createInstructions, getAccount, Trade(..), Status(..))
+import Marketplace.Settlement.Hierarchical (createInstructions, getAccount, Trade(..), Status(..), SettlementMode(..))
 import Marketplace.Issuance.Instrument.Model(Bond(..))
 import SwiftMessage.Model.MT545
 import SwiftMessage.Model.MT547
@@ -134,7 +134,7 @@ template Tranche
           cashSis <- createInstructions True operator bondRegistrar cashProvider settlementBankCashAccount issuerCashAccount settlementId (length bondSis) totalPrice
           instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
           sendSwiftMessage issuer settlementBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
-          create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed
+          create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = Dvp
 
       nonconsuming InstructBndSettlement : ContractId Trade
         with
@@ -158,7 +158,7 @@ template Tranche
           cashSis <- createInstructions True operator bondRegistrar cashProvider bndBankCashAccount settlementBankCashAccount settlementId (length bondSis) totalPrice
           instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
           sendSwiftMessage settlementBank bndBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
-          create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed
+          create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = Dvp
 
       nonconsuming InstructInvestorSettlement : [ContractId Trade]
         with
@@ -178,16 +178,26 @@ template Tranche
                 settlementId = deliveryId.label <> "-" <> partyToText bndBank <> "-" <> partyToText conf.investor
               (_, bndBankSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, bndBank)
               (_, investorSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, conf.investor)
-              let
-                bndBankCashAccount = getAccount True bndBankSettlementInfo bndBank
-                investorCashAccount = getAccount True investorSettlementInfo conf.investor
-                bndBankSecuritiesAccount = getAccount False bndBankSettlementInfo bndBank
-                investorSecuritiesAccount = getAccount False investorSettlementInfo conf.investor
-              assertMsg "Total confirmed amount is larger than available quantity" $ aggregate <= size
-              bondSis <- createInstructions False operator bondRegistrar bondRegistrar bndBankSecuritiesAccount investorSecuritiesAccount settlementId 0 conf.asset
-              cashSis <- createInstructions True operator bondRegistrar cashProvider investorCashAccount bndBankCashAccount settlementId (length bondSis) aggregatePrice
-              instructionIds <- map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+              instructionIds <-
+                if conf.settlementMode == Dvp
+                then do
+                  let
+                    bndBankCashAccount = getAccount True bndBankSettlementInfo bndBank
+                    investorCashAccount = getAccount True investorSettlementInfo conf.investor
+                    bndBankSecuritiesAccount = getAccount False bndBankSettlementInfo bndBank
+                    investorSecuritiesAccount = getAccount False investorSettlementInfo conf.investor
+                  assertMsg "Total confirmed amount is larger than available quantity" $ aggregate <= size
+                  bondSis <- createInstructions False operator bondRegistrar bondRegistrar bndBankSecuritiesAccount investorSecuritiesAccount settlementId 0 conf.asset
+                  cashSis <- createInstructions True operator bondRegistrar cashProvider investorCashAccount bndBankCashAccount settlementId (length bondSis) aggregatePrice
+                  map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
+                else do
+                  let
+                    bndBankSecuritiesAccount = getAccount False bndBankSettlementInfo bndBank
+                    investorSecuritiesAccount = getAccount False investorSettlementInfo conf.investor
+                  assertMsg "Total confirmed amount is larger than available quantity" $ aggregate <= size
+                  bondSis <- createInstructions False operator bondRegistrar bondRegistrar bndBankSecuritiesAccount investorSecuritiesAccount settlementId 0 conf.asset
+                  map (.instructionId) <$> mapA fetch bondSis
               sendSwiftMessage settlementBank bndBank aggregate settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
               exercise confCid Bidding.Delete
-              create Trade with operator; agent = bondRegistrar; deliverer = bndBank; payer = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = aggregatePrice; status = Instructed
+              create Trade with operator; agent = bondRegistrar; deliverer = bndBank; payer = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = aggregatePrice; status = Instructed; settlementMode = conf.settlementMode
           mapA settleConfirmation filtered

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Service.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Service.daml
@@ -7,6 +7,7 @@ import DA.Optional (catOptionals)
 import Marketplace.Distribution.Syndication.Structuring.Model (Deal(..), CreateTranche(..), Tranche, CreateDealRequest(..), AddTrancheRequest(..))
 import Marketplace.Distribution.Syndication.Bidding.Model qualified as Bidding
 import Marketplace.Distribution.Syndication.BookBuilding.Model qualified as BookBuilding
+import Marketplace.Settlement.Hierarchical (SettlementMode)
 import Marketplace.Utils
 
 type S = Service
@@ -41,6 +42,8 @@ template Service
           deliveryId : Id
           paymentId : Id
           size : Decimal
+          issuerSettlementMode : SettlementMode
+          bndSettlementMode : SettlementMode
         do
           create AddTrancheRequest with ..
 

--- a/daml/Marketplace/Settlement/Hierarchical.daml
+++ b/daml/Marketplace/Settlement/Hierarchical.daml
@@ -10,6 +10,8 @@ import DA.Set (fromList)
 import Marketplace.Custody.Model qualified as Custody
 import SwiftMessage.Message
 
+data SettlementMode = Dvp | Fop deriving (Eq, Show)
+
 data Status =
   Instructed
   | Settled
@@ -26,6 +28,7 @@ template Trade
     payment : Asset
     delivery : Asset
     status : Status
+    settlementMode : SettlementMode
   where
     signatory operator
     observer agent

--- a/daml/Marketplace/Trading/Otc/Model.daml
+++ b/daml/Marketplace/Trading/Otc/Model.daml
@@ -62,21 +62,20 @@ template Match
           settlementId = id <> "-" <> partyToText customer <> "-" <> partyToText counterparty
         (_, buyerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, buyer)
         (_, sellerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, seller)
+
+        let 
+          buyerSecuritiesAccount = getAccount False buyerSettlementInfo buyer
+          sellerSecuritiesAccount = getAccount False sellerSettlementInfo seller
+        deliverySis <- createInstructions False operator operator deliveryRegistrar sellerSecuritiesAccount buyerSecuritiesAccount settlementId 0 delivery
         instructionIds <-
             if settlementMode == Dvp
             then do
               let
                 buyerCashAccount = getAccount True buyerSettlementInfo buyer
-                sellerCashAccount = getAccount True sellerSettlementInfo seller
-                buyerSecuritiesAccount = getAccount False buyerSettlementInfo buyer
-                sellerSecuritiesAccount = getAccount False sellerSettlementInfo seller
-              deliverySis <- createInstructions False operator operator deliveryRegistrar sellerSecuritiesAccount buyerSecuritiesAccount settlementId 0 delivery
+                sellerCashAccount = getAccount True sellerSettlementInfo seller      
               paymentSis <- createInstructions True operator operator paymentRegistrar buyerCashAccount sellerCashAccount settlementId (length deliverySis) payment
               map (.instructionId) <$> mapA fetch (deliverySis <> paymentSis)
             else do
-              let
-                buyerSecuritiesAccount = getAccount False buyerSettlementInfo buyer
-                sellerSecuritiesAccount = getAccount False sellerSettlementInfo seller
-              deliverySis <- createInstructions False operator operator deliveryRegistrar sellerSecuritiesAccount buyerSecuritiesAccount settlementId 0 delivery
               map (.instructionId) <$> mapA fetch deliverySis
         create Trade with operator; agent = operator; deliverer = seller; payer = buyer; settlementId; instructionIds; delivery; payment; status = Instructed; settlementMode
+        

--- a/daml/Marketplace/Trading/Otc/Model.daml
+++ b/daml/Marketplace/Trading/Otc/Model.daml
@@ -2,7 +2,7 @@ module Marketplace.Trading.Otc.Model where
 
 import DA.Finance.Types (Asset)
 import Marketplace.Custody.Model qualified as Custody
-import Marketplace.Settlement.Hierarchical (createInstructions, getAccount, Trade(..), Status(..))
+import Marketplace.Settlement.Hierarchical (createInstructions, getAccount, Trade(..), Status(..), SettlementMode(..))
 import Marketplace.Trading.Model (Side(..))
 
 template Order
@@ -17,6 +17,7 @@ template Order
     delivery : Asset
     payment : Asset
     side : Side
+    settlementMode : SettlementMode
   where
     signatory operator, provider, customer
     observer counterparty
@@ -48,6 +49,7 @@ template Match
     delivery : Asset
     payment : Asset
     side : Side
+    settlementMode : SettlementMode
   where
     signatory operator, provider, customer, counterparty
 
@@ -60,12 +62,21 @@ template Match
           settlementId = id <> "-" <> partyToText customer <> "-" <> partyToText counterparty
         (_, buyerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, buyer)
         (_, sellerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, seller)
-        let
-          buyerCashAccount = getAccount True buyerSettlementInfo buyer
-          sellerCashAccount = getAccount True sellerSettlementInfo seller
-          buyerSecuritiesAccount = getAccount False buyerSettlementInfo buyer
-          sellerSecuritiesAccount = getAccount False sellerSettlementInfo seller
-        deliverySis <- createInstructions False operator operator deliveryRegistrar sellerSecuritiesAccount buyerSecuritiesAccount settlementId 0 delivery
-        paymentSis <- createInstructions True operator operator paymentRegistrar buyerCashAccount sellerCashAccount settlementId (length deliverySis) payment
-        instructionIds <- map (.instructionId) <$> mapA fetch (deliverySis <> paymentSis)
-        create Trade with operator; agent = operator; deliverer = seller; payer = buyer; settlementId; instructionIds; delivery; payment; status = Instructed
+        instructionIds <-
+            if settlementMode == Dvp
+            then do
+              let
+                buyerCashAccount = getAccount True buyerSettlementInfo buyer
+                sellerCashAccount = getAccount True sellerSettlementInfo seller
+                buyerSecuritiesAccount = getAccount False buyerSettlementInfo buyer
+                sellerSecuritiesAccount = getAccount False sellerSettlementInfo seller
+              deliverySis <- createInstructions False operator operator deliveryRegistrar sellerSecuritiesAccount buyerSecuritiesAccount settlementId 0 delivery
+              paymentSis <- createInstructions True operator operator paymentRegistrar buyerCashAccount sellerCashAccount settlementId (length deliverySis) payment
+              map (.instructionId) <$> mapA fetch (deliverySis <> paymentSis)
+            else do
+              let
+                buyerSecuritiesAccount = getAccount False buyerSettlementInfo buyer
+                sellerSecuritiesAccount = getAccount False sellerSettlementInfo seller
+              deliverySis <- createInstructions False operator operator deliveryRegistrar sellerSecuritiesAccount buyerSecuritiesAccount settlementId 0 delivery
+              map (.instructionId) <$> mapA fetch deliverySis
+        create Trade with operator; agent = operator; deliverer = seller; payer = buyer; settlementId; instructionIds; delivery; payment; status = Instructed; settlementMode

--- a/daml/Marketplace/Trading/Otc/Service.daml
+++ b/daml/Marketplace/Trading/Otc/Service.daml
@@ -1,6 +1,7 @@
 module Marketplace.Trading.Otc.Service where
 
 import DA.Finance.Types (Asset)
+import Marketplace.Settlement.Hierarchical (SettlementMode)
 import Marketplace.Trading.Model (Side(..))
 import Marketplace.Trading.Otc.Model qualified as Trading
 
@@ -27,6 +28,7 @@ template Service
         payment : Asset
         paymentRegistrar : Party
         side : Side
+        settlementMode : SettlementMode
       controller customer
       do
         if not tradingAllowed

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -3,6 +3,7 @@ module Tests.Distribution.Syndication.Issuance where
 import Daml.Script
 import DA.Set (singleton)
 import Marketplace.Distribution.Syndication.Structuring.Model qualified as Structuring
+import Marketplace.Settlement.Hierarchical (SettlementMode(..))
 import Tests.Distribution.Syndication.Origination (origination, Origination(..))
 import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 import Tests.Distribution.Syndication.Util
@@ -58,14 +59,14 @@ issuance Parties{..} Origination{..} = do
   closeBook operator structurer issuer dealId "TRANCHE1" allocations offeredPrice
   closeBook operator structurer issuer dealId "TRANCHE2" allocations offeredPrice
 
-  confirmation11Cid <- confirm investor1 dealId "TRANCHE1"
-  confirmation12Cid <- confirm investor1 dealId "TRANCHE2"
-  confirmation21Cid <- confirm investor2 dealId "TRANCHE1"
-  confirmation22Cid <- confirm investor2 dealId "TRANCHE2"
-  confirmation31Cid <- confirm investor3 dealId "TRANCHE1"
-  confirmation32Cid <- confirm investor3 dealId "TRANCHE2"
-  confirmation41Cid <- confirm investor4 dealId "TRANCHE1"
-  confirmation42Cid <- confirm investor4 dealId "TRANCHE2"
+  confirmation11Cid <- confirm investor1 dealId "TRANCHE1" Dvp
+  confirmation12Cid <- confirm investor1 dealId "TRANCHE2" Dvp
+  confirmation21Cid <- confirm investor2 dealId "TRANCHE1" Dvp
+  confirmation22Cid <- confirm investor2 dealId "TRANCHE2" Dvp
+  confirmation31Cid <- confirm investor3 dealId "TRANCHE1" Dvp
+  confirmation32Cid <- confirm investor3 dealId "TRANCHE2" Dvp
+  confirmation41Cid <- confirm investor4 dealId "TRANCHE1" Dvp
+  confirmation42Cid <- confirm investor4 dealId "TRANCHE2" Dvp
 
   let
     confirmationCids1 = [ confirmation11Cid, confirmation21Cid, confirmation31Cid, confirmation41Cid ]

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -20,8 +20,8 @@ issuance Parties{..} Origination{..} = do
 
   let dealId = "DEAL1"
   dealCid     <- createDeal operator structurer issuer dealId
-  (dealCid, tranche1Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE1" bond1.id usd.assetId 100_000_000.0
-  (dealCid, tranche2Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE2" bond2.id usd.assetId 100_000_000.0
+  (dealCid, tranche1Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE1" bond1.id usd.assetId 100_000_000.0 Dvp Dvp
+  (dealCid, tranche2Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE2" bond2.id usd.assetId 100_000_000.0 Dvp Dvp
 
   deposit operator cashProvider  issuer     14_000_000.0 usd.assetId
   deposit operator cashProvider  lm1        20_000_000.0 usd.assetId

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -1,13 +1,13 @@
 module Tests.Distribution.Syndication.Issuance where
 
 import Daml.Script
+import DA.Date (Month(Dec), date)
 import DA.Set (singleton)
 import Marketplace.Distribution.Syndication.Structuring.Model qualified as Structuring
 import Marketplace.Settlement.Hierarchical (SettlementMode(..))
 import Tests.Distribution.Syndication.Origination (origination, Origination(..))
 import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 import Tests.Distribution.Syndication.Util
-import DA.Date (Month(Dec), date)
 
 test : Script ()
 test = do

--- a/daml/Tests/Distribution/Syndication/Trading.daml
+++ b/daml/Tests/Distribution/Syndication/Trading.daml
@@ -17,8 +17,8 @@ setTradingStatus operator isTradingAllowed = do
   serviceCids <- map fst <$> queryFilter @Trading.Service operator (\s -> s.operator == operator)
   submit operator do mapA (\sCid -> exerciseCmd sCid Trading.SetStatus with isTradingAllowed) serviceCids
 
-createOrder : Party -> Party -> Party -> Party -> Party -> Text -> Asset -> Asset -> Side -> Script (ContractId Trading.Order)
-createOrder operator customer counterparty deliveryRegistrar paymentRegistrar id delivery payment side = do
+createOrder : Party -> Party -> Party -> Party -> Party -> Text -> Asset -> Asset -> Side -> Settlement.SettlementMode -> Script (ContractId Trading.Order)
+createOrder operator customer counterparty deliveryRegistrar paymentRegistrar id delivery payment side settlementMode = do
   submit customer do exerciseByKeyCmd @Trading.Service (operator, operator, customer) Trading.CreateOrder with ..
 
 acceptOrder : Party -> Party -> ContractId Trading.Order -> Script (ContractId Trading.Match)
@@ -46,7 +46,7 @@ trading Parties{..} Origination{..}= do
   let
     delivery = Asset with id = bond1Desc.assetId; quantity = 1_000_000.0
     payment = Asset with id = usd.assetId; quantity = 1_000_000.0
-  orderCid <- createOrder operator investor1 investor2 bondRegistrar cashProvider "TRD1" delivery payment Buy
+  orderCid <- createOrder operator investor1 investor2 bondRegistrar cashProvider "TRD1" delivery payment Buy Settlement.Dvp
   matchCid <- acceptOrder operator investor2 orderCid
   tradeCid <- instructMatch operator matchCid
 

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -203,8 +203,8 @@ createDeal operator provider customer dealId = do
   createDealRequestCid <- submit customer do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.RequestCreateDeal with ..
   submit provider do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.CreateDeal with ..
 
-addTranche : Party -> Party -> Party -> Party -> Party -> Party -> Party -> Party -> Text -> Text -> Id -> Id -> Decimal -> Script (ContractId Structuring.Deal, ContractId Structuring.Tranche)
-addTranche operator provider customer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId trancheId deliveryId paymentId size = do
+addTranche : Party -> Party -> Party -> Party -> Party -> Party -> Party -> Party -> Text -> Text -> Id -> Id -> Decimal -> SettlementMode -> SettlementMode -> Script (ContractId Structuring.Deal, ContractId Structuring.Tranche)
+addTranche operator provider customer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId trancheId deliveryId paymentId size issuerSettlementMode bndSettlementMode = do
   addTrancheRequestCid <- submit customer do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.RequestAddTranche with ..
   submit provider do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.AddTranche with ..
 

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -34,7 +34,7 @@ import Marketplace.Distribution.Syndication.Structuring.Service qualified as Str
 import Marketplace.Lifecycle.Service qualified as Lifecycle
 import Marketplace.Snapshot.Service qualified as Snapshot
 import Marketplace.Reporting.Service qualified as Reporting
-import Marketplace.Settlement.Hierarchical (SettlementInstruction, Allocate(..), Sign(..), Settle(..), Trade, Delivery, SettleDelivery(..))
+import Marketplace.Settlement.Hierarchical (SettlementInstruction, Allocate(..), Sign(..), Settle(..), Trade, Delivery, SettleDelivery(..), SettlementMode)
 import Marketplace.Trading.Otc.Service qualified as Trading
 
 createCustodianRole : Party -> Party -> Script (ContractId Custodian.Role, ContractId Custody.SettlementInfo)
@@ -224,10 +224,10 @@ closeBook operator provider customer dealId trancheId allocations offeredPrice =
   bidCids <- map fst <$> queryFilter @Bidding.Bid customer (\r -> r.dealId == dealId && r.trancheId == trancheId)
   submit customer do exerciseByKeyCmd @Structuring.Service (operator, provider, customer) Structuring.CloseBook with ..
 
-confirm : Party -> Text -> Text -> Script (ContractId Bidding.Confirmation)
-confirm investor dealId trancheId = do
+confirm : Party -> Text -> Text -> SettlementMode -> Script (ContractId Bidding.Confirmation)
+confirm investor dealId trancheId settlementMode = do
   [(allocationCid, _)] <- queryFilter @Bidding.Allocation investor (\a -> a.dealId == dealId && a.trancheId == trancheId)
-  submit investor do exerciseCmd allocationCid Bidding.Confirm
+  submit investor do exerciseCmd allocationCid Bidding.Confirm with settlementMode
 
 allocateSi : Party -> (ContractId SettlementInstruction, SettlementInstruction) -> Script ()
 allocateSi party (siCid, si) = do
@@ -311,19 +311,19 @@ merge party deposits id = do
   let (adCid, _) :: t = filter (\(_, ad) -> ad.asset.id == id) deposits
   submit party do exerciseCmd adCid AssetDeposit_Merge with depositCids = map fst t
 
-getMaxId : Party -> Id -> Script Id 
-getMaxId payingAgent assetId = do 
+getMaxId : Party -> Id -> Script Id
+getMaxId payingAgent assetId = do
   h :: t <- map snd <$> queryFilter @AssetDescription payingAgent (\ad -> ad.assetId.signatories == assetId.signatories && ad.assetId.label == assetId.label)
   pure $ foldl (\id desc -> if desc.assetId.version > id.version then desc.assetId else id) h.assetId t
 
 upgradeVersion : [Party] -> Id -> Script ()
 upgradeVersion parties maxId = do
-  let upgradeVersionForParty party = do 
+  let upgradeVersionForParty party = do
         let
-          isTargetAsset : AssetDeposit -> Bool 
+          isTargetAsset : AssetDeposit -> Bool
           isTargetAsset deposit = (maxId.version == deposit.asset.id.version && maxId.label == deposit.asset.id.label)
         ads <- queryFilter @AssetDeposit party (\ad -> ad.account.provider == party && isTargetAsset ad)
         mapA_ (\(adCid, ad) -> submit party do
-          let newVersion = maxId.version + 1 
+          let newVersion = maxId.version + 1
           exerciseCmd adCid AssetDeposit_Upgrade with newVersion) ads
   mapA_ upgradeVersionForParty parties


### PR DESCRIPTION
This adds a `SettlementMode` that can be selected by a party for OTC trade settlement, or by an investor for settlement of an issuance. Settlement btw issuer, settlement bank, and BnD bank still happens through DvP.

This doesn't cover the adjustments for Swift messages to be sent out.