### PR TITLE
Feature/fl 334 create mt 548 and integrate to issuance flow and otc trading flow

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -24,7 +24,7 @@ sandbox-options:
   - --wall-clock-time
   - --ledgerid=da-marketplace-sandbox
 scenario-service:
-  grpc-max-message-size: 134217728
+  grpc-max-message-size: 6000000
 codegen:
   js:
     output-directory: daml.js

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -121,7 +121,11 @@ template Tranche
     let
       createNewSettlementMessage: Text -> SwiftMessage -> SwiftMessageType -> Update (ContractId SwiftOutboundMessage)
       createNewSettlementMessage referenceId swiftMessage swiftMessageType =
-        create SwiftOutboundMessage with provider = operator; consumer = operator; status = Pending; observers = fromList [bondRegistrar]; ..
+        let status = case swiftMessageType of
+                      MT548_buy_t -> Finalized
+                      MT548_sell_t -> Finalized
+                      _ -> Pending in
+        create SwiftOutboundMessage with provider = operator; consumer = operator; status; observers = fromList [bondRegistrar]; ..
 
       sendSwiftMessage : Party -> Party -> Decimal -> Decimal -> Id -> Text -> Date -> Date -> Date -> SettlementMode -> Update ()
       sendSwiftMessage seller buyer settledQty settledAmount settledCurrency settlementId dateOfTrade dateOfSettlement effDateOfSettlement settlementMode = do

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -137,7 +137,7 @@ template Tranche
           instrumentId = bond.isin <> "-" <> deliveryId.label
           buyerSafekeepingAcc = getAccount False receiverSettlementInfo buyer
           sellerSafekeepingAcc = getAccount False sellerSettlementInfo seller
-          settlementAdvice = SettlementAdvice with receivingAgent = buyerSafekeepingAcc.provider; deliveringAgent = sellerSafekeepingAcc.provider; ..
+          settlementStatusAndProcessingAdvice = SettlementStatusAndProcessingAdvice with receivingAgent = buyerSafekeepingAcc.provider; deliveringAgent = sellerSafekeepingAcc.provider; ..
         if settlementMode == Dvp then do
           let
             mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider sellerSafekeepingAcc.provider seller buyer
@@ -150,8 +150,8 @@ template Tranche
                     dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
                     
-            mt548_buy = createMT548Details settlementAdvice RECE APMT  
-            mt548_sell = createMT548Details settlementAdvice DELI APMT
+            mt548_buy = createMT548Details settlementStatusAndProcessingAdvice RECE APMT  
+            mt548_sell = createMT548Details settlementStatusAndProcessingAdvice DELI APMT
           
           createNewSettlementMessage settlementId (MT545 mt545) MT545_t
           createNewSettlementMessage settlementId (MT547 mt547) MT547_t
@@ -168,8 +168,8 @@ template Tranche
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
             
             paymentMode = if settlementMode == Fop then FREE else APMT
-            mt548_buy = createMT548Details settlementAdvice RECE paymentMode
-            mt548_sell = createMT548Details settlementAdvice DELI paymentMode
+            mt548_buy = createMT548Details settlementStatusAndProcessingAdvice RECE paymentMode
+            mt548_sell = createMT548Details settlementStatusAndProcessingAdvice DELI paymentMode
           when (settlementMode == Fop) do
             createNewSettlementMessage settlementId (MT544 mt544) MT544_t
             createNewSettlementMessage settlementId (MT546 mt546) MT546_t

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -10,11 +10,12 @@ import Marketplace.Settlement.Hierarchical.Dvp qualified as Hierarchical
 import Marketplace.Settlement.Htlc.Dvp qualified as Htlc
 import Marketplace.Settlement.Htlc.Util (createInstructionsHtlc, HtlcState(..))
 import Marketplace.Issuance.Instrument.Model(Bond(..))
-import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessage(MT544), SwiftMessage(MT546), SwiftMessageType(..), SwiftOutboundMessage(..))
+import SwiftMessage.Message (SwiftMessage(MT547), SwiftMessage(MT545), SwiftMessage(MT544), SwiftMessage(MT546), SwiftMessage(MT548), SwiftMessageType(..), SwiftOutboundMessage(..))
 import SwiftMessage.Model.MT544
 import SwiftMessage.Model.MT545
 import SwiftMessage.Model.MT546
 import SwiftMessage.Model.MT547
