### PR TITLE
Swift Message Integration with FoP

### DIFF
--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -6,8 +6,10 @@ import Marketplace.Custody.Model qualified as Custody
 import Marketplace.Distribution.Syndication.Bidding.Model qualified as Bidding
 import Marketplace.Settlement.Hierarchical (createInstructions, getAccount, Trade(..), Status(..), SettlementMode(..))
 import Marketplace.Issuance.Instrument.Model(Bond(..))
-import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessageType(..), SwiftOutboundMessage(..))
+import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessage(MT544), SwiftMessage(MT546), SwiftMessageType(..), SwiftOutboundMessage(..))
+import SwiftMessage.Model.MT544
 import SwiftMessage.Model.MT545
+import SwiftMessage.Model.MT546
 import SwiftMessage.Model.MT547
 import SwiftMessage.Util
 
@@ -98,8 +100,12 @@ template Tranche
 
     -- helper fuction to send swift message
     let
-      sendSwiftMessage : Party -> Party -> Decimal -> Decimal -> Id -> Text -> Date -> Date -> Date -> Update (ContractId SwiftOutboundMessage)
-      sendSwiftMessage seller buyer settledQty settledAmount settledCurrency settlementId dateOfTrade dateOfSettlement effDateOfSettlement = do
+      createNewSettlementMessage: Text -> SwiftMessage -> SwiftMessageType -> Update (ContractId SwiftOutboundMessage)
+      createNewSettlementMessage referenceId swiftMessage swiftMessageType = 
+        create SwiftOutboundMessage with provider = operator; consumer = operator; status = Pending; observers = fromList [bondRegistrar]; ..
+
+      sendSwiftMessage : Party -> Party -> Decimal -> Decimal -> Id -> Text -> Date -> Date -> Date -> SettlementMode -> Update ()
+      sendSwiftMessage seller buyer settledQty settledAmount settledCurrency settlementId dateOfTrade dateOfSettlement effDateOfSettlement settlementMode = do
         (_, sellerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, seller)
         (_, receiverSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, buyer)
         (_, bond) <- fetchByKey @Bond (fromList [bondRegistrar, issuer], deliveryId.label)
@@ -107,15 +113,29 @@ template Tranche
           instrumentId = bond.isin <> "-" <> deliveryId.label
           buyerSafekeepingAcc = getAccount False receiverSettlementInfo buyer
           sellerSafekeepingAcc = getAccount False sellerSettlementInfo seller
-          mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider seller settledAmount settledCurrency
+        if settlementMode == Dvp then do
+          let 
+            mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider seller settledAmount settledCurrency
                     dateOfTrade dateOfSettlement effDateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
 
-          mt547 = createMT547Details instrumentId settledQty sellerSafekeepingAcc.provider seller settledAmount settledCurrency
+            mt547 = createMT547Details instrumentId settledQty sellerSafekeepingAcc.provider seller settledAmount settledCurrency
                     dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
-        create SwiftOutboundMessage with referenceId = settlementId; provider = operator ; consumer = operator; swiftMessage=MT545 (mt545); swiftMessageType=MT545_t; status=Pending; observers= fromList [bondRegistrar]
-        create SwiftOutboundMessage with referenceId = settlementId; provider = operator ; consumer = operator; swiftMessage=MT547 (mt547); swiftMessageType=MT547_t; status=Pending; observers=fromList [bondRegistrar]
+          createNewSettlementMessage settlementId (MT545 mt545) MT545_t
+          createNewSettlementMessage settlementId (MT547 mt547) MT547_t
+        else do
+          let
+            mt544 = createMT544Details instrumentId settledQty buyerSafekeepingAcc.provider seller
+                    dateOfTrade dateOfSettlement effDateOfSettlement
+                    settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
+
+            mt546 = createMT546Details instrumentId settledQty sellerSafekeepingAcc.provider seller
+                    dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
+                    settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
+          createNewSettlementMessage settlementId (MT544 mt544) MT544_t
+          createNewSettlementMessage settlementId (MT546 mt546) MT546_t
+        pure ()
 
     controller operator can
       nonconsuming InstructIssuerSettlement : ContractId Trade
@@ -147,7 +167,7 @@ template Tranche
               map (.instructionId) <$> mapA fetch (bondSis <> cashSis)
             else do
               map (.instructionId) <$> mapA fetch bondSis
