### PR TITLE
Feature/add par into bond

### DIFF
--- a/daml/Marketplace/Issuance/Instrument/Model.daml
+++ b/daml/Marketplace/Issuance/Instrument/Model.daml
@@ -48,6 +48,7 @@ template Bond
     isPricedDirty : Bool
     isCallable : Bool
     observers : [Party]
+    unitPar: Decimal
   where
     signatory id.signatories
     observer observers
@@ -78,15 +79,15 @@ payment : Observation Date Decimal -> Id -> Date -> Claim Date Decimal Id
 payment amount asset date =
   When (TimeGte date) $ Scale amount (One asset)
 
-unitFloating : Observation Date Decimal -> Id -> [Date] -> Bool -> Claim Date Decimal Id
-unitFloating amount asset dates includeNotional =
-  And $ map (payment amount asset) dates <> if includeNotional then [payment (O.pure 1.0) asset (last dates)] else []
+unitFloating : Observation Date Decimal -> Id -> [Date] -> Bool -> Decimal -> Claim Date Decimal Id
+unitFloating amount asset dates includeNotional unitPar =
+  And $ map (payment amount asset) dates <> if includeNotional then [payment (O.pure unitPar) asset (last dates)] else []
 
-unitFixed : Decimal -> Id -> [Date] -> Bool -> Claim Date Decimal Id
+unitFixed : Decimal -> Id -> [Date] -> Bool -> Decimal -> Claim Date Decimal Id
 unitFixed amount asset dates includeNotional = unitFloating (O.pure amount) asset dates includeNotional
 
-getClaims : Party -> Party -> Optional InterestStream -> Id -> Date -> Bool -> Update (Claim Date Decimal Id)
-getClaims operator provider stream currencyId maturityDate includePrincipal = do
+getClaims : Party -> Party -> Optional InterestStream -> Id -> Date -> Bool -> Decimal -> Update (Claim Date Decimal Id)
+getClaims operator provider stream currencyId maturityDate includePrincipal unitPar = do
   case stream of
     Some s -> do
       let InterestSchedule{..} = s.schedule
@@ -115,10 +116,10 @@ getClaims operator provider stream currencyId maturityDate includePrincipal = do
         claims =
           case s.amount of
             Fixed{annualRate} ->
-              unitFixed (proRata annualRate) currencyId dates includePrincipal
+              unitFixed (proRata annualRate) currencyId dates includePrincipal unitPar
             Float{rateId, periodSpread} ->
               let amount = if periodSpread == 0.0 then O.observe rateId.label else O.observe rateId.label + O.pure periodSpread
-              in unitFloating amount currencyId dates includePrincipal
+              in unitFloating amount currencyId dates includePrincipal unitPar
       pure claims
     None -> do
       pure $ payment (O.pure 1.0) currencyId maturityDate

--- a/daml/Marketplace/Issuance/Instrument/Model.daml
+++ b/daml/Marketplace/Issuance/Instrument/Model.daml
@@ -56,6 +56,12 @@ template Bond
     key (id.signatories, id.label) : (Set Party, Text)
     maintainer key._1
 
+    nonconsuming choice FetchBond: Bond
+      with ctrl: Party
+      controller ctrl
+      do 
+        pure this
+
 template Swap
   with
     id : Id

--- a/daml/Marketplace/Issuance/Instrument/Service.daml
+++ b/daml/Marketplace/Issuance/Instrument/Service.daml
@@ -25,7 +25,7 @@ template Service
       controller customer
         do
           let cfi = CFI with code = "DBXXXX"
-          claims <- getClaims operator provider bond.stream bond.currencyId bond.maturityDate True
+          claims <- getClaims operator provider bond.stream bond.currencyId bond.maturityDate True bond.unitPar
           bondCid <- create bond
           assetCid <- exerciseByKey @Issuance.Service (operator, provider, customer) Issuance.RequestOrigination with assetLabel = bond.id.label; cfi; description = bond.id.label; claims; observers = observers
           pure (assetCid, bondCid)
@@ -37,8 +37,8 @@ template Service
       controller customer
         do
           let cfi = CFI with code = "SRXXXX"
