### PR TITLE
FL-326: initial draft for claim token

### DIFF
--- a/daml/ClaimToken/Model.daml
+++ b/daml/ClaimToken/Model.daml
@@ -1,7 +1,7 @@
 module ClaimToken.Model where
 
-import DA.Finance.Types
 import DA.Finance.Asset (AssetDeposit_Transfer(..), AssetDeposit)
+import DA.Finance.Types
 import DA.Set (Set)
 
 template ClaimToken -- claim token id -> bond id
@@ -36,7 +36,6 @@ template ClaimTokenR -- reverse search (bond id -> claim token id)
 
 template TransferRelationshipOffer
   with
-    asset: Asset
     operator: Party
     provider: Party
     sender: Party

--- a/daml/ClaimToken/Model.daml
+++ b/daml/ClaimToken/Model.daml
@@ -58,7 +58,7 @@ template TransferRelationship
   where
     signatory operator, provider, sender, receiver
 
-    choice TransferClaimToken: ContractId AssetDeposit
+    nonconsuming choice TransferClaimToken: ContractId AssetDeposit
       with 
         ctrl: Party
         assetDepositCid: ContractId AssetDeposit

--- a/daml/ClaimToken/Model.daml
+++ b/daml/ClaimToken/Model.daml
@@ -19,6 +19,11 @@ template ClaimToken -- claim token id -> bond id
     ensure 
       id.signatories == originalId.signatories
 
+    choice GetOriginalId: Id
+      with ctrl: Party
+      controller ctrl 
+      do pure $ originalId
+
 template ClaimTokenR -- reverse search (bond id -> claim token id)
   with
     id: Id
@@ -33,6 +38,11 @@ template ClaimTokenR -- reverse search (bond id -> claim token id)
 
     ensure 
       id.signatories == originalId.signatories
+    
+    choice GetClaimTokenId: Id
+      with ctrl: Party
+      controller ctrl
+      do pure $ id
 
 template TransferRelationshipOffer
   with
@@ -68,6 +78,7 @@ template TransferRelationship
           assertMsg "account provider does not match" (assetDeposit.account.provider == provider && receiverAccount.provider == provider)
           assertMsg "sender should match with account owner" (assetDeposit.account.owner == sender)
           exercise assetDepositCid AssetDeposit_Transfer with receiverAccount
+          
 
 
 

--- a/daml/ClaimToken/Model.daml
+++ b/daml/ClaimToken/Model.daml
@@ -1,0 +1,76 @@
+module ClaimToken.Model where
+
+import DA.Finance.Types
+import DA.Finance.Asset (AssetDeposit_Transfer(..), AssetDeposit)
+import DA.Set (Set)
+
+template ClaimToken -- claim token id -> bond id
+  with
+    id: Id
+    originalId: Id
+    observers: Set Party
+  where
+    signatory id.signatories
+    observer observers
+
+    key (id.signatories, id.label): (Set Party, Text)
+    maintainer key._1
+
+    ensure 
+      id.signatories == originalId.signatories
+
+template ClaimTokenR -- reverse search (bond id -> claim token id)
+  with
+    id: Id
+    originalId: Id
+    observers: Set Party
+  where
+    signatory id.signatories
+    observer observers
+
+    key (id.signatories, originalId.label): (Set Party, Text)
+    maintainer key._1
+
+    ensure 
+      id.signatories == originalId.signatories
+
+template TransferRelationshipOffer
+  with
+    asset: Asset
+    operator: Party
+    provider: Party
+    sender: Party
+    receiver: Party
+  where
+    signatory operator, provider, sender
+
+    controller receiver can
+      AcceptOffer: ContractId TransferRelationship
+        do 
+          create TransferRelationship with ..
+
+template TransferRelationship
+  with 
+    operator: Party
+    provider: Party
+    sender: Party
+    receiver: Party
+  where
+    signatory operator, provider, sender, receiver
+
+    choice TransferClaimToken: ContractId AssetDeposit
+      with 
+        ctrl: Party
+        assetDepositCid: ContractId AssetDeposit
+        receiverAccount: Account
+      controller ctrl 
+        do
+          assetDeposit <- fetch assetDepositCid
+          assertMsg "account provider does not match" (assetDeposit.account.provider == provider && receiverAccount.provider == provider)
+          assertMsg "sender should match with account owner" (assetDeposit.account.owner == sender)
+          exercise assetDepositCid AssetDeposit_Transfer with receiverAccount
+
+
+
+    
+

--- a/daml/ClaimToken/Model.daml
+++ b/daml/ClaimToken/Model.daml
@@ -69,10 +69,9 @@ template TransferRelationship
 
     nonconsuming choice TransferClaimToken: ContractId AssetDeposit
       with 
-        ctrl: Party
         assetDepositCid: ContractId AssetDeposit
         receiverAccount: Account
-      controller ctrl 
+      controller sender
         do
           assetDeposit <- fetch assetDepositCid
           assertMsg "account provider does not match" (assetDeposit.account.provider == provider && receiverAccount.provider == provider)

--- a/daml/ClaimToken/Service.daml
+++ b/daml/ClaimToken/Service.daml
@@ -24,8 +24,8 @@ template Service with
             archive assetDepositCid
             let 
               originalId = originalAssetDeposit.asset.id