+import SwiftMessage.Model.MT548
 import SwiftMessage.Util
 
 template CreateDealRequest
@@ -131,6 +132,7 @@ template Tranche
           instrumentId = bond.isin <> "-" <> deliveryId.label
           buyerSafekeepingAcc = getAccount False receiverSettlementInfo buyer
           sellerSafekeepingAcc = getAccount False sellerSettlementInfo seller
+          settlementAdvice = SettlementAdvice with receivingAgent = buyerSafekeepingAcc.provider; deliveringAgent = sellerSafekeepingAcc.provider; ..
         if settlementMode == Dvp then do
           let
             mt545 = createMT545Details instrumentId settledQty buyerSafekeepingAcc.provider sellerSafekeepingAcc.provider seller buyer
@@ -142,8 +144,14 @@ template Tranche
                     settledAmount settledCurrency
                     dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
+                    
+            mt548_buy = createMT548Details settlementAdvice RECE APMT  
+            mt548_sell = createMT548Details settlementAdvice DELI APMT
+          
           createNewSettlementMessage settlementId (MT545 mt545) MT545_t
           createNewSettlementMessage settlementId (MT547 mt547) MT547_t
+          createNewSettlementMessage settlementId (MT548 mt548_buy) MT548_buy_t
+          createNewSettlementMessage settlementId (MT548 mt548_sell) MT548_sell_t
         else do
           let
             mt544 = createMT544Details instrumentId settledQty buyerSafekeepingAcc.provider buyerSafekeepingAcc.provider seller buyer
@@ -153,8 +161,17 @@ template Tranche
             mt546 = createMT546Details instrumentId settledQty buyerSafekeepingAcc.provider sellerSafekeepingAcc.provider seller buyer
                     dateOfTrade dateOfSettlement effDateOfSettlement dateOfSettlement
                     settlementId settlementId buyerSafekeepingAcc sellerSafekeepingAcc "safekeepingPlace" "placeOfSettlement"
-          createNewSettlementMessage settlementId (MT544 mt544) MT544_t
-          createNewSettlementMessage settlementId (MT546 mt546) MT546_t
+            
+            paymentMode = if settlementMode == Fop then FREE else APMT
+            mt548_buy = createMT548Details settlementAdvice RECE paymentMode
+            mt548_sell = createMT548Details settlementAdvice DELI paymentMode
+          if settlementMode == Fop then do
+            createNewSettlementMessage settlementId (MT544 mt544) MT544_t
+            createNewSettlementMessage settlementId (MT546 mt546) MT546_t
+            pure ()
+          else pure () -- todo refactor this
+          createNewSettlementMessage settlementId (MT548 mt548_buy) MT548_buy_t
+          createNewSettlementMessage settlementId (MT548 mt548_sell) MT548_sell_t
         pure ()
 
       createSettlementResult : Decimal -> Party -> Party -> Update SettlementResult
@@ -234,6 +251,7 @@ template Tranche
           settlementResult@SettlementResult{..} <- createSettlementResult price issuer settlementBank
           instructionIds <- createSettlementInstructionsHtlc settlementResult hashlock expiry
 
+          sendSwiftMessage issuer settlementBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement issuerSettlementMode
           create Htlc.Dvp with operator; deliverer = issuer; delivererAgent = issuer; payer = settlementBank; payerAgent = settlementBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Locked; settlementMode = issuerSettlementMode; hashlock; expiry
 
       nonconsuming InstructBndSettlement : ContractId Hierarchical.Dvp
@@ -262,6 +280,7 @@ template Tranche
           settlementResult@SettlementResult{..} <- createSettlementResult price settlementBank bndBank
           instructionIds <- createSettlementInstructionsHtlc settlementResult hashlock expiry
 
+          sendSwiftMessage settlementBank bndBank size settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement bndSettlementMode
           create Htlc.Dvp with operator; deliverer = settlementBank; delivererAgent = settlementBank; payer = bndBank; payerAgent = bndBank; settlementId; instructionIds; delivery = totalAsset; payment = totalPrice; status = Locked; settlementMode = issuerSettlementMode; hashlock; expiry
 
       nonconsuming InstructInvestorSettlement : [ContractId Hierarchical.Dvp]