-          pay <- getClaims operator provider (Some swap.pay) swap.payCurrencyId swap.maturityDate False
-          receive <- getClaims operator provider (Some swap.receive) swap.receiveCurrencyId swap.maturityDate False
+          pay <- getClaims operator provider (Some swap.pay) swap.payCurrencyId swap.maturityDate False 1.0
+          receive <- getClaims operator provider (Some swap.receive) swap.receiveCurrencyId swap.maturityDate False 1.0
           let claims = And [ Give pay, receive ]
           swapCid <- create swap
           assetCid <- exerciseByKey @Issuance.Service (operator, provider, customer) Issuance.RequestOrigination with assetLabel = swap.id.label; cfi; description = swap.id.label; claims; observers = observers

--- a/daml/Marketplace/Lifecycle/Model.daml
+++ b/daml/Marketplace/Lifecycle/Model.daml
@@ -71,8 +71,8 @@ template Effect
       controller operator
       do
         let
-          sendSwiftMessage : Party -> Account -> Account -> Asset -> Bool -> Update (Optional PayoutRefId)
-          sendSwiftMessage receiver buyerSafekeepingAcc buyerCashAcc asset isRedempt = do
+          sendSwiftMessage : Party -> Account -> Account -> Asset -> Decimal -> Update (Optional PayoutRefId)
+          sendSwiftMessage receiver buyerSafekeepingAcc buyerCashAcc asset amount = do
             (_, description) <- fetchByKey @AssetDescription assetId
             if (description.cfi == CFI.bond) then do
               (_, bond) <- fetchByKey @Instrument.Bond (fromList [issuer, bondRegistrar], assetId.label)
@@ -85,6 +85,7 @@ template Effect
                 payoutDate = date
                 redemptionDate = getRedemptionDate maturityDate payoutDate
                 mt566 = createMT566Details instrumentId assetId description.cfi issuer buyerSafekeepingAcc buyerCashAcc CRED faceAmount currency maturityDate payoutDate redemptionDate
+                isRedempt = (amount == bond.unitPar)
                 refId = PayoutRefId with ..
               create SwiftOutboundMessage with referenceId = show refId; provider = operator ; consumer = operator; swiftMessage=MT566 (mt566); swiftMessageType=MT566_t; status=Pending; observers=fromList [payingAgent]
               pure $ Some refId
@@ -118,7 +119,7 @@ template Effect
 
             instructionCids <- createInstructions True operator payingAgent cashProvider senderAccount receiverCashAccount settlementId instructionIdx asset
             instructionIds <- map (.instructionId) <$> mapA fetch instructionCids
-            payoutRefIdOpt <- sendSwiftMessage receiver receiverSecAccount receiverCashAccount asset (amount == 1.0)
+            payoutRefIdOpt <- sendSwiftMessage receiver receiverSecAccount receiverCashAccount asset amount
             let refIdOpt = show <$> payoutRefIdOpt
             create Delivery with operator; agent = payingAgent; sender; receiver; settlementId; refIdOpt; instructionIds; asset; status = Instructed
 

--- a/daml/Marketplace/Reporting/Service.daml
+++ b/daml/Marketplace/Reporting/Service.daml
@@ -7,6 +7,7 @@ import DA.Finance.Types (Id, Account)
 import DA.List (sortOn, head, groupOn)
 import DA.Optional (whenSome)
 import DA.Set (empty)
+import Marketplace.Issuance.Instrument.Model qualified as Instrument
 import SwiftMessage.Message
 import SwiftMessage.Model.MT535
 import SwiftMessage.Model.MT940
@@ -44,8 +45,14 @@ template Service
             extractKey group = let deposit = head group in
               ReportDetailKey with assetId = deposit.asset.id; account = deposit.account
 