-            (_, claimToken) <- fetchByKey @ClaimToken (originalId.signatories, originalId.label)
-            create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimToken.id)
+            (_, claimTokenR) <- fetchByKey @ClaimTokenR (originalId.signatories, originalId.label)
+            create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimTokenR.id)
 
       controller owner can 
         OfferTransferRelationship : ContractId TransferRelationshipOffer
@@ -45,8 +45,8 @@ template Service with
               (claimTokenAssetDeposit.account.owner == owner && claimTokenAssetDeposit.account.provider == provider) -- todo refactor
             let
               claimTokenId = claimTokenAssetDeposit.asset.id
-            (_, claimTokenR) <- fetchByKey @ClaimTokenR (claimTokenId.signatories, claimTokenId.label)
-            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = claimTokenR.originalId)
+            (_, claimToken) <- fetchByKey @ClaimToken (claimTokenId.signatories, claimTokenId.label)
+            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = claimToken.originalId)
 
             
 

--- a/daml/ClaimToken/Service.daml
+++ b/daml/ClaimToken/Service.daml
@@ -15,20 +15,27 @@ template Service with
 
       key (operator, provider, owner) : (Party, Party, Party)
       maintainer key._1
-    
+
+      let 
+        preProcessCheck : ContractId AssetDeposit -> Update AssetDeposit
+        preProcessCheck assetDepositCid = do
+          assertMsg "claim token service is not allowed at the moment, please inquire operator" isAllowed
+          
+          originalAssetDeposit <- fetch assetDepositCid
+          let currentAccount = originalAssetDeposit.account
+          assertMsg "provider and owner of provided assetDeposit does not match with current Service" (currentAccount.owner == owner && currentAccount.provider == provider)
+          pure originalAssetDeposit
+          
       controller owner can 
         nonconsuming Mint : ContractId AssetDeposit
           with 
             assetDepositCid : ContractId AssetDeposit
           do
-            assertMsg "claim token service is not allowed at the moment, please inquire operator" isAllowed
-            originalAssetDeposit <- fetch assetDepositCid
-            assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used"
-              (originalAssetDeposit.account.owner == owner && originalAssetDeposit.account.provider == provider) -- todo refactor
+            bondAssetDeposit <- preProcessCheck assetDepositCid
             archive assetDepositCid
-            let assetId = originalAssetDeposit.asset.id
+            let assetId = bondAssetDeposit.asset.id
             claimTokenId <- exerciseByKey @ClaimTokenR (assetId.signatories, assetId.label) GetClaimTokenId with ctrl = owner
-            create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimTokenId)
+            create bondAssetDeposit with asset = (bondAssetDeposit.asset with id = claimTokenId) -- bond -> claim token
 
       controller owner can 
         nonconsuming OfferTransferRelationship : ContractId TransferRelationshipOffer
@@ -42,14 +49,11 @@ template Service with
           with
             assetDepositCid : ContractId AssetDeposit
           do
-            assertMsg "claim token service is not allowed at the moment, please inquire operator" isAllowed 
-            claimTokenAssetDeposit <- fetch assetDepositCid
+            claimTokenAssetDeposit <- preProcessCheck assetDepositCid
             archive assetDepositCid
-            assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used" 
-              (claimTokenAssetDeposit.account.owner == owner && claimTokenAssetDeposit.account.provider == provider) -- todo refactor
             let assetId = claimTokenAssetDeposit.asset.id
             originalId <- exerciseByKey @ClaimToken (assetId.signatories, assetId.label) GetOriginalId with ctrl = owner
-            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = originalId)
+            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = originalId) -- claim token -> bond
       
       controller operator can
         AllowService: ContractId Service

--- a/daml/ClaimToken/Service.daml
+++ b/daml/ClaimToken/Service.daml
@@ -1,8 +1,7 @@
 module ClaimToken.Service where
 
-import DA.Finance.Asset
-import DA.Finance.Types
 import ClaimToken.Model
+import DA.Finance.Asset
 
 template Service with
   operator: Party
@@ -12,42 +11,54 @@ template Service with
     where
       signatory operator, provider
       observer owner
+
+      key (operator, provider, owner) : (Party, Party, Party)
+      maintainer key._1
     
       controller owner can 
-        nonconsuming Mint: ContractId AssetDeposit
+        nonconsuming Mint : ContractId AssetDeposit
           with 
             assetDepositCid : ContractId AssetDeposit
+            claimTokenR : ClaimTokenR 
           do
             originalAssetDeposit <- fetch assetDepositCid
-            assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used" 
+            assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used"
               (originalAssetDeposit.account.owner == owner && originalAssetDeposit.account.provider == provider) -- todo refactor
             archive assetDepositCid
-            let 
-              originalId = originalAssetDeposit.asset.id
-            (_, claimTokenR) <- fetchByKey @ClaimTokenR (originalId.signatories, originalId.label)
             create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimTokenR.id)
 
       controller owner can 
         nonconsuming OfferTransferRelationship : ContractId TransferRelationshipOffer
           with 
-            asset: Asset
             receiver: Party
           do
             create TransferRelationshipOffer with sender = owner; ..
 
       controller owner can
-        nonconsuming Burn: ContractId AssetDeposit
+        nonconsuming Burn : ContractId AssetDeposit
           with
             assetDepositCid : ContractId AssetDeposit
