### PR TITLE
remove hash from canton party names

### DIFF
--- a/ui/src/components/CCP/CCP.tsx
+++ b/ui/src/components/CCP/CCP.tsx
@@ -43,6 +43,7 @@ import Members from './Members'
 import MemberAccounts from './MemberAccounts'
 import ExchangeRelationships from './ExchangeRelationships'
 import NotificationCenter, { useAllNotifications } from '../common/NotificationCenter'
+import {formatParty, makePartyLabel} from '../common/utils'
 
 type Props = {
     onLogout: () => void;
@@ -65,7 +66,7 @@ const CCP: React.FC<Props> = ({ onLogout }) => {
             const name = broker.contractData.name;
             return {
                 party,
-                label: `${name} | ${party}`
+                label: makePartyLabel(party, name, "Broker")
             }
         })
 
@@ -76,7 +77,7 @@ const CCP: React.FC<Props> = ({ onLogout }) => {
             const name = investor.contractData.name;
             return {
                 party,
-                label: `${name} | ${party}`
+                label: makePartyLabel(party, name, "Investor")
             }
         })
 
@@ -92,7 +93,7 @@ const CCP: React.FC<Props> = ({ onLogout }) => {
             const name = exchange.contractData.name;
             return {
                 party,
-                label: `${name} | ${party}`
+                label: makePartyLabel(party, name, "Exchange")
             }
         })
 

--- a/ui/src/components/Custodian/CreateDeposit.tsx
+++ b/ui/src/components/Custodian/CreateDeposit.tsx
@@ -10,7 +10,7 @@ import { Token } from '@daml.js/da-marketplace/lib/Marketplace/Token'
 import { AS_PUBLIC, useContractQuery } from '../../websocket/queryStream'
 
 import { useOperator } from '../common/common'
-import { countDecimals, preciseInputSteps } from '../common/utils'
+import { countDecimals, preciseInputSteps, makePartyLabel } from '../common/utils'
 import { TokenInfo, wrapDamlTuple } from '../common/damlTypes'
 import FormErrorHandled from '../common/FormErrorHandled'
 import ContractSelect from '../common/ContractSelect'
@@ -46,7 +46,7 @@ const CreateDeposit = () => {
             const name = broker.contractData.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Broker`
+                label: makePartyLabel(party, name, "Broker")
             }
         })
 
@@ -57,7 +57,7 @@ const CreateDeposit = () => {
             const name = investor.contractData.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Investor`
+                label: makePartyLabel(party, name, "Investor")
             }
         })
 

--- a/ui/src/components/Custodian/Custodian.tsx
+++ b/ui/src/components/Custodian/Custodian.tsx
@@ -34,6 +34,7 @@ import NotificationCenter, { useAllNotifications } from '../common/NotificationC
 import { useRelationshipRequestNotifications } from '../common/RelationshipRequestNotifications'
 import Clients from './Clients'
 import ClientHoldings from './ClientHoldings'
+import { makePartyLabel } from '../common/utils'
 
 type Props = {
     onLogout: () => void;
@@ -56,7 +57,7 @@ const Custodian: React.FC<Props> = ({ onLogout }) => {
             const name = broker.contractData.name;
             return {
                 party,
-                label: `${name} | ${party}`
+                label: makePartyLabel(party, name, "Broker")
             }
         })
 
@@ -67,7 +68,7 @@ const Custodian: React.FC<Props> = ({ onLogout }) => {
             const name = investor.contractData.name;
             return {
                 party,
-                label: `${name} | ${party}`
+                label: makePartyLabel(party, name, "Investor")
             }
         })
 

--- a/ui/src/components/Issuer/Issuer.tsx
+++ b/ui/src/components/Issuer/Issuer.tsx
@@ -37,6 +37,7 @@ import IssueAsset from './IssueAsset'
 import IssueDerivative from './IssueDerivative'
 import IssuedDerivative from './IssuedDerivative'
 import IssuedToken from './IssuedToken'
+import {formatParty, makePartyLabel} from '../common/utils'
 
 type Props = {
     onLogout: () => void;
@@ -69,7 +70,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
             const name = investorMap.get(damlTupleToString(investor.key))?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Investor`
+                label: makePartyLabel(party, name, "Investor")
             }
         })
 
@@ -79,7 +80,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
             const name = brokerMap.get(damlTupleToString(broker.key))?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Broker`
+                label: makePartyLabel(party, name, "Broker")
             }
         })
 
@@ -89,7 +90,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
             const name = exchangeMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Exchange`
+                label: makePartyLabel(party, name, "Exchange")
             }
         });
 
@@ -99,7 +100,7 @@ const Issuer: React.FC<Props> = ({ onLogout }) => {
             const name = custodianMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Custodian`