-            sumQuantity : [AssetDeposit] -> Decimal
-            sumQuantity deposits = sum $ map (.asset.quantity) deposits
+            sumQuantity : [AssetDeposit] -> Update Decimal
+            sumQuantity deposits = do 
+              let toQuantity deposit = if isCashReporting then pure $ deposit.asset.quantity 
+                                        else do 
+                                          let bondId = (head deposits).asset.id
+                                          bond <- exerciseByKey @Instrument.Bond (bondId.signatories, bondId.label) Instrument.FetchBond with ctrl = accountProvider
+                                          pure $ deposit.asset.quantity * bond.unitPar -- calculate notional
+              sum <$> mapA (toQuantity) deposits
 
             createReportingId : Date -> Account -> Text
             createReportingId date account = show date <> "-" <> account.id.label
@@ -75,9 +82,11 @@ template Service
             
             groupSortOn f = (groupOn f . sortOn f)
             groupedDeposits = groupSortOn (\deposit -> (deposit.account.id, deposit.asset.id)) deposits
-            keyToQuantitys = map (\group -> (extractKey group, sumQuantity group)) groupedDeposits
-            despositGroupPerOwner = groupSortOn (\(k, _) -> k.account.owner) keyToQuantitys
-          let prevDate = previousBusinessDay calendar.calendar today
+          keyToQuantitys <- mapA (\group -> do 
+                                              totalQuantity <- sumQuantity group 
+                                              pure (extractKey group, totalQuantity)) groupedDeposits
+          let despositGroupPerOwner = groupSortOn (\(k, _) -> k.account.owner) keyToQuantitys
+              prevDate = previousBusinessDay calendar.calendar today
           swiftMessages <- mapA (createSwiftMessage prevDate) despositGroupPerOwner
           mapA (\(referenceId ,swiftMessage, swiftMessageType) -> do
               -- archive current report if exist

--- a/daml/Marketplace/Settlement/Hierarchical/Util.daml
+++ b/daml/Marketplace/Settlement/Hierarchical/Util.daml
@@ -26,23 +26,31 @@ createInstructions isCash operator agent rootProvider senderAccount receiverAcco
     createInstruction senderAccount.owner receiverAccount.owner senderAccount receiverAccount asset instructionIdx
   else if senderAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
-    let providerAccount = getAccount isCash providerSettlementInfo receiverAccount.owner
-    sis1 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+    let 
+      providerAccount = getAccount isCash providerSettlementInfo receiverAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount assetForInstruction instructionIdx
     sis2 <- createInstructions isCash operator agent rootProvider senderAccount providerAccount settlementId (instructionIdx + 1) asset
     pure $ sis1 <> sis2
   else if receiverAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
-    let providerAccount = getAccount isCash providerSettlementInfo senderAccount.owner
-    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+    let 
+      providerAccount = getAccount isCash providerSettlementInfo senderAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) assetForInstruction instructionIdx
     sis2 <- createInstructions isCash operator agent rootProvider providerAccount receiverAccount settlementId (instructionIdx + 1) asset
     pure $ sis1 <> sis2
   else do
     (_, senderProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
-    let senderProviderAccount = getAccount isCash senderProviderSettlementInfo senderAccount.owner
-    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) instructionIdx
+    let 
+      senderProviderAccount = getAccount isCash senderProviderSettlementInfo senderAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) else asset
+    sis1 <- createInstruction senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) assetForInstruction instructionIdx
     (_, receiverProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
-    let receiverProviderAccount = getAccount isCash receiverProviderSettlementInfo receiverAccount.owner
-    sis2 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) (instructionIdx + 1)
+    let 
+      receiverProviderAccount = getAccount isCash receiverProviderSettlementInfo receiverAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) else asset
+    sis2 <- createInstruction receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount assetForInstruction (instructionIdx + 1)
     sis3 <- createInstructions isCash operator agent rootProvider senderProviderAccount receiverProviderAccount settlementId (instructionIdx + 2) asset
     pure $ sis1 <> sis2 <> sis3
 

--- a/daml/Marketplace/Settlement/Htlc/Util.daml
+++ b/daml/Marketplace/Settlement/Htlc/Util.daml
@@ -21,23 +21,31 @@ createInstructionsHtlc isCash operator rootProvider senderAgent senderAccount re
     createInstructionHtlc senderAccount.owner receiverAccount.owner senderAccount receiverAccount asset instructionIdx
   else if senderAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