+            claimToken : ClaimToken
           do 
             claimTokenAssetDeposit <- fetch assetDepositCid
+            archive assetDepositCid
             assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used" 
               (claimTokenAssetDeposit.account.owner == owner && claimTokenAssetDeposit.account.provider == provider) -- todo refactor
-            let
-              claimTokenId = claimTokenAssetDeposit.asset.id
-            (_, claimToken) <- fetchByKey @ClaimToken (claimTokenId.signatories, claimTokenId.label)
             create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = claimToken.originalId)
 
+template Request 
+  with
+    operator : Party
+    provider : Party
+    owner : Party
+
+  where 
+    signatory operator
+  
+    controller provider can 
+      Approve : ContractId Service
+        do
+          create Service with ..
             
 
 

--- a/daml/ClaimToken/Service.daml
+++ b/daml/ClaimToken/Service.daml
@@ -14,7 +14,7 @@ template Service with
       observer owner
     
       controller owner can 
-        Mint: ContractId AssetDeposit
+        nonconsuming Mint: ContractId AssetDeposit
           with 
             assetDepositCid : ContractId AssetDeposit
           do
@@ -28,7 +28,7 @@ template Service with
             create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimTokenR.id)
 
       controller owner can 
-        OfferTransferRelationship : ContractId TransferRelationshipOffer
+        nonconsuming OfferTransferRelationship : ContractId TransferRelationshipOffer
           with 
             asset: Asset
             receiver: Party
@@ -36,7 +36,7 @@ template Service with
             create TransferRelationshipOffer with sender = owner; ..
 
       controller owner can
-        Burn: ContractId AssetDeposit
+        nonconsuming Burn: ContractId AssetDeposit
           with
             assetDepositCid : ContractId AssetDeposit
           do 

--- a/daml/ClaimToken/Service.daml
+++ b/daml/ClaimToken/Service.daml
@@ -7,6 +7,7 @@ template Service with
   operator: Party
   provider: Party
   owner: Party
+  isAllowed: Bool
 
     where
       signatory operator, provider
@@ -19,13 +20,15 @@ template Service with
         nonconsuming Mint : ContractId AssetDeposit
           with 
             assetDepositCid : ContractId AssetDeposit
-            claimTokenR : ClaimTokenR 
           do
+            assertMsg "claim token service is not allowed at the moment, please inquire operator" isAllowed
             originalAssetDeposit <- fetch assetDepositCid
             assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used"
               (originalAssetDeposit.account.owner == owner && originalAssetDeposit.account.provider == provider) -- todo refactor
             archive assetDepositCid
-            create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimTokenR.id)
+            let assetId = originalAssetDeposit.asset.id
+            claimTokenId <- exerciseByKey @ClaimTokenR (assetId.signatories, assetId.label) GetClaimTokenId with ctrl = owner
+            create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimTokenId)
 
       controller owner can 
         nonconsuming OfferTransferRelationship : ContractId TransferRelationshipOffer
@@ -38,19 +41,31 @@ template Service with
         nonconsuming Burn : ContractId AssetDeposit
           with
             assetDepositCid : ContractId AssetDeposit
-            claimToken : ClaimToken
-          do 
+          do
+            assertMsg "claim token service is not allowed at the moment, please inquire operator" isAllowed 
             claimTokenAssetDeposit <- fetch assetDepositCid
             archive assetDepositCid
             assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used" 
               (claimTokenAssetDeposit.account.owner == owner && claimTokenAssetDeposit.account.provider == provider) -- todo refactor
-            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = claimToken.originalId)
+            let assetId = claimTokenAssetDeposit.asset.id
+            originalId <- exerciseByKey @ClaimToken (assetId.signatories, assetId.label) GetOriginalId with ctrl = owner
+            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = originalId)
+      
+      controller operator can
+        AllowService: ContractId Service
+          do
+            create this with isAllowed = True
+        
+      controller operator can
+        BanService: ContractId Service
+          do
+            create this with isAllowed = False
 
 template Request 
   with
-    operator : Party
-    provider : Party
-    owner : Party
+    operator: Party
+    provider: Party
+    owner: Party
 
   where 
     signatory operator
@@ -58,7 +73,7 @@ template Request
     controller provider can 
       Approve : ContractId Service
         do
-          create Service with ..
+          create Service with isAllowed = True; ..
             
 
 