@@ -282,7 +301,7 @@ template Tranche
 
               instructionIds <- createSettlementInstructions settlementResult (conf.settlementMode == Dvp)
 
-              sendSwiftMessage settlementBank bndBank totalAsset.quantity settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement conf.settlementMode
+              sendSwiftMessage bndBank conf.investor totalAsset.quantity settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement conf.settlementMode
               exercise confCid Bidding.Delete
               create Hierarchical.Dvp with operator; agent = bondRegistrar; deliverer = bndBank; payer = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = totalPrice; status = Instructed; settlementMode = conf.settlementMode
           mapA settleConfirmation filtered
@@ -308,5 +327,6 @@ template Tranche
               instructionIds <- createSettlementInstructionsHtlc settlementResult hashlock expiry
 
               exercise confCid Bidding.Delete
+              sendSwiftMessage bndBank conf.investor totalAsset.quantity settledAmount paymentId settlementId dateOfTrade dateOfSettlement dateOfSettlement conf.settlementMode
               create Htlc.Dvp with operator; deliverer = bndBank; delivererAgent = bndBank; payer = conf.investor; payerAgent = conf.investor; settlementId; instructionIds; delivery = conf.asset; payment = totalPrice; status = Locked; settlementMode = issuerSettlementMode; hashlock; expiry
           mapA settleConfirmation filtered

--- a/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
+++ b/daml/Marketplace/Distribution/Syndication/Structuring/Model.daml
@@ -17,6 +17,7 @@ import SwiftMessage.Model.MT546
 import SwiftMessage.Model.MT547
 import SwiftMessage.Model.MT548
 import SwiftMessage.Util
+import DA.Action (when)
 
 template CreateDealRequest
   with
@@ -169,11 +170,10 @@ template Tranche
             paymentMode = if settlementMode == Fop then FREE else APMT
             mt548_buy = createMT548Details settlementAdvice RECE paymentMode
             mt548_sell = createMT548Details settlementAdvice DELI paymentMode
-          if settlementMode == Fop then do
+          when (settlementMode == Fop) do
             createNewSettlementMessage settlementId (MT544 mt544) MT544_t
             createNewSettlementMessage settlementId (MT546 mt546) MT546_t
             pure ()
-          else pure () -- todo refactor this
           createNewSettlementMessage settlementId (MT548 mt548_buy) MT548_buy_t
           createNewSettlementMessage settlementId (MT548 mt548_sell) MT548_sell_t
         pure ()

--- a/daml/Marketplace/Trading/Otc/Model.daml
+++ b/daml/Marketplace/Trading/Otc/Model.daml
@@ -2,12 +2,17 @@ module Marketplace.Trading.Otc.Model where
 
 import DA.Finance.Types (Asset, Account)
 import DA.Optional (fromSomeNote)
+import DA.Set (singleton)
 import Marketplace.Custody.Model qualified as Custody
+import Marketplace.Issuance.Instrument.Model(Bond(..))
 import Marketplace.Settlement.Hierarchical.Util (createInstructions, getAccount, Status(..), SettlementMode(..))
 import Marketplace.Settlement.Htlc.Util (createInstructionsHtlc, HtlcState(..))
 import Marketplace.Settlement.Htlc.Dvp qualified as Htlc
 import Marketplace.Settlement.Hierarchical.Dvp qualified as Hierarchical
 import Marketplace.Trading.Model (Side(..))
+import SwiftMessage.Util
+import SwiftMessage.Message(SwiftOutboundMessage(..), SwiftMessageType(..), SwiftMessage(..))
+import SwiftMessage.Model.MT548
 
 template Order
   with
@@ -74,11 +79,38 @@ template Match
           delivererSecAccount = getAccount False delivererSettlementInfo deliverer
           delivererCashAccount = getAccount True delivererSettlementInfo deliverer
         pure $ SettlementResult with ..