-    let providerAccount = getAccount isCash providerSettlementInfo receiverAccount.owner
-    sis1 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+    let 
+      providerAccount = getAccount isCash providerSettlementInfo receiverAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome providerSettlementInfo.ownAccount) receiverAccount assetForInstruction instructionIdx
     sis2 <- createInstructionsHtlc isCash operator rootProvider senderAgent senderAccount receiverAgent providerAccount settlementId (instructionIdx + 1) asset hashlock expiry
     pure $ sis1 <> sis2
   else if receiverAccount.provider == rootProvider then do
     (_, providerSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
-    let providerAccount = getAccount isCash providerSettlementInfo senderAccount.owner
-    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) (asset with id.signatories = fromList [providerSettlementInfo.party]) instructionIdx
+    let 
+      providerAccount = getAccount isCash providerSettlementInfo senderAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [providerSettlementInfo.party]) else asset
+    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome providerSettlementInfo.ownAccount) assetForInstruction  instructionIdx
     sis2 <- createInstructionsHtlc isCash operator rootProvider senderAgent providerAccount receiverAgent receiverAccount settlementId (instructionIdx + 1) asset hashlock expiry
     pure $ sis1 <> sis2
   else do
     (_, senderProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, senderAccount.provider)
-    let senderProviderAccount = getAccount isCash senderProviderSettlementInfo senderAccount.owner
-    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) instructionIdx
+    let 
+      senderProviderAccount = getAccount isCash senderProviderSettlementInfo senderAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [senderProviderSettlementInfo.party]) else asset
+    sis1 <- createInstructionHtlc senderAccount.owner senderAccount.provider senderAccount (fromSome senderProviderSettlementInfo.ownAccount) assetForInstruction instructionIdx
     (_, receiverProviderSettlementInfo) <- fetchByKey @Custody.SettlementInfo (operator, receiverAccount.provider)
-    let receiverProviderAccount = getAccount isCash receiverProviderSettlementInfo receiverAccount.owner
-    sis2 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) (instructionIdx + 1)
+    let 
+      receiverProviderAccount = getAccount isCash receiverProviderSettlementInfo receiverAccount.owner
+      assetForInstruction = if isCash then (asset with id.signatories = fromList [receiverProviderSettlementInfo.party]) else asset
+    sis2 <- createInstructionHtlc receiverAccount.provider receiverAccount.owner (fromSome receiverProviderSettlementInfo.ownAccount) receiverAccount assetForInstruction (instructionIdx + 1)
     sis3 <- createInstructionsHtlc isCash operator rootProvider senderAgent senderProviderAccount receiverAgent receiverProviderAccount settlementId (instructionIdx + 2) asset hashlock expiry
     pure $ sis1 <> sis2 <> sis3
 

--- a/daml/Tests/Distribution/Syndication/Hedging.daml
+++ b/daml/Tests/Distribution/Syndication/Hedging.daml
@@ -5,7 +5,6 @@ import DA.Assert ((===))
 import DA.Date (date, Month(..))
 import DA.Finance.Asset (AssetDeposit)
 import DA.Foldable (forA_)
-import DA.Set (singleton)
 import Marketplace.Lifecycle.Model qualified as Lifecycle
 import Tests.Distribution.Syndication.Setup (setup, Parties(..))
 import Tests.Distribution.Syndication.Lifecycle (lifecycleAssets)
@@ -19,9 +18,9 @@ test = do
 
   deposit operator cashProvider  issuer     107_000_000.0 usd.assetId
   depositToAccount operator bondRegistrar custodian1 "Segregated-Investor1@Custodian1@BondRegistrar" 100_000_000.0 bond3.id
-  deposit operator custodian1    investor1  100_000_000.0 (bond3.id with signatories = singleton custodian1)
+  deposit operator custodian1    investor1  100_000_000.0 bond3.id
   depositToAccount operator bondRegistrar custodian1 "Segregated-Investor1@Custodian1@BondRegistrar" 100_000_000.0 swap1.id