-          sendSwiftMessage issuer settlementBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
+          sendSwiftMessage issuer settlementBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement issuerSettlementMode
           create Trade with operator; agent = bondRegistrar; deliverer = issuer; payer = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = issuerSettlementMode
 
       nonconsuming InstructBndSettlement : ContractId Trade
@@ -180,7 +200,7 @@ template Tranche
                 settlementBankSecuritiesAccount = getAccount False settlementBankSettlementInfo settlementBank
               bondSis <- createInstructions False operator bondRegistrar bondRegistrar settlementBankSecuritiesAccount bndBankSecuritiesAccount settlementId 0 totalAsset
               map (.instructionId) <$> mapA fetch bondSis
-          sendSwiftMessage settlementBank bndBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
+          sendSwiftMessage settlementBank bndBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement bndSettlementMode
           create Trade with operator; agent = bondRegistrar; deliverer = settlementBank; payer = bndBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Instructed; settlementMode = bndSettlementMode
 
       nonconsuming InstructInvestorSettlement : [ContractId Trade]
@@ -220,7 +240,7 @@ template Tranche
                   assertMsg "Total confirmed amount is larger than available quantity" $ aggregate <= size
                   bondSis <- createInstructions False operator bondRegistrar bondRegistrar bndBankSecuritiesAccount investorSecuritiesAccount settlementId 0 conf.asset
                   map (.instructionId) <$> mapA fetch bondSis
-              sendSwiftMessage settlementBank bndBank aggregate settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement
+              sendSwiftMessage settlementBank bndBank aggregate settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement conf.settlementMode
               exercise confCid Bidding.Delete
               create Trade with operator; agent = bondRegistrar; deliverer = bndBank; payer = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = aggregatePrice; status = Instructed; settlementMode = conf.settlementMode
           mapA settleConfirmation filtered

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -115,22 +115,24 @@ template Tranche
           sellerSafekeepingAcc = getAccount False sellerSettlementInfo seller
         if settlementMode == Dvp then do
           let 
-            mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider seller settledAmount settledCurrency
+            mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider sellerSafekeepingAcc.provider seller buyer
+                    settledAmount settledCurrency
                     dateOfTrade dateOfSettlement effDateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
 
-            mt547 = createMT547Details instrumentId settledQty sellerSafekeepingAcc.provider seller settledAmount settledCurrency
+            mt547 = createMT547Details instrumentId settledQty buyerSafekeepingAcc.provider sellerSafekeepingAcc.provider seller buyer
+                    settledAmount settledCurrency
                     dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
           createNewSettlementMessage settlementId (MT545 mt545) MT545_t
           createNewSettlementMessage settlementId (MT547 mt547) MT547_t
         else do
           let
-            mt544 = createMT544Details instrumentId settledQty buyerSafekeepingAcc.provider seller
+            mt544 = createMT544Details instrumentId settledQty buyerSafekeepingAcc.provider buyerSafekeepingAcc.provider seller buyer
                     dateOfTrade dateOfSettlement effDateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
 
-            mt546 = createMT546Details instrumentId settledQty sellerSafekeepingAcc.provider seller
+            mt546 = createMT546Details instrumentId settledQty buyerSafekeepingAcc.provider sellerSafekeepingAcc.provider seller buyer
                     dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
           createNewSettlementMessage settlementId (MT544 mt544) MT544_t

--- a/daml/Marketplace/Settlement/Hierarchical.daml
+++ b/daml/Marketplace/Settlement/Hierarchical.daml
@@ -46,10 +46,12 @@ template Trade
               exercise siCid SettleInstruction
           adCids <- mapA settle instructionIds
           tradeCid <- create this with status = Settled
-          finalizeSwiftMessage (operator, settlementId, MT544_t)
-          finalizeSwiftMessage (operator, settlementId, MT545_t)
-          finalizeSwiftMessage (operator, settlementId, MT546_t)
-          finalizeSwiftMessage (operator, settlementId, MT547_t)
+          if settlementMode == Dvp then do 
+            finalizeSwiftMessage (operator, settlementId, MT545_t)
+            finalizeSwiftMessage (operator, settlementId, MT547_t)
+          else do
+            finalizeSwiftMessage (operator, settlementId, MT544_t)
+            finalizeSwiftMessage (operator, settlementId, MT546_t)
           pure (tradeCid, adCids)
 
 template Delivery