+      
+      createSettlementAdvice : Order -> SettlementResult -> Date -> Update SettlementAdvice
+      createSettlementAdvice Order{..} SettlementResult{..} dateOfSettlement = do
+        (_, bond) <- fetchByKey @Bond (delivery.id.signatories, delivery.id.label)
+        let 
+          instrumentId = bond.isin <> "-" <> delivery.id.label
+          settledAmount = payment.quantity
+          settledQty = delivery.quantity
+          buyer = payer
+          buyerSafekeepingAcc = payerSecAccount
+          receivingAgent = payerSecAccount.provider
+          seller = deliverer
+          sellerSafekeepingAcc = delivererSecAccount
+          deliveringAgent = delivererSecAccount.provider
+          dateOfTrade = dateOfSettlement
+        pure $ SettlementAdvice with ..
+
+      sendSwiftMessage : Text -> SettlementAdvice -> SettlementMode -> Party -> Party -> Update ()
+      sendSwiftMessage settlementId settlementAdvice settlementMode operator agent = do
+        let
+          paymentMode = if settlementMode == Fop then FREE else APMT
+          mt548_buy = createMT548Details settlementAdvice RECE paymentMode  
+          mt548_sell = createMT548Details settlementAdvice DELI paymentMode
+        create SwiftOutboundMessage with referenceId = settlementId; provider = operator; consumer = operator; status = Finalized; observers = singleton agent; swiftMessage = MT548 (mt548_buy); swiftMessageType = MT548_buy_t
+        create SwiftOutboundMessage with referenceId = settlementId; provider = operator; consumer = operator; status = Finalized; observers = singleton agent; swiftMessage = MT548 (mt548_sell); swiftMessageType = MT548_sell_t
+        pure ()
 
     nonconsuming choice Instruct : ContractId Hierarchical.Dvp
+      with dateOfSettlement : Date
       controller order.operator
       do
-        SettlementResult {..} <- createSettlementResult order
+        settlementResult@SettlementResult {..} <- createSettlementResult order
         let Order{..} = order
         deliverySis <- createInstructions False operator operator deliveryRegistrar delivererSecAccount payerSecAccount settlementId 0 delivery
         instructionIds <-
@@ -88,16 +120,22 @@ template Match
               map (.instructionId) <$> mapA fetch (deliverySis <> paymentSis)
             else do
               map (.instructionId) <$> mapA fetch deliverySis
+
+        settlementAdvice <- createSettlementAdvice order settlementResult dateOfSettlement
+        sendSwiftMessage settlementId settlementAdvice settlementMode operator operator 
         create Hierarchical.Dvp with operator; agent = operator; deliverer; payer; settlementId; instructionIds; delivery; payment; status = Instructed; settlementMode
       
     nonconsuming choice InstructHtlc : ContractId Htlc.Dvp
       with 
         expiry : Time
+        dateOfSettlement : Date
       controller order.operator
       do 
-        SettlementResult {..} <- createSettlementResult order
+        settlementResult@SettlementResult {..} <- createSettlementResult order
         let Order{..} = order
             hashlock = fromSomeNote "No hashlock specified for HTLC" hashlockOpt
         deliverySis <- createInstructionsHtlc False operator deliveryRegistrar deliverer delivererSecAccount payer payerSecAccount settlementId 0 delivery hashlock expiry
         instructionIds <- map (.instructionId) <$> mapA fetch deliverySis
+        settlementAdvice <- createSettlementAdvice order settlementResult dateOfSettlement
+        sendSwiftMessage settlementId settlementAdvice settlementMode operator payer
         create Htlc.Dvp with delivererAgent = deliverer; payerAgent = payer; status = Locked; ..

--- a/daml/Marketplace/Trading/Otc/Model.daml
+++ b/daml/Marketplace/Trading/Otc/Model.daml
@@ -80,8 +80,8 @@ template Match
           delivererCashAccount = getAccount True delivererSettlementInfo deliverer
         pure $ SettlementResult with ..
       
-      createSettlementAdvice : Order -> SettlementResult -> Date -> Update SettlementAdvice
-      createSettlementAdvice Order{..} SettlementResult{..} dateOfSettlement = do
+      createSettlementStatusAndProcessingAdvice : Order -> SettlementResult -> Date -> Update SettlementStatusAndProcessingAdvice
+      createSettlementStatusAndProcessingAdvice Order{..} SettlementResult{..} dateOfSettlement = do
         (_, bond) <- fetchByKey @Bond (delivery.id.signatories, delivery.id.label)
         let 
           instrumentId = bond.isin <> "-" <> delivery.id.label