-  deposit operator custodian1    investor1  100_000_000.0 (swap1.id with signatories = singleton custodian1)
+  deposit operator custodian1    investor1  100_000_000.0 swap1.id
 
   submitMulti [operator, payingAgent] [] do createCmd Lifecycle.Today with operator; provider = payingAgent; date = date 2021 Jan 15
   submitMulti [operator, payingAgent] [] do createCmd Lifecycle.Observation with operator; provider = payingAgent; label = libor6m.label; date = date 2022 Jun 21; value = 0.003

--- a/daml/Tests/Distribution/Syndication/Lifecycle.daml
+++ b/daml/Tests/Distribution/Syndication/Lifecycle.daml
@@ -65,22 +65,22 @@ testReporting = do
   setTime (time (date 2021 Jan 8) 0 0 0)
 
   -- security report
-  reporting operator bondRegistrar calendar False
-  reporting operator custodian1 calendar False
-  reporting operator custodian2 calendar False
-  reporting operator custodian4 calendar False
-  reporting operator custodian5 calendar False
+  reporting operator bondRegistrar public calendar False
+  reporting operator custodian1 public calendar False
+  reporting operator custodian2 public calendar False
+  reporting operator custodian4 public calendar False
+  reporting operator custodian5 public calendar False
 
   -- cash report
-  reporting operator cashProvider calendar True
+  reporting operator cashProvider public calendar True
 
-  -- make sure that we can submit reporting at the same date without failing
-  reporting operator bondRegistrar calendar False
-  reporting operator cashProvider calendar True
+  -- make sure that we can submit reporting at the public same date without failing
+  reporting operator bondRegistrar public calendar False
+  reporting operator cashProvider public calendar True
 
   -- prev business day of Jan 11 2021 is Jan 8 2021
   setTime (time (date 2021 Jan 11) 0 0 0)
-  reporting operator bondRegistrar calendar False
+  reporting operator bondRegistrar public calendar False
   pure ()
 
 testBond1 : Script ()
@@ -212,8 +212,8 @@ preNotify parties@Parties{..} date assetId = do
   submit operator do exerciseByKeyCmd @Lifecycle.Service (operator, issuer, payingAgent) Lifecycle.SendPrePayoutSwiftMessage with exDivDate = date; ..
   pure ()
 
-reporting : Party -> Party -> HolidayCalendar -> Bool -> Script ()
-reporting operator accountProvider calendar isCashReporting = do
+reporting : Party -> Party -> Party -> HolidayCalendar -> Bool -> Script ()
+reporting operator accountProvider public calendar isCashReporting = do
   depositCids <- map fst <$> queryFilter @AssetDeposit accountProvider (\deposit -> deposit.account.provider == accountProvider)
-  submit accountProvider do exerciseByKeyCmd @Reporting.Service (operator, accountProvider) Reporting.CreateReports with calendar; depositCids; isCashReporting
+  submitMulti [accountProvider] [public] do exerciseByKeyCmd @Reporting.Service (operator, accountProvider) Reporting.CreateReports with calendar; depositCids; isCashReporting
   pure ()

--- a/daml/Tests/Distribution/Syndication/Origination.daml
+++ b/daml/Tests/Distribution/Syndication/Origination.daml
@@ -60,9 +60,9 @@ origination Parties{..} = do
     swapRecAmount = Instrument.Fixed with annualRate = 0.01
     swapPay = Instrument.InterestStream with schedule = swapPaySched; amount = swapPayAmount
     swapRec = Instrument.InterestStream with schedule = swapRecSched; amount = swapRecAmount
