### PR TITLE
FL-302: add prev business date in report details

### DIFF
--- a/daml/Marketplace/Reporting/Service.daml
+++ b/daml/Marketplace/Reporting/Service.daml
@@ -70,7 +70,7 @@ template Service
                 reportDetails = map (\(ReportDetailKey{..}, totalQuantityToday) -> 
                   let prevDayTotalQuantity : Optional Decimal = (fmap totalQuantity . find (\preDayDetail -> preDayDetail.assetId == assetId)) =<< prevDayReportDetailsOpt
                         in ReportDetail with totalQuantity = totalQuantityToday; ..) depositGroup
-              pure $ if isCashReporting then (refId, MT940 (createMT940Details account reportDetails today), messageType) else (refId, MT535 (createMT535Details account reportDetails today), messageType)
+              pure $ if isCashReporting then (refId, MT940 (createMT940Details account reportDetails today prevDate), messageType) else (refId, MT535 (createMT535Details account reportDetails today prevDate), messageType)
             
             groupSortOn f = (groupOn f . sortOn f)
             groupedDeposits = groupSortOn (\deposit -> (deposit.account.id, deposit.asset.id)) deposits

--- a/daml/SwiftMessage/Model/MT535.daml
+++ b/daml/SwiftMessage/Model/MT535.daml
@@ -8,7 +8,7 @@ data MT535Details = MT535Details with
     reportDetails: ReportDetails
   deriving (Eq, Show)
  
-createMT535Details : Account -> [ReportDetail] -> Date -> MT535Details
-createMT535Details safekeepingAccount reportDetails reportDate = 
+createMT535Details : Account -> [ReportDetail] -> Date -> Date -> MT535Details
+createMT535Details safekeepingAccount reportDetails reportDate prevBusinessDate = 
   MT535Details with reportDetails = ReportDetails with ..
   

--- a/daml/SwiftMessage/Model/MT940.daml
+++ b/daml/SwiftMessage/Model/MT940.daml
@@ -8,7 +8,7 @@ data MT940Details = MT940Details with
     reportDetails : ReportDetails
   deriving (Eq, Show)
 
-createMT940Details : Account -> [ReportDetail] -> Date -> MT940Details
-createMT940Details safekeepingAccount reportDetails reportDate = 
+createMT940Details : Account -> [ReportDetail] -> Date -> Date -> MT940Details
+createMT940Details safekeepingAccount reportDetails reportDate prevBusinessDate = 
   MT940Details with reportDetails = ReportDetails with ..
   

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -94,6 +94,7 @@ data ReportDetail = ReportDetail with
 data ReportDetails = ReportDetails with
     safekeepingAccount: Account
     reportDate: Date
+    prevBusinessDate: Date
     reportDetails: [ReportDetail]
   deriving (Eq, Show)
   


### PR DESCRIPTION
This PR adds T-1 business day into ReportDetails data record as we need this piece of data in MT940 message (cash reporting) as discussed in [FL-302](https://digitalasset.atlassian.net/browse/FL-302)