+                label: makePartyLabel(party, name, "Custodian")
             }
         }),
         ...exchangeProviders,

--- a/ui/src/components/common/Holdings.tsx
+++ b/ui/src/components/common/Holdings.tsx
@@ -13,7 +13,7 @@ import { useContractQuery } from '../../websocket/queryStream'
 
 import { IconClose } from '../../icons/Icons'
 import { DepositInfo, wrapDamlTuple, getAccountProvider } from './damlTypes'
-import { groupDepositsByAsset, groupDepositsByProvider, sumDepositArray, getPartyLabel, IPartyInfo } from './utils'
+import { groupDepositsByAsset, groupDepositsByProvider, sumDepositArray, getPartyLabel, IPartyInfo, formatParty } from './utils'
 import { useOperator } from './common'
 import { AppError } from './errorTypes'
 import FormErrorHandled from './FormErrorHandled'
@@ -53,7 +53,7 @@ const Holdings: React.FC<Props> = ({ deposits, clearingDeposits, marginDeposits,
                             {label}
                         </p>
                         <p className='p2'>
-                            {party}
+                            {formatParty(party)}
                         </p>
                      </div>
                     { Object.entries(assetDeposits).map(([assetLabel, deposits]) => (
@@ -80,7 +80,7 @@ const Holdings: React.FC<Props> = ({ deposits, clearingDeposits, marginDeposits,
                             {label}
                         </p>
                         <p className='p2'>
-                            {party}
+                            {formatParty(party)}
                         </p>
                      </div>
                     { Object.entries(assetDeposits).map(([assetLabel, deposits]) => (

--- a/ui/src/components/common/MarketRelationships.tsx
+++ b/ui/src/components/common/MarketRelationships.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Header } from 'semantic-ui-react'
 
-import { getAbbreviation } from '../common/utils';
+import { getAbbreviation, formatParty } from '../common/utils';
 
 import { CustodianRelationshipInfo, RelationshipRequestChoice } from './damlTypes'
 
@@ -31,7 +31,7 @@ const MarketRelationships: React.FC<Props> = ({ relationshipRequestChoice, custo
                 </div>
                 <div className='relationship-info'>
                     <Header className='bold name' as='h3'>{custodian.name}</Header>
-                    <p>{custodian?.custodian}</p>
+                    <p>{formatParty(custodian?.custodian)}</p>
                 </div>
             </div>
         )

--- a/ui/src/components/common/Wallet.tsx
+++ b/ui/src/components/common/Wallet.tsx
@@ -20,6 +20,7 @@ import WalletTransaction from './WalletTransaction'
 import PageSection from './PageSection'
 import Holdings from './Holdings'
 import Page from './Page'
+import { makePartyLabel } from './utils'
 
 const Wallet = (props: {
     sideNav: React.ReactElement;
@@ -65,7 +66,7 @@ const Wallet = (props: {
             const name = brokerMap.get(damlTupleToString(broker.key))?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Broker`
+                label: makePartyLabel(party, name, "Broker")
             }
         })
 
@@ -75,7 +76,7 @@ const Wallet = (props: {
             const name = exchangeMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Exchange`
+                label: makePartyLabel(party, name, "Exchange")
             }
         });
 
@@ -85,7 +86,7 @@ const Wallet = (props: {
             const name = ccpMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | CCP`
+                label: makePartyLabel(party, name, "CCP")
             }
         });
 
@@ -95,7 +96,7 @@ const Wallet = (props: {
             const name = custodianMap.get(party)?.name;
             return {
                 party,
-                label: `${name ? `${name} (${party})` : party} | Custodian`
+                label: makePartyLabel(party, name, "Custodian")
             }
         }),
         ...exchangeProviders,

--- a/ui/src/components/common/utils.ts
+++ b/ui/src/components/common/utils.ts
@@ -144,6 +144,14 @@ export function getPartyLabel(partyId: string, parties: IPartyInfo[]) {
     return { party: partyInfo?.party || partyId , label: partyInfo?.label.substring(0, partyInfo.label.lastIndexOf('|')) || partyId}
 }
 
+export const formatParty = (party: string): string => {
+  return party.split("::")[0]
+}
+
+export const makePartyLabel = (party: string, name: string | undefined, role: string): string => {
+    return `${name ? `${name} (${formatParty(party)})` : formatParty(party)} | ${role}`
+}
+
 export function getAbbreviation(phrase: string) {
     const wordsToExclude =  ["and", "or", "of", "to", "the"]
     return phrase.split(' ')


### PR DESCRIPTION
Removes the hash from party strings in the UI as it was breaking some components.