--- a/daml/Marketplace/Settlement/Hierarchical.daml
+++ b/daml/Marketplace/Settlement/Hierarchical.daml
@@ -46,7 +46,9 @@ template Trade
               exercise siCid SettleInstruction
           adCids <- mapA settle instructionIds
           tradeCid <- create this with status = Settled
+          finalizeSwiftMessage (operator, settlementId, MT544_t)
           finalizeSwiftMessage (operator, settlementId, MT545_t)
+          finalizeSwiftMessage (operator, settlementId, MT546_t)
           finalizeSwiftMessage (operator, settlementId, MT547_t)
           pure (tradeCid, adCids)
 

--- a/daml/SwiftMessage/Message.daml
+++ b/daml/SwiftMessage/Message.daml
@@ -3,7 +3,9 @@ module SwiftMessage.Message where
 import SwiftMessage.Util
 import SwiftMessage.Model.MT535
 import SwiftMessage.Model.MT940
+import SwiftMessage.Model.MT544
 import SwiftMessage.Model.MT545
+import SwiftMessage.Model.MT546
 import SwiftMessage.Model.MT547
 import SwiftMessage.Model.MT564
 import SwiftMessage.Model.MT566
@@ -11,7 +13,9 @@ import DA.Set (Set)
 import DA.Optional (whenSome)
 
 data SwiftMessage = 
-      MT545 (MT545Details)
+      MT544 (MT544Details)
+    | MT545 (MT545Details)
+    | MT546 (MT546Details)
     | MT547 (MT547Details)
     | MT564 (MT564Details)
     | MT566 (MT566Details)
@@ -19,7 +23,7 @@ data SwiftMessage =
     | MT940 (MT940Details)
   deriving (Eq, Show)
 
-data SwiftMessageType = MT545_t | MT547_t | MT564_t | MT566_t | MT535_t | MT940_t
+data SwiftMessageType = MT544_t | MT545_t | MT546_t | MT547_t | MT564_t | MT566_t | MT535_t | MT940_t
   deriving (Eq, Show)
 
 

--- a/daml/SwiftMessage/Model/MT544.daml
+++ b/daml/SwiftMessage/Model/MT544.daml
@@ -7,18 +7,14 @@ import SwiftMessage.Util
 -- FoP confirmation for buyer
 data MT544Details = MT544Details with
     messageType: MessageType
-
-    deliveringAgent: Party  -- security account provider for the buyer
-    seller: Party
-    
     settlementDetails: SettlementDetails
   deriving (Eq, Show)
 
 
-createMT544Details : Text -> Decimal -> Party -> Party
+createMT544Details : Text -> Decimal -> Party -> Party -> Party -> Party
   -> Date -> Date -> Date 
   -> Text -> Text -> Account -> Account -> Text -> Text -> MT544Details
-createMT544Details instrumentId qtyOfInstrument deliveringAgent seller
+createMT544Details instrumentId qtyOfInstrument deliveringAgent receivingAgent seller buyer
   dateOfTrade dateOfSettlement effDateOfSettlement 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT544Details with messageType = NEWM; settlementDetails = SettlementDetails with ..; ..
+    MT544Details with messageType = NEWM; settlementDetails = SettlementDetails with ..

--- a/daml/SwiftMessage/Model/MT544.daml
+++ b/daml/SwiftMessage/Model/MT544.daml
@@ -1,0 +1,24 @@
+module SwiftMessage.Model.MT544 where
+
+import DA.Finance.Types
+import SwiftMessage.Util
+
+
+-- FoP confirmation for buyer
+data MT544Details = MT544Details with
+    messageType: MessageType
+
+    deliveringAgent: Party  -- security account provider for the buyer
+    seller: Party
+    
+    settlementDetails: SettlementDetails
+  deriving (Eq, Show)
+
+
+createMT544Details : Text -> Decimal -> Party -> Party
+  -> Date -> Date -> Date 
+  -> Text -> Text -> Account -> Account -> Text -> Text -> MT544Details
+createMT544Details instrumentId qtyOfInstrument deliveringAgent seller
+  dateOfTrade dateOfSettlement effDateOfSettlement 
+  senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
+    MT544Details with messageType = NEWM; settlementDetails = SettlementDetails with ..; ..

--- a/daml/SwiftMessage/Model/MT545.daml
+++ b/daml/SwiftMessage/Model/MT545.daml
@@ -6,25 +6,10 @@ import SwiftMessage.Util
 data MT545Details = MT545Details with
     messageType: MessageType -- NEWM
     