--- a/daml/ClaimToken/Service.daml
+++ b/daml/ClaimToken/Service.daml
@@ -1,0 +1,54 @@
+module ClaimToken.Service where
+
+import DA.Finance.Asset
+import DA.Finance.Types
+import ClaimToken.Model
+
+template Service with
+  operator: Party
+  provider: Party
+  owner: Party
+
+    where
+      signatory operator, provider
+      observer owner
+    
+      controller owner can 
+        Mint: ContractId AssetDeposit
+          with 
+            assetDepositCid : ContractId AssetDeposit
+          do
+            originalAssetDeposit <- fetch assetDepositCid
+            assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used" 
+              (originalAssetDeposit.account.owner == owner && originalAssetDeposit.account.provider == provider) -- todo refactor
+            archive assetDepositCid
+            let 
+              originalId = originalAssetDeposit.asset.id
+            (_, claimToken) <- fetchByKey @ClaimToken (originalId.signatories, originalId.label)
+            create originalAssetDeposit with asset = (originalAssetDeposit.asset with id = claimToken.id)
+
+      controller owner can 
+        OfferTransferRelationship : ContractId TransferRelationshipOffer
+          with 
+            asset: Asset
+            receiver: Party
+          do
+            create TransferRelationshipOffer with sender = owner; ..
+
+      controller owner can
+        Burn: ContractId AssetDeposit
+          with
+            assetDepositCid : ContractId AssetDeposit
+          do 
+            claimTokenAssetDeposit <- fetch assetDepositCid
+            assertMsg "provider and owner of provided assetDeposit does not match with the Service Contract used" 
+              (claimTokenAssetDeposit.account.owner == owner && claimTokenAssetDeposit.account.provider == provider) -- todo refactor
+            let
+              claimTokenId = claimTokenAssetDeposit.asset.id
+            (_, claimTokenR) <- fetchByKey @ClaimTokenR (claimTokenId.signatories, claimTokenId.label)
+            create claimTokenAssetDeposit with asset = (claimTokenAssetDeposit.asset with id = claimTokenR.originalId)
+
+            
+
+
+    

--- a/daml/Marketplace/Issuance/Instrument/Model.daml
+++ b/daml/Marketplace/Issuance/Instrument/Model.daml
@@ -48,6 +48,7 @@ template Bond
     isPricedDirty : Bool
     isCallable : Bool
     observers : [Party]
+    claimTokenId : Text
   where
     signatory id.signatories
     observer observers

--- a/daml/Marketplace/Issuance/Instrument/Model.daml
+++ b/daml/Marketplace/Issuance/Instrument/Model.daml
@@ -48,7 +48,7 @@ template Bond
     isPricedDirty : Bool
     isCallable : Bool
     observers : [Party]
-    claimTokenId : Text
+    claimTokenId : Optional Text -- None: does not support claim token, Some (claim token id): claim token id that current bond links to
   where
     signatory id.signatories
     observer observers

--- a/daml/Marketplace/Issuance/Instrument/Service.daml
+++ b/daml/Marketplace/Issuance/Instrument/Service.daml
@@ -2,6 +2,7 @@ module Marketplace.Issuance.Instrument.Service where
 
 import ClaimToken.Model
 import ContingentClaims.Claim.Serializable (Claim(And, Give))
+import DA.Optional (whenSome)
 import DA.Set (fromList)
 import Marketplace.Issuance.CFI (CFI(..))
 import Marketplace.Issuance.Service qualified as Issuance
@@ -29,8 +30,10 @@ template Service
           let cfi = CFI with code = "DBXXXX"
           claims <- getClaims operator provider bond.stream bond.currencyId bond.maturityDate True
           bondCid <- create bond
-          create ClaimToken with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList observers
-          create ClaimTokenR with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList observers
+          whenSome bond.claimTokenId (\claimTokenId -> do 
+                                  create ClaimToken with id = (bond.id with label = claimTokenId); originalId = bond.id; observers = fromList observers
+                                  create ClaimTokenR with id = (bond.id with label = claimTokenId); originalId = bond.id; observers = fromList observers
+                                  pure ())
           assetCid <- exerciseByKey @Issuance.Service (operator, provider, customer) Issuance.RequestOrigination with assetLabel = bond.id.label; cfi; description = bond.id.label; claims; observers = observers
           pure (assetCid, bondCid)
 

--- a/daml/Marketplace/Issuance/Instrument/Service.daml
+++ b/daml/Marketplace/Issuance/Instrument/Service.daml
@@ -1,6 +1,8 @@
 module Marketplace.Issuance.Instrument.Service where
 
+import ClaimToken.Model
 import ContingentClaims.Claim.Serializable (Claim(And, Give))
+import DA.Set (fromList)
 import Marketplace.Issuance.CFI (CFI(..))
 import Marketplace.Issuance.Service qualified as Issuance
 import Marketplace.Issuance.Instrument.Model (getClaims, Bond(..), Swap(..))
@@ -27,6 +29,8 @@ template Service
           let cfi = CFI with code = "DBXXXX"
           claims <- getClaims operator provider bond.stream bond.currencyId bond.maturityDate True
           bondCid <- create bond
+          create ClaimToken with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList [operator]
+          create ClaimTokenR with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList [operator]
           assetCid <- exerciseByKey @Issuance.Service (operator, provider, customer) Issuance.RequestOrigination with assetLabel = bond.id.label; cfi; description = bond.id.label; claims; observers = observers
           pure (assetCid, bondCid)
 

--- a/daml/Marketplace/Issuance/Instrument/Service.daml
+++ b/daml/Marketplace/Issuance/Instrument/Service.daml
@@ -1,10 +1,11 @@
 module Marketplace.Issuance.Instrument.Service where
 
 import ClaimToken.Model
-import ContingentClaims.Claim.Serializable (Claim(And, Give))
+import ContingentClaims.Claim.Serializable (Claim(And, Give, Zero))
 import DA.Optional (whenSome)
