### PR TITLE
fix: autoapproval triggers script fails with invalid input text r #499

### DIFF
--- a/scripts/run-autoapproval-triggers.sh
+++ b/scripts/run-autoapproval-triggers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-parties=$(yq r daml.yaml 'parties.*')
+parties=$(yq -r '.parties[]' daml.yaml)
 dar=$1
 state_dir=$2
 


### PR DESCRIPTION
A fix for issue #499.