### PR TITLE
Feature/fl 296 update terminate controllers remove redundant templates

### DIFF
--- a/daml/Marketplace/Clearing/Market/Service.daml
+++ b/daml/Marketplace/Clearing/Market/Service.daml
@@ -79,7 +79,7 @@ template Service
         ctrl : Party
       controller ctrl
       do
-        pure ()
+        assertMsg ("only provider:" <> partyToText provider <> "or customer" <> partyToText customer <> "is allowed to terminate") (ctrl `Set.member` Set.fromList [provider, customer])
 
 template Offer
   with

--- a/daml/Marketplace/Clearing/Model.daml
+++ b/daml/Marketplace/Clearing/Model.daml
@@ -99,12 +99,6 @@ template RejectedMarginCalculation
     key (provider, customer, calculation.calculationId) : (Party, Party, Text)
     maintainer key._1
 
-    choice RejectedMarginCalculation_Retry : ContractId MarginCalculation
-      with
-        ctrl : Party
-      controller ctrl
-      do create calculation
-
     controller provider can
       RejectedMarginCalculation_Cancel : ()
         do return ()
@@ -149,12 +143,6 @@ template RejectedMarkToMarketCalculation
 
     key (provider, customer, calculation.calculationId) : (Party, Party, Text)
     maintainer key._1
-
-    choice RejectedMarkToMarketCalculation_Retry : ContractId MarkToMarketCalculation
-      with
-        ctrl : Party
-      controller ctrl
-      do create calculation
 
     controller provider can
       RejectedMarkToMarketCalculation_Cancel : ()

--- a/daml/Marketplace/Clearing/Service.daml
+++ b/daml/Marketplace/Clearing/Service.daml
@@ -181,6 +181,7 @@ template Service
         ctrl : Party
       controller ctrl
       do
+        assertMsg ("only provider:" <> partyToText provider <> "or customer" <> partyToText customer <> "is allowed to terminate") (ctrl `Set.member` Set.fromList [provider, customer])
         (standingCid,_) <- fetchByKey @MemberStanding (provider,customer)
         archive standingCid
 

--- a/daml/Marketplace/Custody/Service.daml
+++ b/daml/Marketplace/Custody/Service.daml
@@ -3,6 +3,7 @@ module Marketplace.Custody.Service where
 import DA.Finance.Asset
 import DA.Finance.Types
 import DA.Finance.Utils (fetchAndArchive)
+import DA.Set qualified as Set
 import DA.Map qualified as M
 import DA.Set (empty, fromList)
 import Marketplace.Custody.Model qualified as Custody
@@ -108,8 +109,9 @@ template Service
     choice Terminate : ()
       with
         ctrl : Party
-      controller ctrl
-      do pure ()
+      controller ctrl 
+      do
+        assertMsg ("only provider:" <> partyToText provider <> "or customer" <> partyToText customer <> "is allowed to terminate") (ctrl `Set.member` Set.fromList [provider, customer])
 
 template Offer
   with

--- a/daml/Marketplace/Listing/Service.daml
+++ b/daml/Marketplace/Listing/Service.daml
@@ -1,7 +1,7 @@
 module Marketplace.Listing.Service where
 
 import DA.Finance.Types
-import DA.Set (Set, fromList)
+import DA.Set qualified as Set
 import Marketplace.Clearing.Market.Service qualified as Clearing
 import Marketplace.Trading.Error qualified as Error
 import Marketplace.Listing.Model ( ListingType(..), Listing(..), Status(..))
@@ -37,9 +37,9 @@ template Service
         do
           listingType <- case listingType of
             CollateralizedRequest -> return Collateralized
-            (ClearedRequest p)    -> Cleared p <$> (exerciseByKey @Clearing.Service (operator, p, customer) Clearing.ApproveClearedListing with observers = fromList observers; ..)
+            (ClearedRequest p)    -> Cleared p <$> (exerciseByKey @Clearing.Service (operator, p, customer) Clearing.ApproveClearedListing with observers = Set.fromList observers; ..)
 
-          create CreateListingRequest with status = Active; observers = fromList observers; ..
+          create CreateListingRequest with status = Active; observers = Set.fromList observers; ..
 
       nonconsuming RequestDisableListing : ContractId DisableListingRequest
         with
@@ -84,7 +84,9 @@ template Service
       with
         ctrl : Party
       controller ctrl
-      do pure ()
+      do
+        assertMsg ("only provider:" <> partyToText provider <> "or customer" <> partyToText customer <> "is allowed to terminate") (ctrl `Set.member` Set.fromList [provider, customer])
+        pure ()
 
 template Offer
   with
@@ -145,7 +147,7 @@ template CreateListingRequest
     minimumTradableQuantity : Decimal
     maximumTradableQuantity : Decimal
     status : Status
-    observers : Set Party
+    observers : Set.Set Party
   where
     signatory operator, provider, customer
 

--- a/daml/Marketplace/Trading/Otc/Service.daml
+++ b/daml/Marketplace/Trading/Otc/Service.daml
@@ -1,6 +1,7 @@
 module Marketplace.Trading.Otc.Service where
 
 import DA.Finance.Types (Asset)
+import DA.Set qualified as Set
 import Marketplace.Settlement.Hierarchical (SettlementMode)
 import Marketplace.Trading.Model (Side(..))
 import Marketplace.Trading.Otc.Model qualified as Trading
@@ -56,8 +57,10 @@ template Service
     choice Terminate : ()
       with
         ctrl : Party
-      controller ctrl
-      do pure ()
+      controller ctrl        
+      do
+        assertMsg ("only provider:" <> partyToText provider <> "or customer" <> partyToText customer <> "is allowed to terminate") (ctrl `Set.member` Set.fromList [provider, customer])
+        pure ()
 
 template Offer
   with

--- a/daml/Marketplace/Trading/Service.daml
+++ b/daml/Marketplace/Trading/Service.daml
@@ -183,7 +183,9 @@ template Service
       with
         ctrl : Party
       controller ctrl
-      do pure ()
+      do
+        assertMsg ("only provider:" <> partyToText provider <> "or customer" <> partyToText customer <> "is allowed to terminate") (ctrl `Set.member` Set.fromList [provider, customer])
+        pure ()
 
 template Offer
   with


### PR DESCRIPTION
This PR include below changes

1. use provider or customer as controllers for some Services' Terminate choice (see the list of Services in [FL-296](https://digitalasset.atlassian.net/browse/FL-296))
2. Remove 
       - RejectedMarginCalculation:RejectedMarginCalculation_Retry
       - RejectedMarkToMarketCalculation: RejectedMarkToMarketCalculation_Retry