-    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True [public, operator]
-    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True [public, operator]
-    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True [public, operator]
+    bond1 = createFixedRateBond     bond1Id "ISIN1" usd.assetId issuer bondSched1.startDate bondSched1.endDate bondSched1 0.04 True True True 1.0 [public, operator]
+    bond2 = createFixedRateBond     bond2Id "ISIN2" usd.assetId issuer bondSched2.startDate bondSched2.endDate bondSched2 0.05 True True True 1.0 [public, operator]
+    bond3 = createFloatingRateBond  bond3Id "ISIN3" usd.assetId issuer bondSched3.startDate bondSched3.endDate bondSched3 libor6m 0.01 True True True 1.0 [public, operator]
     swap1 = createSwap              swap1Id usd.assetId usd.assetId issuer swapPaySched.startDate swapPaySched.endDate swapPay swapRec True [public]
 
   calendarCid <- submitMulti [operator, bondRegistrar] [] do createCmd HolidayCalendar with operator; provider = bondRegistrar; calendar = fedCalendar; observers = fromList [issuer, public]

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -165,7 +165,7 @@ createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule
 
 createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
 createZeroCouponBond id isin currencyId issuer issueDate maturityDate isTradeable isPricedDirty isCallable observers =
-  Instrument.Bond with unitPar = 0.0; stream = None; ..
+  Instrument.Bond with unitPar = 1.0; stream = None; ..
 
 createSwap : Id -> Id -> Id -> Party -> Date -> Date -> Instrument.InterestStream -> Instrument.InterestStream -> Bool -> [Party] -> Instrument.Swap
 createSwap id payCurrencyId receiveCurrencyId issuer issueDate maturityDate pay receive isTradeable observers =

--- a/daml/Tests/Distribution/Syndication/Util.daml
+++ b/daml/Tests/Distribution/Syndication/Util.daml
@@ -149,15 +149,15 @@ createSchedule : Date -> Date -> PeriodEnum -> Int -> [Text] -> BusinessDayConve
 createSchedule startDate endDate period periodMultiplier calendarIds businessDayConvention dayCountConvention rollConvention =
   Instrument.InterestSchedule with ..
 
-createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFixedRateBond id isin currencyId issuer issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable observers =
+createFixedRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Decimal -> Bool -> Bool -> Bool -> Decimal -> [Party] -> Instrument.Bond
+createFixedRateBond id isin currencyId issuer issueDate maturityDate schedule annualRate isTradeable isPricedDirty isCallable unitPar observers =
   let
     amount = Instrument.Fixed with annualRate
     stream = Some Instrument.InterestStream with schedule; amount
   in Instrument.Bond with ..
 
-createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
-createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable observers =
+createFloatingRateBond : Id -> Text -> Id -> Party -> Date -> Date -> Instrument.InterestSchedule -> Id -> Decimal -> Bool -> Bool -> Bool -> Decimal -> [Party] -> Instrument.Bond
+createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule rateId periodSpread isTradeable isPricedDirty isCallable unitPar observers =
   let
     amount = Instrument.Float with rateId; periodSpread
     stream = Some Instrument.InterestStream with schedule; amount
@@ -165,7 +165,7 @@ createFloatingRateBond id isin currencyId issuer issueDate maturityDate schedule
 
 createZeroCouponBond : Id -> Text -> Id -> Party -> Date -> Date -> Bool -> Bool -> Bool -> [Party] -> Instrument.Bond
 createZeroCouponBond id isin currencyId issuer issueDate maturityDate isTradeable isPricedDirty isCallable observers =
-  Instrument.Bond with stream = None; ..
+  Instrument.Bond with unitPar = 0.0; stream = None; ..
 
 createSwap : Id -> Id -> Id -> Party -> Date -> Date -> Instrument.InterestStream -> Instrument.InterestStream -> Bool -> [Party] -> Instrument.Swap
 createSwap id payCurrencyId receiveCurrencyId issuer issueDate maturityDate pay receive isTradeable observers =


### PR DESCRIPTION
 The change in this PR  includes

1. add unitPar (unit to dollar ratio, e.g. 1 bond unit is 0.8 usd then unitPar = 0.8) into `Bond` contract
2. use unitPar to calculate notional value instead of using quantity for MT535 totalQuantity field (Bond Report)
3. same as https://github.com/digital-asset/da-marketplace/pull/490/files#r837065953 we will keep AssetDeposit.id.signatories same for all Bonds(non-cash assetDeposit) to easily link up asset deposit and it's corresponding `Bond` contract