@@ -94,14 +94,14 @@ template Match
           sellerSafekeepingAcc = delivererSecAccount
           deliveringAgent = delivererSecAccount.provider
           dateOfTrade = dateOfSettlement
-        pure $ SettlementAdvice with ..
+        pure $ SettlementStatusAndProcessingAdvice with ..
 
-      sendSwiftMessage : Text -> SettlementAdvice -> SettlementMode -> Party -> Party -> Update ()
-      sendSwiftMessage settlementId settlementAdvice settlementMode operator agent = do
+      sendSwiftMessage : Text -> SettlementStatusAndProcessingAdvice -> SettlementMode -> Party -> Party -> Update ()
+      sendSwiftMessage settlementId settlementStatusAndProcessingAdvice settlementMode operator agent = do
         let
           paymentMode = if settlementMode == Fop then FREE else APMT
-          mt548_buy = createMT548Details settlementAdvice RECE paymentMode  
-          mt548_sell = createMT548Details settlementAdvice DELI paymentMode
+          mt548_buy = createMT548Details settlementStatusAndProcessingAdvice RECE paymentMode  
+          mt548_sell = createMT548Details settlementStatusAndProcessingAdvice DELI paymentMode
         create SwiftOutboundMessage with referenceId = settlementId; provider = operator; consumer = operator; status = Finalized; observers = singleton agent; swiftMessage = MT548 (mt548_buy); swiftMessageType = MT548_buy_t
         create SwiftOutboundMessage with referenceId = settlementId; provider = operator; consumer = operator; status = Finalized; observers = singleton agent; swiftMessage = MT548 (mt548_sell); swiftMessageType = MT548_sell_t
         pure ()
@@ -121,8 +121,8 @@ template Match
             else do
               map (.instructionId) <$> mapA fetch deliverySis
 
-        settlementAdvice <- createSettlementAdvice order settlementResult dateOfSettlement
-        sendSwiftMessage settlementId settlementAdvice settlementMode operator operator 
+        settlementStatusAndProcessingAdvice <- createSettlementStatusAndProcessingAdvice order settlementResult dateOfSettlement
+        sendSwiftMessage settlementId settlementStatusAndProcessingAdvice settlementMode operator operator 
         create Hierarchical.Dvp with operator; agent = operator; deliverer; payer; settlementId; instructionIds; delivery; payment; status = Instructed; settlementMode
       
     nonconsuming choice InstructHtlc : ContractId Htlc.Dvp
@@ -136,6 +136,6 @@ template Match
             hashlock = fromSomeNote "No hashlock specified for HTLC" hashlockOpt
         deliverySis <- createInstructionsHtlc False operator deliveryRegistrar deliverer delivererSecAccount payer payerSecAccount settlementId 0 delivery hashlock expiry
         instructionIds <- map (.instructionId) <$> mapA fetch deliverySis
-        settlementAdvice <- createSettlementAdvice order settlementResult dateOfSettlement
-        sendSwiftMessage settlementId settlementAdvice settlementMode operator payer
+        settlementStatusAndProcessingAdvice <- createSettlementStatusAndProcessingAdvice order settlementResult dateOfSettlement
+        sendSwiftMessage settlementId settlementStatusAndProcessingAdvice settlementMode operator payer
         create Htlc.Dvp with delivererAgent = deliverer; payerAgent = payer; status = Locked; ..

--- a/daml/SwiftMessage/Message.daml
+++ b/daml/SwiftMessage/Message.daml
@@ -7,6 +7,7 @@ import SwiftMessage.Model.MT544
 import SwiftMessage.Model.MT545
 import SwiftMessage.Model.MT546
 import SwiftMessage.Model.MT547
+import SwiftMessage.Model.MT548
 import SwiftMessage.Model.MT564
 import SwiftMessage.Model.MT566
 import DA.Set (Set)
@@ -17,13 +18,14 @@ data SwiftMessage =
     | MT545 (MT545Details)
     | MT546 (MT546Details)
     | MT547 (MT547Details)