-    instrumentId: Text --ISIN IE00BYVQ9F29 ISHARES NASDAQ 100 UCITS ETF ISHARES NASDAQ 100 EUR-H ACC
-    qtyOfInstrument: Decimal -- security quantity
-
-    deliveringAgent: Party  -- placeholder as pending on GS side // deliverying or receiving agent??
+    deliveringAgent: Party  -- security account provider for the buyer
     seller: Party
-
-    settledAmount: Decimal -- notional
-    settledCurrency: Id
-    dateOfTrade: Date -- 20201029
-    dateOfSettlement: Date  -- 20201102
-    effDateOfSettlement: Date -- this should be SETT instead of ESET and should be same as dateOfSettlement
     
-    senderMsgRef: Text -- settlement id
-    relatedMsgRef: Text -- same as senderMessageReference 
-    
-    buyerSafekeepingAcc: Account -- custodian bond registart account 
-    sellerSafekeepingAcc: Account -- Issuer bondregistar account 
-    safekeepingPlace: Text --  TOKENIZED INFRASTRUCTURE
-    placeOfSettlement: Text --  TOKENIZED INFRASTRUCTURE
+    settlementDetails: DvPSettlementDetails
   deriving (Eq, Show)
 
   
@@ -34,4 +19,4 @@ createMT545Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
 createMT545Details instrumentId qtyOfInstrument deliveringAgent seller settledAmount settledCurrency 
   dateOfTrade dateOfSettlement effDateOfSettlement 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT545Details with messageType = NEWM; ..
+    MT545Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with ..; ..

--- a/daml/SwiftMessage/Model/MT545.daml
+++ b/daml/SwiftMessage/Model/MT545.daml
@@ -3,6 +3,7 @@ module SwiftMessage.Model.MT545 where
 import DA.Finance.Types (Id(..), Account(..))
 import SwiftMessage.Util
 
+-- DvP confirmation for buyer
 data MT545Details = MT545Details with
     messageType: MessageType -- NEWM
     

--- a/daml/SwiftMessage/Model/MT545.daml
+++ b/daml/SwiftMessage/Model/MT545.daml
@@ -6,7 +6,7 @@ import SwiftMessage.Util
 -- DvP confirmation for buyer
 data MT545Details = MT545Details with
     messageType: MessageType -- NEWM    
-    settlementDetails: DvPSettlementDetails
+    dvpSettlementDetails: DvPSettlementDetails
   deriving (Eq, Show)
 
   
@@ -18,4 +18,4 @@ createMT545Details instrumentId qtyOfInstrument deliveringAgent receivingAgent s
   settledAmount settledCurrency 
   dateOfTrade dateOfSettlement effDateOfSettlement 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT545Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with settlementDetails = SettlementDetails with ..; ..
+    MT545Details with messageType = NEWM; dvpSettlementDetails = DvPSettlementDetails with settlementDetails = SettlementDetails with ..; ..

--- a/daml/SwiftMessage/Model/MT545.daml
+++ b/daml/SwiftMessage/Model/MT545.daml
@@ -5,19 +5,17 @@ import SwiftMessage.Util
 
 -- DvP confirmation for buyer
 data MT545Details = MT545Details with
-    messageType: MessageType -- NEWM
-    
-    deliveringAgent: Party  -- security account provider for the buyer
-    seller: Party
-    
+    messageType: MessageType -- NEWM    
     settlementDetails: DvPSettlementDetails
   deriving (Eq, Show)
 
   
-createMT545Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
+createMT545Details : Text -> Decimal -> Party -> Party -> Party -> Party
+  -> Decimal -> Id
   -> Date -> Date -> Date 
   -> Text -> Text -> Account -> Account -> Text -> Text -> MT545Details
-createMT545Details instrumentId qtyOfInstrument deliveringAgent seller settledAmount settledCurrency 
+createMT545Details instrumentId qtyOfInstrument deliveringAgent receivingAgent seller buyer
+  settledAmount settledCurrency 
   dateOfTrade dateOfSettlement effDateOfSettlement 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT545Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with ..; ..
+    MT545Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with settlementDetails = SettlementDetails with ..; ..