-import DA.Set (fromList)
-import Marketplace.Issuance.CFI (CFI(..))
+import DA.Set (empty, fromList)
+import Marketplace.Issuance.AssetDescription
+import Marketplace.Issuance.CFI qualified as CFI
 import Marketplace.Issuance.Service qualified as Issuance
 import Marketplace.Issuance.Instrument.Model (getClaims, Bond(..), Swap(..))
 
@@ -27,12 +28,15 @@ template Service
           bond : Bond
           observers : [Party]
         do
-          let cfi = CFI with code = "DBXXXX"
+          let cfi = CFI.bond
           claims <- getClaims operator provider bond.stream bond.currencyId bond.maturityDate True
           bondCid <- create bond
           whenSome bond.claimTokenId (\claimTokenId -> do 
-                                  create ClaimToken with id = (bond.id with label = claimTokenId); originalId = bond.id; observers = fromList observers
-                                  create ClaimTokenR with id = (bond.id with label = claimTokenId); originalId = bond.id; observers = fromList observers
+                                  let id = (bond.id with label = claimTokenId)
+                                  create ClaimToken with id; originalId = bond.id; observers = fromList observers
+                                  create ClaimTokenR with id; originalId = bond.id; observers = fromList observers
+                                  -- create dummy asset description for claim token
+                                  create AssetDescription with assetId = id; description = "claim-token-" <> bond.id.label; cfi = CFI.other; issuer = customer; claims = Zero; registrar = provider; observers = empty
                                   pure ())
           assetCid <- exerciseByKey @Issuance.Service (operator, provider, customer) Issuance.RequestOrigination with assetLabel = bond.id.label; cfi; description = bond.id.label; claims; observers = observers
           pure (assetCid, bondCid)
@@ -42,7 +46,7 @@ template Service
           swap : Swap
           observers : [Party]
         do
-          let cfi = CFI with code = "SRXXXX"
+          let cfi = CFI.CFI with code = "SRXXXX"
           pay <- getClaims operator provider (Some swap.pay) swap.payCurrencyId swap.maturityDate False
           receive <- getClaims operator provider (Some swap.receive) swap.receiveCurrencyId swap.maturityDate False
           let claims = And [ Give pay, receive ]

--- a/daml/Marketplace/Issuance/Instrument/Service.daml
+++ b/daml/Marketplace/Issuance/Instrument/Service.daml
@@ -29,8 +29,8 @@ template Service
           let cfi = CFI with code = "DBXXXX"
           claims <- getClaims operator provider bond.stream bond.currencyId bond.maturityDate True
           bondCid <- create bond
-          create ClaimToken with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList [operator]
-          create ClaimTokenR with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList [operator]
+          create ClaimToken with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList observers
+          create ClaimTokenR with id = (bond.id with label = bond.claimTokenId); originalId = bond.id; observers = fromList observers
           assetCid <- exerciseByKey @Issuance.Service (operator, provider, customer) Issuance.RequestOrigination with assetLabel = bond.id.label; cfi; description = bond.id.label; claims; observers = observers
           pure (assetCid, bondCid)
 

--- a/daml/Marketplace/Settlement/Hierarchical/Util.daml
+++ b/daml/Marketplace/Settlement/Hierarchical/Util.daml
@@ -26,22 +26,26 @@ createInstructions isCash operator agent rootProvider senderAccount receiverAcco
   else if senderAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
     let providerAccount = getAccount isCash providerSettlementInfo receiverAccount.owner
-    sis1 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+        assetSi = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount assetSi instructionIdx
     sis2 <- createInstructions isCash operator agent rootProvider senderAccount providerAccount settlementId (instructionIdx + 1) asset
     pure $ sis1 <> sis2
   else if receiverAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
     let providerAccount = getAccount isCash providerSettlementInfo senderAccount.owner
-    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+        assetSi = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) assetSi instructionIdx
     sis2 <- createInstructions isCash operator agent rootProvider providerAccount receiverAccount settlementId (instructionIdx + 1) asset
     pure $ sis1 <> sis2
   else do
     (_, senderProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
     let senderProviderAccount = getAccount isCash senderProviderSettlementInfo senderAccount.owner
-    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) instructionIdx
+        assetSi = if isCash then (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) else asset
+    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) assetSi instructionIdx
     (_, receiverProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
     let receiverProviderAccount = getAccount isCash receiverProviderSettlementInfo receiverAccount.owner
-    sis2 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) (instructionIdx + 1)
+        assetSi = if isCash then (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) else asset
+    sis2 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount assetSi (instructionIdx + 1)
     sis3 <- createInstructions isCash operator agent rootProvider senderProviderAccount receiverProviderAccount settlementId (instructionIdx + 2) asset
     pure $ sis1 <> sis2 <> sis3
 

--- a/daml/Marketplace/Settlement/Htlc/Util.daml
+++ b/daml/Marketplace/Settlement/Htlc/Util.daml
@@ -22,22 +22,26 @@ createInstructionsHtlc isCash operator rootProvider senderAgent senderAccount re
   else if senderAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
     let providerAccount = getAccount isCash providerSettlementInfo receiverAccount.owner
-    sis1 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+        assetSi = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount assetSi instructionIdx
     sis2 <- createInstructionsHtlc isCash operator rootProvider senderAgent senderAccount receiverAgent providerAccount settlementId (instructionIdx + 1) asset hashlock expiry
     pure $ sis1 <> sis2
   else if receiverAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
     let providerAccount = getAccount isCash providerSettlementInfo senderAccount.owner