+    | MT548 (MT548Details)
     | MT564 (MT564Details)
     | MT566 (MT566Details)
     | MT535 (MT535Details)
     | MT940 (MT940Details)
   deriving (Eq, Show)
 
-data SwiftMessageType = MT544_t | MT545_t | MT546_t | MT547_t | MT564_t | MT566_t | MT535_t | MT940_t
+data SwiftMessageType = MT544_t | MT545_t | MT546_t | MT547_t | MT548_sell_t | MT548_buy_t | MT564_t | MT566_t | MT535_t | MT940_t
   deriving (Eq, Show)
 
 

--- a/daml/SwiftMessage/Model/MT548.daml
+++ b/daml/SwiftMessage/Model/MT548.daml
@@ -1,0 +1,17 @@
+module SwiftMessage.Model.MT548 where
+
+import SwiftMessage.Util
+
+data REDE = RECE | DELI deriving (Show, Eq) -- buy side (RECE) and sell side (DELI) indicato
+
+data PAMT = APMT | FREE deriving (Show, Eq) -- payment indicator DvP (against payment: APMT) and FoP (free of payment: FREE)
+
+data MT548Details = MT548Details with
+    settlementAdvice: SettlementAdvice
+    side: REDE
+    payment: PAMT
+  deriving (Show, Eq) -- todo refactor dup part
+
+createMT548Details: SettlementAdvice -> REDE -> PAMT -> MT548Details
+createMT548Details settlementAdvice side payment = 
+    MT548Details with ..