--- a/daml/SwiftMessage/Model/MT546.daml
+++ b/daml/SwiftMessage/Model/MT546.daml
@@ -1,0 +1,24 @@
+module SwiftMessage.Model.MT546 where
+
+import DA.Finance.Types
+import SwiftMessage.Util
+
+-- FoP confirmation for seller
+data MT546Details = MT546Details with
+    messageType: MessageType -- NEWM
+    
+    receivingAgent: Party  -- security account provider for the seller 
+    seller: Party
+    
+    valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
+
+    settlementDetails: SettlementDetails
+  deriving (Show, Eq)
+
+createMT546Details : Text -> Decimal -> Party -> Party
+  -> Date -> Date -> Date -> Date
+  -> Text -> Text -> Account -> Account -> Text -> Text -> MT546Details
+createMT546Details instrumentId qtyOfInstrument receivingAgent seller
+  dateOfTrade dateOfSettlement effDateOfSettlement valueDate 
+  senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
+    MT546Details with messageType = NEWM; settlementDetails = SettlementDetails with .. ; ..

--- a/daml/SwiftMessage/Model/MT546.daml
+++ b/daml/SwiftMessage/Model/MT546.daml
@@ -6,19 +6,14 @@ import SwiftMessage.Util
 -- FoP confirmation for seller
 data MT546Details = MT546Details with
     messageType: MessageType -- NEWM
-    
-    receivingAgent: Party  -- security account provider for the seller 
-    seller: Party
-    
-    valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
-
     settlementDetails: SettlementDetails
+    valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
   deriving (Show, Eq)
 
-createMT546Details : Text -> Decimal -> Party -> Party
+createMT546Details : Text -> Decimal -> Party -> Party -> Party -> Party
   -> Date -> Date -> Date -> Date
   -> Text -> Text -> Account -> Account -> Text -> Text -> MT546Details
-createMT546Details instrumentId qtyOfInstrument receivingAgent seller
+createMT546Details instrumentId qtyOfInstrument deliveringAgent receivingAgent seller buyer
   dateOfTrade dateOfSettlement effDateOfSettlement valueDate 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
     MT546Details with messageType = NEWM; settlementDetails = SettlementDetails with .. ; ..

--- a/daml/SwiftMessage/Model/MT547.daml
+++ b/daml/SwiftMessage/Model/MT547.daml
@@ -6,19 +6,16 @@ import SwiftMessage.Util
 -- DvP confirmation for seller 
 data MT547Details = MT547Details with
     messageType: MessageType -- NEWM
-    
-    receivingAgent: Party  -- security account provider for the seller 
-    seller: Party
-    
-    valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
-
     settlementDetails: DvPSettlementDetails
+    valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
   deriving (Eq, Show)
 
-createMT547Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
+createMT547Details : Text -> Decimal -> Party -> Party -> Party -> Party
+  -> Decimal -> Id
   -> Date -> Date -> Date -> Date
   -> Text -> Text -> Account -> Account -> Text -> Text -> MT547Details
-createMT547Details instrumentId qtyOfInstrument receivingAgent seller settledAmount settledCurrency 
+createMT547Details instrumentId qtyOfInstrument deliveringAgent receivingAgent seller buyer 
+  settledAmount settledCurrency 
   dateOfTrade dateOfSettlement effDateOfSettlement valueDate 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT547Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with .. ; ..
+    MT547Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with settlementDetails = SettlementDetails with ..; ..; ..

--- a/daml/SwiftMessage/Model/MT547.daml
+++ b/daml/SwiftMessage/Model/MT547.daml
@@ -6,7 +6,7 @@ import SwiftMessage.Util
 -- DvP confirmation for seller 
 data MT547Details = MT547Details with
     messageType: MessageType -- NEWM
-    settlementDetails: DvPSettlementDetails
+    dvpSettlementDetails: DvPSettlementDetails
     valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
   deriving (Eq, Show)
 
@@ -18,4 +18,4 @@ createMT547Details instrumentId qtyOfInstrument deliveringAgent receivingAgent s
   settledAmount settledCurrency 
   dateOfTrade dateOfSettlement effDateOfSettlement valueDate 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT547Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with settlementDetails = SettlementDetails with ..; ..; ..
+    MT547Details with messageType = NEWM; dvpSettlementDetails = DvPSettlementDetails with settlementDetails = SettlementDetails with ..; ..; ..

--- a/daml/SwiftMessage/Model/MT547.daml
+++ b/daml/SwiftMessage/Model/MT547.daml
@@ -1,9 +1,9 @@
-
 module SwiftMessage.Model.MT547 where
 
 import DA.Finance.Types (Id(..), Account(..))
 import SwiftMessage.Util
 