-    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+        assetSi = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) assetSi instructionIdx
     sis2 <- createInstructionsHtlc isCash operator rootProvider senderAgent providerAccount receiverAgent receiverAccount settlementId (instructionIdx + 1) asset hashlock expiry
     pure $ sis1 <> sis2
   else do
     (_, senderProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
     let senderProviderAccount = getAccount isCash senderProviderSettlementInfo senderAccount.owner
-    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) instructionIdx
+        assetSi = if isCash then (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) else asset
+    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) assetSi instructionIdx
     (_, receiverProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
     let receiverProviderAccount = getAccount isCash receiverProviderSettlementInfo receiverAccount.owner
-    sis2 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) (instructionIdx + 1)
+        assetSi = if isCash then (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) else asset
+    sis2 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount assetSi (instructionIdx + 1)
     sis3 <- createInstructionsHtlc isCash operator rootProvider senderAgent senderProviderAccount receiverAgent receiverProviderAccount settlementId (instructionIdx + 2) asset hashlock expiry
     pure $ sis1 <> sis2 <> sis3
 

--- a/daml/Tests/Distribution/Syndication/ClaimToken.daml
+++ b/daml/Tests/Distribution/Syndication/ClaimToken.daml
@@ -1,15 +1,15 @@
 module Tests.Distribution.Syndication.ClaimToken where
 
-import ClaimToken.Service qualified as ClaimToken
 import ClaimToken.Model qualified as ClaimToken
+import ClaimToken.Service qualified as ClaimToken
 import DA.Finance.Asset(AssetDeposit)
 import DA.List (head)
 import Daml.Script
 import Marketplace.Custody.Model qualified as Custody
 import Marketplace.Settlement.Hierarchical.Util (getAccount)
-import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 import Tests.Distribution.Syndication.Issuance (issuance)
 import Tests.Distribution.Syndication.Origination (origination, Origination(..))
+import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 
 
 

--- a/daml/Tests/Distribution/Syndication/ClaimToken.daml
+++ b/daml/Tests/Distribution/Syndication/ClaimToken.daml
@@ -43,7 +43,7 @@ claimTokenTest = do
   transferRelationshipCid <- submit investor4 do exerciseCmd transferRelationshipOfferCid ClaimToken.AcceptOffer
   Some (_, settlementInfoReceiver) <- queryContractKey @Custody.SettlementInfo operator (operator, investor4)
   let receiverAccount = getAccount False settlementInfoReceiver investor4
-  claimTokenAssetDepositCid <- submit investor3 do exerciseCmd transferRelationshipCid ClaimToken.TransferClaimToken with ctrl = investor3; receiverAccount; assetDepositCid = claimTokenAssetDepositCid
+  claimTokenAssetDepositCid <- submit investor3 do exerciseCmd transferRelationshipCid ClaimToken.TransferClaimToken with receiverAccount; assetDepositCid = claimTokenAssetDepositCid
 
   -- burn
   Some assetDeposit <- queryContractId @AssetDeposit investor4 claimTokenAssetDepositCid

--- a/daml/Tests/Distribution/Syndication/ClaimToken.daml
+++ b/daml/Tests/Distribution/Syndication/ClaimToken.daml
@@ -36,8 +36,7 @@ claimTokenTest = do
   -- mint
   (assetDepositCid, assetDeposit) <- head <$> query @AssetDeposit investor3
   let assetId = assetDeposit.asset.id
-  Some (_, claimTokenR) <- queryContractKey @ClaimToken.ClaimTokenR operator (assetId.signatories, assetId.label)
-  claimTokenAssetDepositCid <- submit investor3 do exerciseCmd serviceId ClaimToken.Mint with assetDepositCid; claimTokenR
+  claimTokenAssetDepositCid <- submitMulti [investor3] [public] do exerciseCmd serviceId ClaimToken.Mint with assetDepositCid
   
   -- transfer
   transferRelationshipOfferCid <- submit investor3 do exerciseCmd serviceId ClaimToken.OfferTransferRelationship with receiver = investor4
@@ -50,5 +49,5 @@ claimTokenTest = do
   Some assetDeposit <- queryContractId @AssetDeposit investor4 claimTokenAssetDepositCid
   let assetId = assetDeposit.asset.id
   Some (_, claimToken) <- queryContractKey @ClaimToken.ClaimToken operator (assetId.signatories, assetId.label)
-  submit investor4 do exerciseCmd serviceId2 ClaimToken.Burn with assetDepositCid = claimTokenAssetDepositCid; claimToken
+  submitMulti [investor4] [public] do exerciseCmd serviceId2 ClaimToken.Burn with assetDepositCid = claimTokenAssetDepositCid
   pure ()