--- a/daml/SwiftMessage/Model/MT548.daml
+++ b/daml/SwiftMessage/Model/MT548.daml
@@ -7,11 +7,11 @@ data REDE = RECE | DELI deriving (Show, Eq) -- buy side (RECE) and sell side (DE
 data PAMT = APMT | FREE deriving (Show, Eq) -- payment indicator DvP (against payment: APMT) and FoP (free of payment: FREE)
 
 data MT548Details = MT548Details with
-    settlementAdvice: SettlementAdvice
+    settlementStatusAndProcessingAdvice: SettlementStatusAndProcessingAdvice
     side: REDE
     payment: PAMT
   deriving (Show, Eq) -- todo refactor dup part
 
-createMT548Details: SettlementAdvice -> REDE -> PAMT -> MT548Details
-createMT548Details settlementAdvice side payment = 
+createMT548Details: SettlementStatusAndProcessingAdvice -> REDE -> PAMT -> MT548Details
+createMT548Details settlementStatusAndProcessingAdvice side payment = 
     MT548Details with ..

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -47,6 +47,23 @@ data DvPSettlementDetails = DvPSettlementDetails with
 
 data CRDB = CRED | DEBT deriving (Eq, Show)
 
+data SettlementAdvice = SettlementAdvice with -- for MT548
+    instrumentId: Text -- ISIN + Bond Label
+    settledAmount: Decimal -- cash amount for buyer
+    settledQty: Decimal -- bond qty for sender
+
+    buyer: Party
+    buyerSafekeepingAcc: Account
+    receivingAgent: Party
+
+    seller: Party
+    sellerSafekeepingAcc: Account
+    deliveringAgent: Party
+
+    dateOfSettlement: Date
+    dateOfTrade: Date
+  deriving (Show, Eq)
+
 data PayoutDetails = PayoutDetails with
     instrumentId : Text -- ISIN + bond id label
     assetId : Id -- bond id

--- a/daml/SwiftMessage/Util.daml
+++ b/daml/SwiftMessage/Util.daml
@@ -47,7 +47,7 @@ data DvPSettlementDetails = DvPSettlementDetails with
 
 data CRDB = CRED | DEBT deriving (Eq, Show)
 
-data SettlementAdvice = SettlementAdvice with -- for MT548
+data SettlementStatusAndProcessingAdvice = SettlementStatusAndProcessingAdvice with -- for MT548
     instrumentId: Text -- ISIN + Bond Label
     settledAmount: Decimal -- cash amount for buyer
     settledQty: Decimal -- bond qty for sender

--- a/daml/Tests/Distribution/Syndication/Trading.daml
+++ b/daml/Tests/Distribution/Syndication/Trading.daml
@@ -1,6 +1,7 @@
 module Tests.Distribution.Syndication.Trading where
 
 import Daml.Script
+import DA.Date
 import DA.Finance.Types (Asset(..))
 import DA.Set (singleton)
 import DA.Text (sha256)
@@ -29,13 +30,13 @@ acceptOrder : Party -> Party -> ContractId Trading.Order -> Script (ContractId T
 acceptOrder operator customer orderCid = do
   submit customer do exerciseByKeyCmd @Trading.Service (operator, operator, customer) Trading.AcceptOrder with ctrl = customer; orderCid
 
-instructMatch : Party -> ContractId Trading.Match -> Script (ContractId Hierarchical.Dvp)
-instructMatch operator matchCid = do
-  submit operator do exerciseCmd matchCid Trading.Instruct
+instructMatch : Party -> ContractId Trading.Match -> Date -> Script (ContractId Hierarchical.Dvp)
+instructMatch operator matchCid dateOfSettlement = do
+  submit operator do exerciseCmd matchCid Trading.Instruct with ..
 
-instructMatchHtlc : Party -> ContractId Trading.Match -> Time -> Script (ContractId Htlc.Dvp)
-instructMatchHtlc operator matchCid expiry = do
-  submit operator do exerciseCmd matchCid Trading.InstructHtlc with expiry
+instructMatchHtlc : Party -> ContractId Trading.Match -> Time -> Date -> Script (ContractId Htlc.Dvp)
+instructMatchHtlc operator matchCid expiry dateOfSettlement = do
+  submit operator do exerciseCmd matchCid Trading.InstructHtlc with ..
 
 test : Script ()
 test = do
@@ -45,7 +46,7 @@ test = do
   trading parties orig
 
 trading : Parties -> Origination -> Script ()
-trading Parties{..} Origination{..}= do
+trading Parties{..} Origination{..} = do
 
   deposit operator cashProvider  lm1        1_000_000.0 usd.assetId
   deposit operator lm1           investor1  1_000_000.0 (usd.assetId with signatories = singleton lm1)
@@ -60,14 +61,15 @@ trading Parties{..} Origination{..}= do
     
     payment3 = Asset with id = usd.assetId; quantity = 3_000_000.0
     delivery3 = Asset with id = bond3Desc.assetId; quantity = 3_000_000.0
+    dateOfSettlement = date 2022 Jun 17
 
   orderCid <- createOrder operator investor1 investor2 bondRegistrar cashProvider "TRD1" delivery payment Buy Dvp None
   matchCid <- acceptOrder operator investor2 orderCid
-  tradeCid <- instructMatch operator matchCid
+  tradeCid <- instructMatch operator matchCid dateOfSettlement
   
   orderCid2 <- createOrder operator investor1 investor2 bondRegistrar cashProvider "TRD2" delivery2 payment2 Buy Fop None
   matchCid2 <- acceptOrder operator investor2 orderCid2
-  tradeCid2 <- instructMatch operator matchCid2
+  tradeCid2 <- instructMatch operator matchCid2 dateOfSettlement
 
   now <- getTime
   let 
@@ -76,7 +78,7 @@ trading Parties{..} Origination{..}= do
     expiry = addRelTime now $ hours 1
   orderCid3 <- createOrder operator investor1 investor2 bondRegistrar cashProvider "TRD3" delivery3 payment3 Buy Htlc (Some hashlock)
   matchCid3 <- acceptOrder operator investor2 orderCid3
-  tradeCid3 <- instructMatchHtlc operator matchCid3 expiry
+  tradeCid3 <- instructMatchHtlc operator matchCid3 expiry dateOfSettlement
 
   allocateInstructions [ lm1, lm2, investor1, investor2, custodian1, custodian2 ]
   allocateInstructionsHtlc [ investor2, custodian1, custodian2 ]


### PR DESCRIPTION
The PR includes changes for [FL-334](https://digitalasset.atlassian.net/browse/FL-334):

1. add MT548 model and type
2. integrate MT548 into issuance flow (including HTLC)
3. integrate MT548 into otc-trading flow (including HTLC) 

One thing to note is that for MT548 unlike other settlement messages, we only have status `Finalized` (we don't have `Pending` status that gets converted to `Finalized` during Settle)