+-- DvP confirmation for seller 
 data MT547Details = MT547Details with
     messageType: MessageType -- NEWM
     

--- a/daml/SwiftMessage/Model/MT547.daml
+++ b/daml/SwiftMessage/Model/MT547.daml
@@ -7,26 +7,12 @@ import SwiftMessage.Util
 data MT547Details = MT547Details with
     messageType: MessageType -- NEWM
     
-    instrumentId: Text --ISIN IE00BYVQ9F29 ISHARES NASDAQ 100 UCITS ETF ISHARES NASDAQ 100 EUR-H ACC
-    qtyOfInstrument: Decimal -- security quantity
-    
-    receivingAgent: Party  -- placeholder as pending on GS side // deliverying or receiving agent??
+    receivingAgent: Party  -- security account provider for the seller 
     seller: Party
     
-    settledAmount: Decimal -- notional
-    settledCurrency: Id
-    dateOfTrade: Date -- 20201029
-    dateOfSettlement: Date  -- 20201102
-    effDateOfSettlement: Date -- this should be SETT instead of ESET and should be same as dateOfSettlement
     valueDate: Date --  Value Date/Time at which cash becomes available to the account owner (in a credit entry), or cease to be available to the account owner (in a debit entry).
 
-    senderMsgRef: Text -- settlementId
-    relatedMsgRef: Text -- same as senderMessageReference 
-    
-    buyerSafekeepingAcc: Account -- GS suggests putting AccountID as placeholder
-    sellerSafekeepingAcc: Account -- GS suggests putting Account ID as placeholder
-    safekeepingPlace: Text --  TOKENIZED INFRASTRUCTURE
-    placeOfSettlement: Text
+    settlementDetails: DvPSettlementDetails
   deriving (Eq, Show)
 
 createMT547Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
@@ -35,4 +21,4 @@ createMT547Details : Text -> Decimal -> Party -> Party -> Decimal -> Id
 createMT547Details instrumentId qtyOfInstrument receivingAgent seller settledAmount settledCurrency 
   dateOfTrade dateOfSettlement effDateOfSettlement valueDate 
   senderMsgRef relatedMsgRef buyerSafekeepingAcc sellerSafekeepingAcc safekeepingPlace placeOfSettlement =
-    MT547Details with messageType = NEWM; ..
+    MT547Details with messageType = NEWM; settlementDetails = DvPSettlementDetails with .. ; ..

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -16,6 +16,29 @@ data MessageType =
   | RMDR
   deriving (Eq, Show)
 
+data SettlementDetails = SettlementDetails with 
+    instrumentId: Text --ISIN + Bond label
+    qtyOfInstrument: Decimal -- quantity of Bond
+    
+    dateOfTrade: Date
+    dateOfSettlement: Date
+    effDateOfSettlement: Date -- this should be SETT instead of ESET and should be same as dateOfSettlement
+    
+    senderMsgRef: Text -- settlement id
+    relatedMsgRef: Text -- same as senderMsgRef
+    
+    buyerSafekeepingAcc: Account -- buyer's security account 
+    sellerSafekeepingAcc: Account -- seller's security account 
+    safekeepingPlace: Text --  TOKENIZED INFRASTRUCTURE (placeholder)
+    placeOfSettlement: Text --  TOKENIZED INFRASTRUCTURE (placeholder)
+  deriving (Eq, Show)
+
+
+data DvPSettlementDetails = DvPSettlementDetails with
+    settledAmount: Decimal -- notional
+    settledCurrency: Id
+  deriving (Eq, Show)
+
 data CRDB = CRED | DEBT deriving (Eq, Show)
 
 data PayoutDetails = PayoutDetails with

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -31,12 +31,18 @@ data SettlementDetails = SettlementDetails with
     sellerSafekeepingAcc: Account -- seller's security account 
     safekeepingPlace: Text --  TOKENIZED INFRASTRUCTURE (placeholder)
     placeOfSettlement: Text --  TOKENIZED INFRASTRUCTURE (placeholder)
+
+    deliveringAgent: Party  -- security account provider for the buyer
+    receivingAgent: Party  -- security account provider for the seller 
+    seller: Party
+    buyer: Party
   deriving (Eq, Show)
 
 
 data DvPSettlementDetails = DvPSettlementDetails with
     settledAmount: Decimal -- notional
     settledCurrency: Id