--- a/daml/Tests/Distribution/Syndication/ClaimToken.daml
+++ b/daml/Tests/Distribution/Syndication/ClaimToken.daml
@@ -1,0 +1,54 @@
+module Tests.Distribution.Syndication.ClaimToken where
+
+import ClaimToken.Service qualified as ClaimToken
+import ClaimToken.Model qualified as ClaimToken
+import DA.Finance.Asset(AssetDeposit)
+import DA.List (head)
+import Daml.Script
+import Marketplace.Custody.Model qualified as Custody
+import Marketplace.Settlement.Hierarchical.Util (getAccount)
+import Tests.Distribution.Syndication.Setup (setup, Parties(..))
+import Tests.Distribution.Syndication.Issuance (issuance)
+import Tests.Distribution.Syndication.Origination (origination, Origination(..))
+
+
+
+init : Script (Parties, Origination)
+init = do
+  parties@Parties{..} <- setup
+  orig <- origination parties
+  issuance parties orig
+  
+  requestCid1 <- submit operator do createCmd ClaimToken.Request with operator; provider = custodian5; owner = investor3
+  requestCid2 <- submit operator do createCmd ClaimToken.Request with operator; provider = custodian5; owner = investor4
+  submit custodian5 do exerciseCmd requestCid1 ClaimToken.Approve
+  submit custodian5 do exerciseCmd requestCid2 ClaimToken.Approve
+
+  pure (parties, orig)
+
+
+claimTokenTest : Script ()
+claimTokenTest = do
+  (Parties{..}, Origination{..}) <- init
+  Some (serviceId, _) <- queryContractKey @ClaimToken.Service operator (operator, custodian5, investor3)
+  Some (serviceId2, _) <- queryContractKey @ClaimToken.Service operator (operator, custodian5, investor4)
+  
+  -- mint
+  (assetDepositCid, assetDeposit) <- head <$> query @AssetDeposit investor3
+  let assetId = assetDeposit.asset.id
+  Some (_, claimTokenR) <- queryContractKey @ClaimToken.ClaimTokenR operator (assetId.signatories, assetId.label)
+  claimTokenAssetDepositCid <- submit investor3 do exerciseCmd serviceId ClaimToken.Mint with assetDepositCid; claimTokenR
+  
+  -- transfer
+  transferRelationshipOfferCid <- submit investor3 do exerciseCmd serviceId ClaimToken.OfferTransferRelationship with receiver = investor4
+  transferRelationshipCid <- submit investor4 do exerciseCmd transferRelationshipOfferCid ClaimToken.AcceptOffer
+  Some (_, settlementInfoReceiver) <- queryContractKey @Custody.SettlementInfo operator (operator, investor4)
+  let receiverAccount = getAccount False settlementInfoReceiver investor4
+  claimTokenAssetDepositCid <- submit investor3 do exerciseCmd transferRelationshipCid ClaimToken.TransferClaimToken with ctrl = investor3; receiverAccount; assetDepositCid = claimTokenAssetDepositCid
+
+  -- burn
+  Some assetDeposit <- queryContractId @AssetDeposit investor4 claimTokenAssetDepositCid
+  let assetId = assetDeposit.asset.id
+  Some (_, claimToken) <- queryContractKey @ClaimToken.ClaimToken operator (assetId.signatories, assetId.label)
+  submit investor4 do exerciseCmd serviceId2 ClaimToken.Burn with assetDepositCid = claimTokenAssetDepositCid; claimToken
+  pure ()

--- a/daml/Tests/Distribution/Syndication/Hedging.daml
+++ b/daml/Tests/Distribution/Syndication/Hedging.daml
@@ -5,7 +5,6 @@ import DA.Assert ((===))
 import DA.Date (date, Month(..))
 import DA.Finance.Asset (AssetDeposit)
 import DA.Foldable (forA_)
-import DA.Set (singleton)
 import Marketplace.Lifecycle.Model qualified as Lifecycle
 import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 import Tests.Distribution.Syndication.Lifecycle (lifecycleAssets)
@@ -19,9 +18,9 @@ test = do
 
   deposit operator cashProvider  issuer     107_000_000.0 usd.assetId
   depositToAccount operator bondRegistrar custodian1 "Segregated-Investor1@Custodian1@BondRegistrar" 100_000_000.0 bond3.id
-  deposit operator custodian1    investor1  100_000_000.0 (bond3.id with signatories = singleton custodian1)
+  deposit operator custodian1    investor1  100_000_000.0 bond3.id
   depositToAccount operator bondRegistrar custodian1 "Segregated-Investor1@Custodian1@BondRegistrar" 100_000_000.0 swap1.id
-  deposit operator custodian1    investor1  100_000_000.0 (swap1.id with signatories = singleton custodian1)
+  deposit operator custodian1    investor1  100_000_000.0 swap1.id
 
   submitMulti [operator, payingAgent] [] do createCmd Lifecycle.Today with operator; provider = payingAgent; date = date 2021 Jan 15
   submitMulti [operator, payingAgent] [] do createCmd Lifecycle.Observation with operator; provider = payingAgent; label = libor6m.label; date = date 2022 Jun 21; value = 0.003

--- a/daml/Tests/Distribution/Syndication/Issuance.daml
+++ b/daml/Tests/Distribution/Syndication/Issuance.daml
@@ -133,7 +133,7 @@ issuance Parties{..} Origination{..} = do
   settleTrades bondRegistrar [ dvpCid21, dvpCid22 ]
   settleTradeHtlc bndBank (secret, dvpCid23)
 
-  -- -- -- Step 3
+  -- Step 3
   dvpCids31 <- submit operator do exerciseCmd tranche1Cid Structuring.InstructInvestorSettlement with confirmationCids = confirmationCids1; price; dateOfSettlement; dateOfTrade
   dvpCids32 <- submit operator do exerciseCmd tranche2Cid Structuring.InstructInvestorSettlement with confirmationCids = confirmationCids2; price; dateOfSettlement; dateOfTrade
   dvpCids33 <- submit operator do exerciseCmd tranche3Cid Structuring.InstructInvestorSettlementHtlc with confirmationCids = confirmationCids3; price; dateOfSettlement; dateOfTrade; expiry

--- a/daml/Tests/Distribution/Syndication/Origination.daml
+++ b/daml/Tests/Distribution/Syndication/Origination.daml
@@ -59,9 +59,9 @@ origination Parties{..} = do
     swapRecAmount = Instrument.Fixed with annualRate = 0.01
     swapPay = Instrument.InterestStream with schedule = swapPaySched; amount = swapPayAmount
     swapRec = Instrument.InterestStream with schedule = swapRecSched; amount = swapRecAmount
-    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator] "claim-token-BOND1"
-    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator] "claim-token-BOND2"
-    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator] "claim-token-BOND3"
+    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator] $ Some "claim-token-BOND1"
+    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator] $ Some "claim-token-BOND2"
+    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator] $ Some "claim-token-BOND3"
     swap1 = createSwap              swap1Id usd.assetId usd.assetId issuer swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
 
   calendarCid <- submitMulti [operator, bondRegistrar] [] do createCmd HolidayCalendar with operator; provider = bondRegistrar; calendar = fedCalendar; observers = fromList [issuer, public]

--- a/daml/Tests/Distribution/Syndication/Origination.daml
+++ b/daml/Tests/Distribution/Syndication/Origination.daml
@@ -59,9 +59,9 @@ origination Parties{..} = do
     swapRecAmount = Instrument.Fixed with annualRate = 0.01
     swapPay = Instrument.InterestStream with schedule = swapPaySched; amount = swapPayAmount
     swapRec = Instrument.InterestStream with schedule = swapRecSched; amount = swapRecAmount
-    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator]
-    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator]
-    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator]
+    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator] "claim-token-BOND1"
+    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator] "claim-token-BOND2"
+    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator] "claim-token-BOND3"
     swap1 = createSwap              swap1Id usd.assetId usd.assetId issuer swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
 
   calendarCid <- submitMulti [operator, bondRegistrar] [] do createCmd HolidayCalendar with operator; provider = bondRegistrar; calendar = fedCalendar; observers = fromList [issuer, public]

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -150,21 +150,21 @@ createSchedule : Date -> Date -> PeriodEnum -> Int -> [Text] -> BusinessDayConve
 createSchedule startDate endDate period periodMultiplier calendarIds businessDayConvention dayCountConvention rollConvention =
   Instrument.InterestSchedule with ..
 
-createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Text -> Instrument.Bond
+createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Optional Text -> Instrument.Bond
 createFixedRateBond id isin currencyId issuer issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable observers claimTokenId =
   let
     amount = Instrument.Fixed with annualRate
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Text -> Instrument.Bond
+createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Optional Text -> Instrument.Bond
 createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable observers claimTokenId =
   let
     amount = Instrument.Float with rateId; periodSpread
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Text -> Instrument.Bond
+createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Optional Text -> Instrument.Bond
 createZeroCouponBond id isin currencyId issuer issueDate maturityDate isTradeable isPricedDirty isCallable observers claimTokenId =
   Instrument.Bond with stream = None; ..
 

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -150,22 +150,22 @@ createSchedule : Date -> Date -> PeriodEnum -> Int -> [Text] -> BusinessDayConve
 createSchedule startDate endDate period periodMultiplier calendarIds businessDayConvention dayCountConvention rollConvention =
   Instrument.InterestSchedule with ..
 
-createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFixedRateBond id isin currencyId issuer issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable observers =
+createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Text -> Instrument.Bond
+createFixedRateBond id isin currencyId issuer issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable observers claimTokenId =
   let
     amount = Instrument.Fixed with annualRate
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable observers =
+createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Text -> Instrument.Bond
+createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable observers claimTokenId =
   let
     amount = Instrument.Float with rateId; periodSpread
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createZeroCouponBond id isin currencyId issuer issueDate maturityDate isTradeable isPricedDirty isCallable observers =
+createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Text -> Instrument.Bond
+createZeroCouponBond id isin currencyId issuer issueDate maturityDate isTradeable isPricedDirty isCallable observers claimTokenId =
   Instrument.Bond with stream = None; ..
 
 createSwap : Id -> Id -> Id -> Party -> Date -> Date -> Instrument.InterestStream -> Instrument.InterestStream -> Bool -> [Party] -> Instrument.Swap


### PR DESCRIPTION
Note that this PR serves that purpose of initial design checkpoint and will not and should not be merged into syndication-dev branch.

@georg-da I assume that the whole flow will be

1. during bond origination ClaimToken and ClaimTokenR contracts are created
2. during bond life-cycling, we will not only need to pass in AssetDeposits for specified bonds but also for corresponding claim token
3. We are not handling custodian settlement chain in TransferClaimToken (we assume that the sender and receiver accounts are provided by the same provider