+    settlementDetails: SettlementDetails
   deriving (Eq, Show)
 
 data CRDB = CRED | DEBT deriving (Eq, Show)

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -21,17 +21,17 @@ issuance Parties{..} Origination{..} = do
   let dealId = "DEAL1"
   dealCid     <- createDeal operator structurer issuer dealId
   (dealCid, tranche1Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE1" bond1.id usd.assetId 100_000_000.0 Dvp Dvp
-  (dealCid, tranche2Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE2" bond2.id usd.assetId 100_000_000.0 Dvp Dvp
+  (dealCid, tranche2Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE2" bond2.id usd.assetId 100_000_000.0 Fop Fop
   (dealCid, tranche3Cid) <- addTranche operator structurer issuer settlementBank bndBank bondRegistrar cashProvider payingAgent dealId "TRANCHE3" bond3.id usd.assetId 100_000_000.0 Dvp Dvp
 
   deposit operator cashProvider  issuer     14_000_000.0 usd.assetId
-  deposit operator cashProvider  lm1        30_000_000.0 usd.assetId
-  deposit operator cashProvider  lm2       300_000_000.0 usd.assetId
-  deposit operator cashProvider  lm3       300_000_000.0 usd.assetId
-  deposit operator lm1           investor1  30_000_000.0 (usd.assetId with signatories = singleton lm1)
-  deposit operator lm2           investor2  60_000_000.0 (usd.assetId with signatories = singleton lm2)
-  deposit operator lm3           investor3  90_000_000.0 (usd.assetId with signatories = singleton lm3)
-  deposit operator lm3           investor4  120_000_000.0 (usd.assetId with signatories = singleton lm3)
+  deposit operator cashProvider  lm1        20_000_000.0 usd.assetId
+  deposit operator cashProvider  lm2       200_000_000.0 usd.assetId
+  deposit operator cashProvider  lm3       200_000_000.0 usd.assetId
+  deposit operator lm1           investor1  20_000_000.0 (usd.assetId with signatories = singleton lm1)
+  deposit operator lm2           investor2  40_000_000.0 (usd.assetId with signatories = singleton lm2)
+  deposit operator lm3           investor3  60_000_000.0 (usd.assetId with signatories = singleton lm3)
+  deposit operator lm3           investor4  80_000_000.0 (usd.assetId with signatories = singleton lm3)
 
   issue operator bondRegistrar issuer "BOND1-Issuance" tranche1Cid
   issue operator bondRegistrar issuer "BOND2-Issuance" tranche2Cid
@@ -71,16 +71,16 @@ issuance Parties{..} Origination{..} = do
   closeBook operator structurer issuer dealId "TRANCHE3" allocations offeredPrice
 
   confirmation11Cid <- confirm investor1 dealId "TRANCHE1" Dvp
-  confirmation12Cid <- confirm investor1 dealId "TRANCHE2" Dvp
+  confirmation12Cid <- confirm investor1 dealId "TRANCHE2" Fop
   confirmation13Cid <- confirm investor1 dealId "TRANCHE3" Dvp
   confirmation21Cid <- confirm investor2 dealId "TRANCHE1" Dvp
-  confirmation22Cid <- confirm investor2 dealId "TRANCHE2" Dvp
+  confirmation22Cid <- confirm investor2 dealId "TRANCHE2" Fop
   confirmation23Cid <- confirm investor2 dealId "TRANCHE3" Dvp
   confirmation31Cid <- confirm investor3 dealId "TRANCHE1" Dvp
-  confirmation32Cid <- confirm investor3 dealId "TRANCHE2" Dvp
+  confirmation32Cid <- confirm investor3 dealId "TRANCHE2" Fop
   confirmation33Cid <- confirm investor3 dealId "TRANCHE3" Dvp
   confirmation41Cid <- confirm investor4 dealId "TRANCHE1" Dvp
-  confirmation42Cid <- confirm investor4 dealId "TRANCHE2" Dvp
+  confirmation42Cid <- confirm investor4 dealId "TRANCHE2" Fop
   confirmation43Cid <- confirm investor4 dealId "TRANCHE3" Dvp
 
   let


### PR DESCRIPTION
The changes in this PR includes:

1. add FOP swift messages (MT544 and MT546)
2. refactor current DvP swift messages (MT545 and MT547) along with newly added FoP messages 
3. use bond2 in the issuance script to test FoP settlement flow

Note that this change should be merged only after https://github.com/digital-asset/da-marketplace/pull/478 is merged (to avoid conflicts)